### PR TITLE
fix: Reviewer not triggering after coder - tool.execute.after implementation

### DIFF
--- a/.opencode/plugin/workspace-plugin.ts
+++ b/.opencode/plugin/workspace-plugin.ts
@@ -294,8 +294,8 @@ interface SystemTransformInput {
 /** Tracks in-flight coder task callIDs with timestamps for stale cleanup */
 const activeCoderCalls = new Map<string, { startTime: number }>()
 
-/** Stale call timeout - 5 minutes */
-const STALE_CALL_TIMEOUT_MS = 5 * 60 * 1000
+/** Stale call timeout - matches MAX_RUN_TIME_MS in background-agents.ts */
+const STALE_CALL_TIMEOUT_MS = 15 * 60 * 1000
 
 /** Periodic cleanup of orphaned callIDs (runs every 60s) */
 const cleanupInterval = setInterval(() => {

--- a/workers/kdco-registry/files/plugin/workspace-plugin.ts
+++ b/workers/kdco-registry/files/plugin/workspace-plugin.ts
@@ -294,8 +294,8 @@ interface SystemTransformInput {
 /** Tracks in-flight coder task callIDs with timestamps for stale cleanup */
 const activeCoderCalls = new Map<string, { startTime: number }>()
 
-/** Stale call timeout - 5 minutes */
-const STALE_CALL_TIMEOUT_MS = 5 * 60 * 1000
+/** Stale call timeout - matches MAX_RUN_TIME_MS in background-agents.ts */
+const STALE_CALL_TIMEOUT_MS = 15 * 60 * 1000
 
 /** Periodic cleanup of orphaned callIDs (runs every 60s) */
 const cleanupInterval = setInterval(() => {


### PR DESCRIPTION
## Summary
Fixes the broken `tool.execute.after` hook that was checking `output.args.subagent_type` which doesn't exist in the after hook.

## Changes
- Added `activeCoderCalls` Map with timestamps at module level
- Added `tool.execute.before` hook to track coder task callIDs
- Fixed `tool.execute.after` to use callID-based lookup
- Added 60s cleanup sweep for orphaned callIDs (5-min timeout)
- Trigger fires only when ALL coder tasks complete

## Files Changed
- `.opencode/plugin/workspace-plugin.ts`
- `workers/kdco-registry/files/plugin/workspace-plugin.ts` (mirror)

## Testing
- `bun run check` passes (lint clean, pre-existing type issues unrelated)
- Code reviewed and approved

Fixes #11