### PR TITLE
fix: prevent delegation metadata sessions from polluting session list

### DIFF
--- a/workers/kdco-registry/files/plugin/background-agents.ts
+++ b/workers/kdco-registry/files/plugin/background-agents.ts
@@ -46,6 +46,7 @@ interface GeneratedMetadata {
 async function generateMetadata(
 	client: OpencodeClient,
 	resultContent: string,
+	parentID: string,
 	debugLog: (msg: string) => Promise<void>,
 ): Promise<GeneratedMetadata> {
 	const fallbackMetadata = (): GeneratedMetadata => {
@@ -72,7 +73,10 @@ async function generateMetadata(
 
 		// Create a session for metadata generation
 		const session = await client.session.create({
-			body: { title: "Metadata Generation" },
+			body: {
+				title: "Metadata Generation",
+				parentID,
+			},
 		})
 
 		if (!session.data?.id) {
@@ -543,7 +547,9 @@ class DelegationManager {
 		const result = await this.getResult(delegation)
 
 		// Generate title and description using small model
-		const metadata = await generateMetadata(this.client, result, (msg) => this.debugLog(msg))
+		const metadata = await generateMetadata(this.client, result, delegation.sessionID, (msg) =>
+			this.debugLog(msg),
+		)
 		delegation.title = metadata.title
 		delegation.description = metadata.description
 


### PR DESCRIPTION
## Summary

Fixes #31 - Delegation sessions were polluting the `/session` list with "Metadata Generation" entries.

## Solution

Added `parentID` to metadata generation sessions, linking them to the delegation session. Sessions with `parentID` are automatically filtered from the main session list in OpenCode's UI.

## Changes

- Added `parentID: string` parameter to `generateMetadata` function
- Pass `parentID` when creating the metadata session
- Call site passes `delegation.sessionID` as the parent

## Testing

- [x] Lint check passed
- [ ] Manual testing (delegations should no longer leave "Metadata Generation" sessions visible)