### PR TITLE
fix(facades): update opencode-worktree sync to use correct filenames

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -11,8 +11,12 @@ kdcokenny/opencode-background-agents:
     dest: README.md
 
 kdcokenny/opencode-worktree:
-  - source: workers/kdco-registry/files/plugin/worktree-plugin.ts
-    dest: src/plugin/worktree-plugin.ts
+  - source: workers/kdco-registry/files/plugin/worktree.ts
+    dest: src/plugin/worktree.ts
+  - source: workers/kdco-registry/files/plugin/worktree/state.ts
+    dest: src/plugin/worktree/state.ts
+  - source: workers/kdco-registry/files/plugin/worktree/terminal.ts
+    dest: src/plugin/worktree/terminal.ts
   - source: facades/opencode-worktree/README.md
     dest: README.md
 


### PR DESCRIPTION
## Summary

Fixes the opencode-worktree facade sync configuration to use the correct current filenames and include file dependencies.

## Changes

- `worktree-plugin.ts` → `worktree.ts` (correct current filename)
- Added `worktree/state.ts` sync entry
- Added `worktree/terminal.ts` sync entry

## Testing

Once merged, the GitHub Action will automatically sync the correct files to the `kdcokenny/opencode-worktree` facade repo.

Fixes #28