### PR TITLE
feat: add README sync to facade repos

### DIFF
--- a/.github/workflows/_sync-facade.yml
+++ b/.github/workflows/_sync-facade.yml
@@ -1,0 +1,72 @@
+name: Sync Facade (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      source_plugin_path:
+        description: 'Path to plugin file in OCX repo'
+        required: true
+        type: string
+      target_plugin_path:
+        description: 'Destination path in target repo'
+        required: true
+        type: string
+      source_readme_path:
+        description: 'Path to README in OCX repo'
+        required: true
+        type: string
+      target_repo:
+        description: 'Target repository (org/repo)'
+        required: true
+        type: string
+      checkout_path:
+        description: 'Local checkout directory name'
+        required: true
+        type: string
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout OCX
+        uses: actions/checkout@v4
+        with:
+          path: ocx
+
+      - name: Checkout Target Repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.target_repo }}
+          token: ${{ secrets.FACADE_SYNC_PAT }}
+          path: ${{ inputs.checkout_path }}
+
+      - name: Sync Files
+        run: |
+          # Ensure target directory exists
+          mkdir -p ${{ inputs.checkout_path }}/$(dirname ${{ inputs.target_plugin_path }})
+
+          # Sync plugin file
+          rsync -av \
+            ocx/${{ inputs.source_plugin_path }} \
+            ${{ inputs.checkout_path }}/${{ inputs.target_plugin_path }}
+
+          # Sync README
+          rsync -av \
+            ocx/${{ inputs.source_readme_path }} \
+            ${{ inputs.checkout_path }}/README.md
+
+      - name: Commit and Push
+        working-directory: ${{ inputs.checkout_path }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "No changes to sync"
+            exit 0
+          fi
+
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          git add .
+          git commit -m "sync: update from ocx@${SHORT_SHA} [skip ci]"
+          git push

--- a/.github/workflows/sync-background-agents.yml
+++ b/.github/workflows/sync-background-agents.yml
@@ -7,47 +7,16 @@ on:
       - main
     paths:
       - 'workers/kdco-registry/files/plugin/background-agents.ts'
+      - 'facades/opencode-background-agents/**'
 
 jobs:
   sync:
     if: github.repository == 'kdcokenny/ocx'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout OCX
-        uses: actions/checkout@v4
-        with:
-          path: ocx
-
-      - name: Checkout Background Agents Repo
-        uses: actions/checkout@v4
-        with:
-          repository: kdcokenny/opencode-background-agents
-          token: ${{ secrets.FACADE_SYNC_PAT }}
-          path: background-agents
-
-      - name: Sync Files
-        run: |
-          # Sync plugin file
-          rsync -av \
-            ocx/workers/kdco-registry/files/plugin/background-agents.ts \
-            background-agents/src/plugin/background-agents.ts
-          
-          # Remove skill directory if it exists (was deleted from source)
-          rm -rf background-agents/src/skill/
-
-      - name: Commit and Push
-        working-directory: background-agents
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Check if there are changes
-          if git diff --quiet; then
-            echo "No changes to sync"
-            exit 0
-          fi
-
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          git add .
-          git commit -m "sync: update from ocx@${SHORT_SHA} [skip ci]"
-          git push
+    uses: ./.github/workflows/_sync-facade.yml
+    with:
+      source_plugin_path: workers/kdco-registry/files/plugin/background-agents.ts
+      target_plugin_path: src/plugin/background-agents.ts
+      source_readme_path: facades/opencode-background-agents/README.md
+      target_repo: kdcokenny/opencode-background-agents
+      checkout_path: background-agents
+    secrets: inherit

--- a/.github/workflows/sync-notify.yml
+++ b/.github/workflows/sync-notify.yml
@@ -1,48 +1,22 @@
 name: Sync Notify
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
     paths:
       - 'workers/kdco-registry/files/plugin/notify.ts'
+      - 'facades/opencode-notify/**'
 
 jobs:
   sync:
     if: github.repository == 'kdcokenny/ocx'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout OCX
-        uses: actions/checkout@v4
-        with:
-          path: ocx
-
-      - name: Checkout Notify Repo
-        uses: actions/checkout@v4
-        with:
-          repository: kdcokenny/opencode-notify
-          token: ${{ secrets.FACADE_SYNC_PAT }}
-          path: notify
-
-      - name: Sync Files
-        run: |
-          # Sync plugin file (rsync for consistency with other sync workflows)
-          rsync -av \
-            ocx/workers/kdco-registry/files/plugin/notify.ts \
-            notify/src/notify.ts
-
-      - name: Commit and Push
-        working-directory: notify
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git diff --quiet; then
-            echo "No changes to sync"
-            exit 0
-          fi
-
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          git add .
-          git commit -m "sync: update from ocx@${SHORT_SHA} [skip ci]"
-          git push
+    uses: ./.github/workflows/_sync-facade.yml
+    with:
+      source_plugin_path: workers/kdco-registry/files/plugin/notify.ts
+      target_plugin_path: src/notify.ts
+      source_readme_path: facades/opencode-notify/README.md
+      target_repo: kdcokenny/opencode-notify
+      checkout_path: notify
+    secrets: inherit

--- a/.github/workflows/sync-workspace.yml
+++ b/.github/workflows/sync-workspace.yml
@@ -1,0 +1,22 @@
+name: Sync Workspace
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'workers/kdco-registry/files/plugin/workspace-plugin.ts'
+      - 'facades/opencode-workspace/**'
+
+jobs:
+  sync:
+    if: github.repository == 'kdcokenny/ocx'
+    uses: ./.github/workflows/_sync-facade.yml
+    with:
+      source_plugin_path: workers/kdco-registry/files/plugin/workspace-plugin.ts
+      target_plugin_path: src/plugin/workspace-plugin.ts
+      source_readme_path: facades/opencode-workspace/README.md
+      target_repo: kdcokenny/opencode-workspace
+      checkout_path: workspace
+    secrets: inherit

--- a/.github/workflows/sync-worktree.yml
+++ b/.github/workflows/sync-worktree.yml
@@ -1,0 +1,22 @@
+name: Sync Worktree
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'workers/kdco-registry/files/plugin/worktree-plugin.ts'
+      - 'facades/opencode-worktree/**'
+
+jobs:
+  sync:
+    if: github.repository == 'kdcokenny/ocx'
+    uses: ./.github/workflows/_sync-facade.yml
+    with:
+      source_plugin_path: workers/kdco-registry/files/plugin/worktree-plugin.ts
+      target_plugin_path: src/plugin/worktree-plugin.ts
+      source_readme_path: facades/opencode-worktree/README.md
+      target_repo: kdcokenny/opencode-worktree
+      checkout_path: worktree
+    secrets: inherit

--- a/facades/opencode-background-agents/README.md
+++ b/facades/opencode-background-agents/README.md
@@ -1,0 +1,118 @@
+# opencode-background-agents
+
+> Keep working while research runs in the background. Your work survives context compaction.
+
+A plugin for [OpenCode](https://github.com/sst/opencode) that enables async background delegation. Fire off research tasks, continue brainstorming or coding, and retrieve results when you need them.
+
+## Why This Exists
+
+Context windows fill up. When that happens, compaction kicks in and your AI loses track of research it just did. You end up re-explaining, re-researching, starting over.
+
+Background agents solve this:
+
+- **Keep working** - Delegate research and continue your conversation. Brainstorm, code review, discuss architecture - you're not blocked waiting.
+- **Survive compaction** - Results are saved to disk as markdown. When context gets tight, the AI knows exactly where to retrieve past research.
+- **Fire and forget** - Use the "waiter model": you don't follow the waiter to the kitchen. A notification arrives when your order is ready.
+
+## Installation
+
+Install via [OCX](https://github.com/kdcokenny/ocx), the package manager for OpenCode extensions:
+
+```bash
+# Install OCX
+curl -fsSL https://ocx.kdco.dev/install.sh | sh
+
+# Initialize and add the plugin
+ocx init
+ocx registry add --name kdco https://registry.kdco.dev
+ocx add kdco/background-agents
+```
+
+Want the full experience? Install `kdco-workspace` instead - it bundles background agents with specialist agents, planning tools, and research protocols:
+
+```bash
+ocx add kdco/workspace
+```
+
+## How It Works
+
+```
+1. Delegate    →  "Research OAuth2 PKCE best practices"
+2. Continue    →  Keep coding, brainstorming, reviewing
+3. Notified    →  <system-reminder> tells you it's done
+4. Retrieve    →  AI calls delegation_read() to get the result
+```
+
+Results are persisted to `~/.local/share/opencode/delegations/` as markdown files. Each delegation is automatically tagged with a title and summary, so the AI can scan past research and find what's relevant.
+
+## Usage
+
+The plugin adds three tools:
+
+| Tool | Purpose |
+|------|---------|
+| `delegate(prompt, agent)` | Launch a background task |
+| `delegation_read(id)` | Retrieve a specific result |
+| `delegation_list()` | List all delegations with titles and summaries |
+
+## Limitations
+
+### Read-Only Agents Only
+
+Only read-only agents (`researcher`, `explore`) can use `delegate`. Write-capable agents (`coder`, `scribe`) must use the native `task` tool.
+
+**Why?** Background delegations run in isolated sessions outside OpenCode's session tree. The undo/branching system cannot track changes made in background sessions—reverting would not affect these changes, risking unexpected data loss.
+
+> A workaround is being explored.
+
+### Timeout
+
+Delegations timeout after **15 minutes**.
+
+### Real-Time Monitoring
+
+View active and completed sub-agents using OpenCode's navigation shortcuts:
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+X Up` | Jump to parent session |
+| `Ctrl+X Left` | Previous sub-agent |
+| `Ctrl+X Right` | Next sub-agent |
+
+## FAQ
+
+### How does the AI know what each delegation contains?
+
+Each delegation is automatically tagged with a title and summary when it completes. When the AI calls `delegation_list()`, it sees all past research with descriptions - not just opaque IDs. This lets it scan for relevant prior work and retrieve exactly what it needs.
+
+### Does this persist after the session ends?
+
+Results are saved to disk and survive context compaction, session restarts, and process crashes. Within a session, the AI can retrieve any past delegation. New sessions start fresh but the files remain on disk.
+
+### Does this bloat my context?
+
+The opposite - it *saves* context. Heavy research runs in a separate sub-agent session. Only the distilled result comes back to your main conversation when you call `delegation_read()`.
+
+### How is this different from Claude Code's Task tool?
+
+Claude's native task tool runs sub-agents but results can be lost when context compacts. This plugin adds a persistence layer - results are written to markdown files, so the AI always knows where to find them.
+
+### Why install via OCX?
+
+One command, auto-configured, registry-backed updates. You could copy the files manually, but you'd need to handle dependencies (`unique-names-generator`) and updates yourself.
+
+## Manual Installation
+
+If you prefer not to use OCX, copy the source files from [`src/`](./src) to `.opencode/plugin/background-agents.ts`.
+
+**Caveats:**
+- Manually install dependencies (`unique-names-generator`)
+- Updates require manual re-copying
+
+## Part of the OCX Ecosystem
+
+This plugin is part of the [KDCO Registry](https://github.com/kdcokenny/ocx/tree/main/registry/src/kdco). For the full experience, check out [kdco-workspace](https://github.com/kdcokenny/ocx) which bundles background agents with specialist agents, planning tools, and notification support.
+
+## License
+
+MIT

--- a/facades/opencode-notify/README.md
+++ b/facades/opencode-notify/README.md
@@ -1,0 +1,119 @@
+# opencode-notify
+
+> Know when your AI needs you back. Native OS notifications for OpenCode.
+
+A plugin for [OpenCode](https://github.com/sst/opencode) that delivers native desktop notifications when tasks complete, errors occur, or the AI needs your input. Stop tab-switching to check if it's done.
+
+## Why This Exists
+
+You delegate a task and switch to another window. Now you're checking back every 30 seconds. Did it finish? Did it error? Is it waiting for permission?
+
+This plugin solves that:
+
+- **Stay focused** - Work in other apps. A notification arrives when the AI needs you.
+- **Native feel** - Uses macOS Notification Center, Windows Toast, or Linux notify-send.
+- **Smart defaults** - Won't spam you. Only notifies for meaningful events, and only when you're not already looking at the terminal.
+
+## Installation
+
+Install via [OCX](https://github.com/kdcokenny/ocx), the package manager for OpenCode extensions:
+
+```bash
+# Install OCX
+curl -fsSL https://ocx.kdco.dev/install.sh | sh
+
+# Initialize and add the plugin
+ocx init
+ocx registry add --name kdco https://registry.kdco.dev
+ocx add kdco/notify
+```
+
+Or get everything at once with `kdco-workspace`:
+
+```bash
+ocx add kdco/workspace
+```
+
+## How It Works
+
+> "Notify the human when the AI needs them back, not for every micro-event."
+
+| Event | Notifies? | Sound | Why |
+|-------|-----------|-------|-----|
+| Session complete | Yes | Glass | Main task done - time to review |
+| Session error | Yes | Basso | Something broke - needs attention |
+| Permission needed | Yes | Submarine | AI is blocked, waiting for you |
+| Sub-task complete | No | - | Parent session handles orchestration |
+
+The plugin automatically:
+1. Detects your terminal emulator (supports 37+ terminals)
+2. Suppresses notifications when your terminal is focused
+3. Enables click-to-focus on macOS (click notification → terminal foregrounds)
+
+## Platform Support
+
+| Feature | macOS | Windows | Linux |
+|---------|-------|---------|-------|
+| Native notifications | Yes | Yes | Yes |
+| Custom sounds | Yes | No | No |
+| Focus detection | Yes | No | No |
+| Click-to-focus | Yes | No | No |
+| Terminal detection | Yes | Yes | Yes |
+
+## Configuration (Optional)
+
+Works out of the box. To customize, create `~/.config/opencode/kdco-notify.json`:
+
+```json
+{
+  "enabled": true,
+  "notifyChildSessions": false,
+  "suppressWhenFocused": true,
+  "sounds": {
+    "idle": "Glass",
+    "error": "Basso",
+    "permission": "Submarine"
+  }
+}
+```
+
+**Available macOS sounds:** Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink
+
+## FAQ
+
+### Does this add bloat to my context?
+
+Minimal footprint. The plugin is event-driven - it listens for session events and fires notifications. No tools are added to your conversation, no prompts are injected beyond initial setup.
+
+### Will I get spammed with notifications?
+
+No. Smart defaults prevent noise:
+- Only notifies for parent sessions (not every sub-task)
+- Suppresses when your terminal is the active window
+- Batches notifications when multiple delegations complete together
+
+### Can I disable it temporarily?
+
+Set `"enabled": false` in the config file, or delete the config to return to defaults.
+
+## Supported Terminals
+
+Uses [`detect-terminal`](https://github.com/jonschlinkert/detect-terminal) to automatically identify your terminal. Supports 37+ terminals including:
+
+Ghostty, Kitty, iTerm2, WezTerm, Alacritty, Hyper, Terminal.app, Windows Terminal, VS Code integrated terminal, and many more.
+
+## Manual Installation
+
+If you prefer not to use OCX, copy the source from [`src/`](./src) to `.opencode/plugin/`.
+
+**Caveats:**
+- Manually install dependencies (`node-notifier`, `detect-terminal`)
+- Updates require manual re-copying
+
+## Part of the OCX Ecosystem
+
+This plugin is part of the [KDCO Registry](https://github.com/kdcokenny/ocx/tree/main/registry/src/kdco). For the full experience, check out [kdco-workspace](https://github.com/kdcokenny/ocx) which bundles notifications with background agents, specialist agents, and planning tools.
+
+## License
+
+MIT

--- a/facades/opencode-workspace/README.md
+++ b/facades/opencode-workspace/README.md
@@ -1,0 +1,210 @@
+# opencode-workspace
+
+> Plan before you build. Structured implementation plans with rule injection.
+
+A plugin for [OpenCode](https://github.com/sst/opencode) that adds planning workflows and agent coordination. Save implementation plans, track phases, and get context-aware rules injected based on which agent is active.
+
+## Why This Exists
+
+Complex tasks need planning. Without structure, AI dives straight into code - missing edge cases, duplicating work, forgetting earlier decisions.
+
+This plugin solves that:
+
+- **Phased planning** - Break work into phases with tracked tasks
+- **Citation support** - Link decisions to research with `ref:delegation-id`
+- **Targeted rules** - Different agents get different instructions automatically
+- **Survives compaction** - Plans are saved to disk and re-injected when context compacts
+
+## Installation
+
+Install via [OCX](https://github.com/kdcokenny/ocx), the package manager for OpenCode extensions:
+
+```bash
+# Install OCX
+curl -fsSL https://ocx.kdco.dev/install.sh | sh
+
+# Initialize and add the plugin
+ocx init
+ocx registry add --name kdco https://registry.kdco.dev
+ocx add kdco/workspace
+```
+
+## How It Works
+
+```
+1. Plan        →  AI creates phased implementation plan
+2. Validate    →  plan_save validates structure before saving
+3. Execute     →  Each phase has tracked tasks with ← CURRENT marker
+4. Recover     →  Plan survives context compaction and session restarts
+```
+
+Plans are stored in `~/.local/share/opencode/workspace/<project-hash>/<session-id>/plan.md`.
+
+## Usage
+
+The plugin adds two tools:
+
+| Tool | Purpose |
+|------|---------|
+| `plan_save(content)` | Save the implementation plan as markdown. Must include citations (ref:delegation-id) for decisions based on research. Plan is validated before saving. |
+| `plan_read(reason)` | Read the current implementation plan for this session. |
+
+### Plan Format
+
+```markdown
+---
+status: in-progress
+phase: 2
+updated: 2026-01-07
+---
+
+# Implementation Plan
+
+## Goal
+Add dark mode support with system preference detection.
+
+## Context & Decisions
+| Decision | Rationale | Source |
+|----------|-----------|--------|
+| Use CSS custom properties | Better performance than class toggling | `ref:swift-tiger-moon` |
+| Prefer prefers-color-scheme | Native, no JS required for initial load | `ref:bold-eagle-star` |
+
+## Phase 1: Research [COMPLETE]
+- [x] 1.1 Research dark mode best practices → `ref:swift-tiger-moon`
+- [x] 1.2 Audit existing color usage in codebase
+
+## Phase 2: Implementation [IN PROGRESS]
+- [x] 2.1 Create CSS custom property system
+- [ ] **2.2 Add theme toggle component** ← CURRENT
+- [ ] 2.3 Implement system preference detection
+
+## Phase 3: Polish [PENDING]
+- [ ] 3.1 Add transition animations
+- [ ] 3.2 Persist user preference to localStorage
+```
+
+### Validation Rules
+
+Plans are validated with Zod schemas before saving:
+
+| Rule | Requirement |
+|------|-------------|
+| Frontmatter | Must have `status`, `phase`, and `updated` (YYYY-MM-DD) |
+| Goal | At least 10 characters |
+| Phases | At least one phase with at least one task |
+| Task IDs | Hierarchical format: `1.1`, `2.3`, etc. |
+| Current marker | Only ONE task may have `← CURRENT` |
+| Citations | Must follow `ref:word-word-word` format |
+
+If validation fails, you get a detailed error:
+
+```
+❌ Plan validation failed:
+
+[phases.1.tasks]: Phase must have at least one task
+[frontmatter.updated]: Date must be YYYY-MM-DD
+
+💡 Load skill('plan-protocol') for the full format spec.
+```
+
+## Agent Rule Injection
+
+The plugin automatically injects different rules based on which agent is active:
+
+### Plan Agent (`PLAN_RULES`)
+
+Injected when `agent === "plan"`:
+- Agent routing boundaries (explore = internal, researcher = external)
+- Plan format specification
+- Skill loading guidance (code-philosophy, frontend-philosophy)
+- Citation requirements
+
+### Build Agent (`BUILD_RULES`)
+
+Injected when `agent === "build"`:
+- Orchestrator delegation mandate (no direct edits, use coder/scribe)
+- Verification workflow (delegate bash commands to coder)
+- Code review protocol (delegate to reviewer before completion)
+- Plan/delegation reading workflow
+
+### Universal Injection
+
+All agents receive:
+- Current date awareness (prevents AI from using outdated years in searches)
+
+## Hooks
+
+### Context Compaction Hook
+
+When OpenCode compacts context, the plugin injects:
+- Full plan content
+- Current task (the one marked `← CURRENT`)
+- Instructions to verify citations with `delegation_read()`
+
+This ensures the AI can resume work after compaction without losing track.
+
+### Post-Task Hook
+
+After a `coder` task completes, a reminder is injected:
+- Proceed to code review if all work is done
+- Delegate to `reviewer` agent
+- Include findings in completion report
+
+## FAQ
+
+### How do citations work?
+
+When you use `delegate()` from background-agents, each delegation gets an ID like `swift-tiger-moon`. Reference these in your plan:
+
+```markdown
+- [x] 1.2 Research OAuth2 patterns → `ref:swift-tiger-moon`
+```
+
+Later, the AI can call `delegation_read("swift-tiger-moon")` to retrieve the full research.
+
+### Does the plan persist across sessions?
+
+Plans are scoped to the root session and survive:
+- Context compaction (re-injected automatically)
+- Session restarts (loaded from disk)
+- Sub-agent sessions (sub-agents access the same plan)
+
+New root sessions start fresh - each major task gets its own plan.
+
+### What if I don't want planning?
+
+You don't have to use it. The tools are available but optional. The rule injection still happens for agent coordination, which helps regardless of whether you use formal plans.
+
+### Can I edit the plan manually?
+
+Yes. Plans are markdown files at `~/.local/share/opencode/workspace/<hash>/<session>/plan.md`. Edit them with any text editor. Next `plan_read()` will load your changes.
+
+## Limitations
+
+### Session Scope
+
+Plans are scoped to the root session. If you start a fresh OpenCode session, you start with no plan. The old plan files remain on disk but aren't loaded automatically.
+
+### Validation Strictness
+
+The Zod validation is intentionally strict. If your plan doesn't follow the format, it won't save. This prevents drift and ensures the plan remains machine-parseable.
+
+## Manual Installation
+
+If you prefer not to use OCX, copy the source from [`src/`](./src) to `.opencode/plugin/`.
+
+**Caveats:**
+- Updates require manual re-copying
+- No external dependencies required
+
+## Part of the OCX Ecosystem
+
+This plugin is part of the [KDCO Registry](https://github.com/kdcokenny/ocx/tree/main/registry/src/kdco). For the full experience, combine with:
+
+- [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents) - Async delegation with persistent outputs
+- [opencode-worktree](https://github.com/kdcokenny/opencode-worktree) - Isolated git worktrees for AI experiments
+- [opencode-notify](https://github.com/kdcokenny/opencode-notify) - Native OS notifications
+
+## License
+
+MIT

--- a/facades/opencode-worktree/README.md
+++ b/facades/opencode-worktree/README.md
@@ -1,0 +1,217 @@
+# opencode-worktree
+
+> Isolated branches for AI experiments. Git worktrees that spawn their own terminal.
+
+A plugin for [OpenCode](https://github.com/sst/opencode) that creates isolated git worktrees for risky AI development sessions. Each worktree gets its own terminal window with OpenCode running inside.
+
+## Why This Exists
+
+AI makes risky changes. Sometimes it wants to refactor half the codebase, try a wild architectural idea, or experiment with something that might break everything.
+
+You don't want to stash your current work. You don't want to commit half-done code. You need isolation.
+
+This plugin solves that:
+
+- **Zero-friction isolation** - Create a worktree with one tool call. No manual git commands.
+- **Auto-spawns terminal** - A new terminal opens automatically with OpenCode ready to work.
+- **Clean exit** - Changes are committed and worktrees cleaned up when the session ends.
+- **File sync** - Copy `.env` files, symlink `node_modules`, run post-create hooks.
+
+## Installation
+
+Install via [OCX](https://github.com/kdcokenny/ocx), the package manager for OpenCode extensions:
+
+```bash
+# Install OCX
+curl -fsSL https://ocx.kdco.dev/install.sh | sh
+
+# Initialize and add the plugin
+ocx init
+ocx registry add --name kdco https://registry.kdco.dev
+ocx add kdco/worktree
+```
+
+Want the full experience? Install `kdco-workspace` instead - it bundles worktrees with background agents, planning tools, and notifications:
+
+```bash
+ocx add kdco/workspace
+```
+
+## How It Works
+
+```
+1. Create      →  worktree_create("feature/dark-mode")
+2. Terminal    →  New window opens with OpenCode at .opencode/worktrees/feature/dark-mode
+3. Work        →  AI experiments in complete isolation from your main branch
+4. Delete      →  worktree_delete() commits changes and cleans up
+```
+
+Worktrees are stored in `.opencode/worktrees/<branch-name>/` within your repository.
+
+## Usage
+
+The plugin adds two tools:
+
+| Tool | Purpose |
+|------|---------|
+| `worktree_create(branch, baseBranch?)` | Create a new git worktree for isolated development. A new terminal will open with OpenCode in the worktree. |
+| `worktree_delete(reason)` | Delete the current worktree and clean up. Changes will be committed before removal. |
+
+### Creating a Worktree
+
+```
+worktree_create:
+  branch: "feature/dark-mode"
+  baseBranch: "main"  # optional, defaults to HEAD
+```
+
+The AI calls this and:
+1. Git worktree is created at `.opencode/worktrees/feature/dark-mode`
+2. Files are synced based on `.opencode/worktree.jsonc` config
+3. Post-create hooks run (e.g., `pnpm install`)
+4. A new terminal window opens with OpenCode
+
+### Deleting a Worktree
+
+```
+worktree_delete:
+  reason: "Feature complete, merging to main"
+```
+
+The AI calls this and:
+1. Pre-delete hooks run (e.g., `docker compose down`)
+2. All changes are committed with a snapshot message
+3. Git worktree is removed with `--force`
+4. Session state is cleaned up
+
+## Platform Support
+
+The plugin detects your terminal and spawns appropriately:
+
+| Platform | Terminals Supported |
+|----------|---------------------|
+| **macOS** | Ghostty, iTerm2, Kitty, WezTerm, Alacritty, Warp, Terminal.app |
+| **Linux** | Kitty, WezTerm, Alacritty, Ghostty, Foot, GNOME Terminal, Konsole, XFCE4 Terminal, xterm |
+| **Windows** | Windows Terminal (wt.exe), cmd.exe fallback |
+| **tmux** | Creates new tmux window (any platform) |
+| **WSL** | Uses Windows Terminal via wt.exe interop |
+
+### Priority Detection
+
+1. **tmux** - If inside tmux, creates new window (takes priority on any platform)
+2. **WSL** - Detects Windows Subsystem for Linux, uses wt.exe
+3. **Environment vars** - Checks `TERM_PROGRAM`, `KITTY_WINDOW_ID`, `GHOSTTY_RESOURCES_DIR`, etc.
+4. **Fallback** - Uses system defaults (Terminal.app on macOS, xterm on Linux)
+
+## Configuration
+
+The plugin auto-creates `.opencode/worktree.jsonc` on first use:
+
+```jsonc
+{
+  "$schema": "https://registry.kdco.dev/schemas/worktree.json",
+
+  "sync": {
+    // Files to copy from main worktree to new worktrees
+    // Example: [".env", ".env.local", "dev.sqlite"]
+    "copyFiles": [],
+
+    // Directories to symlink (saves disk space)
+    // Example: ["node_modules"]
+    "symlinkDirs": [],
+
+    // Patterns to exclude from copying
+    "exclude": []
+  },
+
+  "hooks": {
+    // Commands to run after worktree creation
+    // Example: ["pnpm install", "docker compose up -d"]
+    "postCreate": [],
+
+    // Commands to run before worktree deletion
+    // Example: ["docker compose down"]
+    "preDelete": []
+  }
+}
+```
+
+### Common Configurations
+
+**Node.js project:**
+```jsonc
+{
+  "sync": {
+    "copyFiles": [".env", ".env.local"],
+    "symlinkDirs": ["node_modules"]
+  },
+  "hooks": {
+    "postCreate": ["pnpm install"]
+  }
+}
+```
+
+**Docker-based project:**
+```jsonc
+{
+  "sync": {
+    "copyFiles": [".env"]
+  },
+  "hooks": {
+    "postCreate": ["docker compose up -d"],
+    "preDelete": ["docker compose down"]
+  }
+}
+```
+
+## Limitations
+
+### Security
+
+- Branch names are validated against git ref rules and shell metacharacters
+- File sync paths are validated to prevent directory traversal (no `..` or absolute paths)
+- Hook commands run with user privileges in the worktree directory
+
+### Terminal Spawning
+
+- Ghostty on macOS uses inline commands to avoid permission dialogs for temp scripts
+- Kitty tab support requires `allow_remote_control` in kitty config (falls back to new window)
+- Some terminals don't support tabs; a new OS window is opened instead
+
+## FAQ
+
+### What happens to my changes if I forget to delete the worktree?
+
+Changes remain in the worktree directory (`.opencode/worktrees/<branch>/`). The branch still exists in git. You can manually check it out or delete it later.
+
+### Can I have multiple worktrees open at once?
+
+Yes. Each worktree gets its own terminal and OpenCode session. They're fully independent.
+
+### Does this work with my existing git workflow?
+
+Yes. It uses standard git worktrees under the hood. You can `git worktree list` to see them, merge branches normally, etc.
+
+### Why spawn a new terminal instead of using the current one?
+
+Isolation. The worktree session is independent - you can close it, the original terminal keeps working. If the AI breaks something, your main session is unaffected.
+
+## Manual Installation
+
+If you prefer not to use OCX, copy the source from [`src/`](./src) to `.opencode/plugin/`.
+
+**Caveats:**
+- Manually install dependencies (`jsonc-parser`)
+- Updates require manual re-copying
+
+## Part of the OCX Ecosystem
+
+This plugin is part of the [KDCO Registry](https://github.com/kdcokenny/ocx/tree/main/registry/src/kdco). For the full experience, combine with:
+
+- [opencode-workspace](https://github.com/kdcokenny/opencode-workspace) - Structured planning with rule injection
+- [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents) - Async delegation with persistent outputs
+- [opencode-notify](https://github.com/kdcokenny/opencode-notify) - Native OS notifications
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
Makes OCX the single source of truth for code AND documentation for facade repositories.

## Changes
- Created `facades/` directory with READMEs for 4 facade repos
- Copied existing READMEs verbatim from `opencode-notify` and `opencode-background-agents`
- Wrote new READMEs for `opencode-worktree` and `opencode-workspace` (styled after existing)
- Created reusable workflow `_sync-facade.yml` with shared sync logic
- Refactored all 4 sync workflows to use reusable pattern (~175 lines eliminated)

## Files
| File | Action |
|------|--------|
| `facades/opencode-notify/README.md` | Created (verbatim copy) |
| `facades/opencode-background-agents/README.md` | Created (verbatim copy) |
| `facades/opencode-worktree/README.md` | Created (new) |
| `facades/opencode-workspace/README.md` | Created (new) |
| `.github/workflows/_sync-facade.yml` | Created (reusable) |
| `.github/workflows/sync-notify.yml` | Refactored |
| `.github/workflows/sync-background-agents.yml` | Refactored |
| `.github/workflows/sync-worktree.yml` | Refactored |
| `.github/workflows/sync-workspace.yml` | Refactored |

## Notes
- Workflows for `opencode-worktree` and `opencode-workspace` are ready but won't trigger until those repos are created
- All workflows use `FACADE_SYNC_PAT` secret for cross-repo push access

Closes #10