### PR TITLE
Add NaN validation for --limit flag in search command

### DIFF
--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -9,7 +9,7 @@ import fuzzysort from "fuzzysort"
 import kleur from "kleur"
 import { fetchRegistryIndex } from "../registry/fetcher.js"
 import { readOcxConfig, readOcxLock } from "../schemas/config.js"
-import { createSpinner, handleError, logger, outputJson } from "../utils/index.js"
+import { createSpinner, handleError, logger, outputJson, ValidationError } from "../utils/index.js"
 
 interface SearchOptions {
 	cwd: string
@@ -35,6 +35,9 @@ export function registerSearchCommand(program: Command): void {
 		.action(async (query: string | undefined, options: SearchOptions) => {
 			try {
 				const limit = parseInt(String(options.limit), 10)
+				if (Number.isNaN(limit)) {
+					throw new ValidationError("--limit must be a valid number");
+				}
 
 				// List installed only
 				if (options.installed) {


### PR DESCRIPTION
This PR adds explicit validation for the `--limit` flag in the `search` command to ensure only valid numeric values are accepted.

Currently, the flag value is parsed using `parseInt()` without checking for `NaN`, which can lead to unexpected behavior when an invalid value (e.g. `--limit abc`) is provided.

Affected Issue: https://github.com/kdcokenny/ocx/issues/4