### PR TITLE
feat: Registry catalog support and dependency conflict detection

### DIFF
--- a/.opencode/bun.lock
+++ b/.opencode/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "opencode-plugins",
       "dependencies": {
-        "@opencode-ai/plugin": "1.1.4",
+        "@opencode-ai/plugin": "1.1.6",
       },
       "devDependencies": {
         "detect-terminal": "2.0.0",
@@ -17,9 +17,9 @@
     },
   },
   "packages": {
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.4", "", { "dependencies": { "@opencode-ai/sdk": "1.1.4", "zod": "4.1.8" } }, "sha512-RA7KsC6uoqjwJturbTLX7cq+XYet3XA2tRbsh5JTEm98wH7xuQREbkCiFUqk97nbV+BgCf/ex8MyF6P/B0wFCA=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.6", "", { "dependencies": { "@opencode-ai/sdk": "1.1.6", "zod": "4.1.8" } }, "sha512-psGajIrj4V03gn85/7Xy5YXdPoCsRGwBsifruG5TfG63+7Jd1TENNufp+SxGb+xtlddDteDMGVHSnE98q9LbDw=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.4", "", {}, "sha512-fhQH1U3b2K9HDTTJ6Ia7q4FoBwLlrsDf5pTF/D11FntOJPkZoFAhRBznjc8rwCqrGeDzg4YFs+68oLqWgCL/iA=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.6", "", {}, "sha512-7Tiso9BExVgxz86VY6F807McCyOgu/SCaQJ87wwxxVSN8GpPpmUIYN5h6LH38EBNJWKXDjokasn/y9EkKxOisQ=="],
 
     "detect-terminal": ["detect-terminal@2.0.0", "", {}, "sha512-94Pxgtl45fB4DAfC/dmSNQglU0En4iAmMm5kn8iycZ3lnxWBtWpW622T7WkPEomN9rn7P8LDQbQjPIoyerZW0g=="],
 

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -10,6 +10,6 @@
     "jsonc-parser": "3.3.1"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "1.1.4"
+    "@opencode-ai/plugin": "1.1.6"
   }
 }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [examples/registry-starter](./examples/registry-starter) for the full templa
 ## What OCX Handles
 
 - **npm Dependencies** — Plugins need packages? Installed automatically. No manual `package.json` editing.
+- **Catalog Support** — Registries can define shared dependency versions that components reference via `catalog:name` syntax
 - **MCP Servers** — Registered to your config with one command. No manual JSON.
 - **Config Merging** — Components bring settings that merge safely with yours.
 - **Lockfiles** — Track versions, verify integrity with SHA-256 hashes.

--- a/docs/CREATING_REGISTRIES.md
+++ b/docs/CREATING_REGISTRIES.md
@@ -29,7 +29,37 @@ OCX follows the **Cargo + ShadCN model**:
 1. **Namespace as Identity**: Every registry declares a `namespace` (e.g., `kdco`). Components are referenced as `namespace/component` (e.g., `kdco/researcher`).
 2. **Clean Component Names**: Components within a registry use clean names (`researcher`, not `kdco-researcher`). The namespace provides provenance.
 3. **Explicit Trust**: Cross-namespace dependencies require the user to have that registry configured. No auto-fetching from unknown sources.
-4. **Own Your Code**: Components are copied into your project with clean filenames. The lockfile tracks provenance.
+4. **Own Your Code**: Components are copied into your project, not hidden in `node_modules`. You own the code—customize freely.
+
+## Using Catalogs for Dependency Management
+
+If multiple components share the same npm dependencies, use a catalog to manage versions centrally:
+
+1. Define the catalog in your registry index:
+
+```json
+{
+  "catalog": {
+    "zod": "^4.3.5",
+    "lodash": "^4.17.21"
+  }
+}
+```
+
+2. Reference catalog entries in component manifests:
+
+```json
+{
+  "npmDevDependencies": ["catalog:zod", "catalog:lodash"]
+}
+```
+
+3. To update a dependency version, change it once in the catalog - all components will use the new version.
+
+**Best Practices:**
+- Use catalogs for dependencies shared across 2+ components
+- Use pinned versions directly for component-specific dependencies
+- Use bare names (no version) when any version is acceptable
 
 ## Structure
 

--- a/docs/REGISTRY_PROTOCOL.md
+++ b/docs/REGISTRY_PROTOCOL.md
@@ -45,6 +45,10 @@ Returns registry metadata and a list of available components. Must conform to [`
   "namespace": "myregistry",
   "version": "1.0.0",
   "author": "Your Name",
+  "catalog": {
+    "zod": "^4.3.5",
+    "openai": "^4.73.0"
+  },
   "components": [
     {
       "name": "my-skill",
@@ -63,7 +67,41 @@ Returns registry metadata and a list of available components. Must conform to [`
 | `namespace` | string | Yes | Unique identifier (kebab-case) |
 | `version` | string | Yes | Registry version (semver recommended) |
 | `author` | string | Yes | Registry author or organization |
+| `catalog` | object | No | Shared dependency versions (see Catalog section below) |
 | `components` | array | Yes | List of available components |
+
+#### Catalog (Shared Dependency Versions)
+
+Registries can define a `catalog` field to centralize dependency versions. This allows component authors to update a dependency version in one place instead of editing every component manifest.
+
+```json
+{
+  "name": "kdco",
+  "version": "1.0.0",
+  "catalog": {
+    "zod": "^4.3.5",
+    "openai": "^4.73.0",
+    "jsonc-parser": "^3.3.1"
+  },
+  "components": [...]
+}
+```
+
+Components can reference catalog entries using the `catalog:` prefix in `npmDependencies` or `npmDevDependencies`:
+
+```json
+{
+  "name": "workspace-plugin",
+  "npmDevDependencies": ["catalog:zod", "catalog:openai"]
+}
+```
+
+When OCX resolves dependencies, `catalog:zod` is expanded to `zod@^4.3.5` based on the registry's catalog.
+
+**Benefits:**
+- Single source of truth for dependency versions
+- Easy version updates across all components
+- Follows [pnpm catalogs](https://pnpm.io/catalogs) pattern
 
 ### Component Packument
 
@@ -186,5 +224,5 @@ Registries can be hosted on:
 ## Related Documentation
 
 - [Registry Schema](./schemas/registry.schema.json) - Full JSON Schema for validation
-- [Creating a Registry](../registry/REGISTRY.md) - Guide to building your own registry
+- [Creating a Registry](./CREATING_REGISTRIES.md) - Guide to building your own registry
 - [Enterprise Features](./ENTERPRISE.md) - Locking, versioning, and integrity verification

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -35,6 +35,20 @@
 			"items": {
 				"$ref": "#/definitions/component"
 			}
+		},
+		"catalog": {
+			"type": "object",
+			"description": "Shared dependency versions. Components reference via 'catalog:key' syntax in npmDependencies/npmDevDependencies.",
+			"additionalProperties": {
+				"type": "string",
+				"description": "Version specifier (e.g., '^4.3.5', '~2.0.0', '4.0.0')"
+			},
+			"examples": [
+				{
+					"zod": "^4.3.5",
+					"openai": "^4.73.0"
+				}
+			]
 		}
 	},
 	"definitions": {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -11,13 +11,20 @@ import { dirname, join } from "node:path"
 import type { Command } from "commander"
 import { CLI_VERSION, GITHUB_REPO } from "../constants.js"
 import { fetchFileContent, fetchRegistryIndex } from "../registry/fetcher.js"
-import type { ResolvedComponent } from "../registry/resolver.js"
+import type { ResolvedComponent, ResolvedNpmDependency } from "../registry/resolver.js"
 import { type ResolvedDependencies, resolveDependencies } from "../registry/resolver.js"
 import { type OcxLock, readOcxConfig, readOcxLock } from "../schemas/config.js"
 import type { ComponentFileObject, RegistryIndex } from "../schemas/registry.js"
 import { updateOpencodeJsonConfig } from "../updaters/update-opencode-config.js"
 import { isContentIdentical } from "../utils/content.js"
-import { ConfigError, ConflictError, IntegrityError, ValidationError } from "../utils/errors.js"
+import {
+	ConfigError,
+	ConflictError,
+	type DependencyConflict,
+	DependencyConflictError,
+	IntegrityError,
+	ValidationError,
+} from "../utils/errors.js"
 import {
 	collectCompatIssues,
 	createSpinner,
@@ -78,29 +85,33 @@ async function runAdd(componentNames: string[], options: AddOptions): Promise<vo
 	spin?.start()
 
 	try {
-		// Resolve all dependencies across all configured registries
-		const resolved = await resolveDependencies(config.registries, componentNames)
+		// Fetch registry indexes BEFORE resolution (needed for catalog resolution)
+		const registryIndexes = new Map<string, RegistryIndex>()
+		const failedRegistries = new Set<string>()
+
+		// Fetch registry indexes in parallel
+		await Promise.all(
+			Object.entries(config.registries).map(async ([namespace, regConfig]) => {
+				try {
+					const index = await fetchRegistryIndex(regConfig.url)
+					registryIndexes.set(namespace, index)
+				} catch {
+					failedRegistries.add(namespace)
+					logger.warn(
+						`Could not fetch registry index for ${namespace} - catalog references will not work`,
+					)
+				}
+			}),
+		)
+
+		// Resolve all dependencies across all configured registries (with catalog data)
+		const resolved = await resolveDependencies(config.registries, componentNames, registryIndexes)
 
 		if (options.verbose) {
 			logger.info("Install order:")
 			for (const name of resolved.installOrder) {
 				logger.info(`  - ${name}`)
 			}
-		}
-
-		// Fetch registry indexes once (Law 2: Parse at boundary)
-		const registryIndexes = new Map<string, RegistryIndex>()
-		const uniqueBaseUrls = new Map<string, string>() // namespace -> baseUrl
-
-		for (const component of resolved.components) {
-			if (!uniqueBaseUrls.has(component.registryName)) {
-				uniqueBaseUrls.set(component.registryName, component.baseUrl)
-			}
-		}
-
-		for (const [namespace, baseUrl] of uniqueBaseUrls) {
-			const index = await fetchRegistryIndex(baseUrl)
-			registryIndexes.set(namespace, index)
 		}
 
 		spin?.succeed(
@@ -116,6 +127,24 @@ async function runAdd(componentNames: string[], options: AddOptions): Promise<vo
 					ocxVersion: CLI_VERSION,
 				})
 				warnCompatIssues(namespace, issues)
+			}
+		}
+
+		// Check for npm dependency version conflicts (Law 4: Fail Fast)
+		const existingDeps = await getExistingDevDependencies(cwd)
+		const allResolved = [...resolved.npmDependencies, ...resolved.npmDevDependencies]
+		const conflicts = detectVersionConflicts(allResolved, existingDeps)
+
+		if (conflicts.length > 0) {
+			if (!options.yes) {
+				throw new DependencyConflictError(conflicts)
+			}
+			// With --yes: warn and continue (last declared wins)
+			logger.warn("Dependency version conflicts detected (continuing with --yes):")
+			for (const conflict of conflicts) {
+				logger.warn(
+					`  ${conflict.packageName}: ${conflict.versions.map((v) => v.version).join(" vs ")}`,
+				)
 			}
 		}
 
@@ -418,7 +447,13 @@ function logResolved(resolved: ResolvedDependencies): void {
 		logger.info("")
 		logger.info("Would install npm dependencies:")
 		for (const dep of resolved.npmDependencies) {
-			logger.info(`  ${dep}`)
+			if (dep.kind === "catalog") {
+				logger.info(`  ${dep.name}@${dep.version} (from catalog:${dep.catalogKey})`)
+			} else if (dep.kind === "pinned") {
+				logger.info(`  ${dep.name}@${dep.version}`)
+			} else {
+				logger.info(`  ${dep.name} (latest)`)
+			}
 		}
 	}
 
@@ -426,7 +461,13 @@ function logResolved(resolved: ResolvedDependencies): void {
 		logger.info("")
 		logger.info("Would install npm dev dependencies:")
 		for (const dep of resolved.npmDevDependencies) {
-			logger.info(`  ${dep}`)
+			if (dep.kind === "catalog") {
+				logger.info(`  ${dep.name}@${dep.version} (from catalog:${dep.catalogKey})`)
+			} else if (dep.kind === "pinned") {
+				logger.info(`  ${dep.name}@${dep.version}`)
+			} else {
+				logger.info(`  ${dep.name} (latest)`)
+			}
 		}
 	}
 }
@@ -438,6 +479,18 @@ function logResolved(resolved: ResolvedDependencies): void {
 interface NpmDependency {
 	name: string
 	version: string
+}
+
+/**
+ * Converts a ResolvedNpmDependency to NpmDependency for package.json.
+ * - catalog/pinned: uses the resolved version
+ * - bare: uses "*" as version (any version acceptable)
+ */
+function toNpmDependency(dep: ResolvedNpmDependency): NpmDependency {
+	if (dep.kind === "bare") {
+		return { name: dep.name, version: "*" }
+	}
+	return { name: dep.name, version: dep.version }
 }
 
 interface OpencodePackageJson {
@@ -452,33 +505,6 @@ const DEFAULT_PACKAGE_JSON: OpencodePackageJson = {
 	name: "opencode-plugins",
 	private: true,
 	type: "module",
-}
-
-/**
- * Parses an npm dependency spec into name and version.
- * Handles: "lodash", "lodash@4.0.0", "@types/node", "@types/node@1.0.0"
- */
-function parseNpmDependency(spec: string): NpmDependency {
-	// Guard: invalid input
-	if (!spec?.trim()) {
-		throw new ValidationError(`Invalid npm dependency: expected non-empty string, got "${spec}"`)
-	}
-
-	const trimmed = spec.trim()
-	const lastAt = trimmed.lastIndexOf("@")
-
-	// Has version: "lodash@4.0.0" or "@types/node@1.0.0"
-	if (lastAt > 0) {
-		const name = trimmed.slice(0, lastAt)
-		const version = trimmed.slice(lastAt + 1)
-		if (!version) {
-			throw new ValidationError(`Invalid npm dependency: missing version after @ in "${spec}"`)
-		}
-		return { name, version }
-	}
-
-	// No version: "lodash" or "@types/node" → use "*"
-	return { name: trimmed, version: "*" }
 }
 
 /**
@@ -555,20 +581,20 @@ async function ensureManifestFilesAreTracked(opencodeDir: string): Promise<void>
  */
 async function updateOpencodeDevDependencies(
 	cwd: string,
-	npmDeps: string[],
-	npmDevDeps: string[],
+	npmDeps: ResolvedNpmDependency[],
+	npmDevDeps: ResolvedNpmDependency[],
 ): Promise<void> {
 	// Guard: no deps to process
-	const allDepSpecs = [...npmDeps, ...npmDevDeps]
-	if (allDepSpecs.length === 0) return
+	const allDeps = [...npmDeps, ...npmDevDeps]
+	if (allDeps.length === 0) return
 
 	const opencodeDir = join(cwd, ".opencode")
 
 	// Ensure directory exists
 	await mkdir(opencodeDir, { recursive: true })
 
-	// Parse all deps - fails fast on invalid
-	const parsedDeps = allDepSpecs.map(parseNpmDependency)
+	// Convert resolved deps to package.json format
+	const parsedDeps = allDeps.map(toNpmDependency)
 
 	// Read → merge → write
 	const existing = await readOpencodePackageJson(opencodeDir)
@@ -577,6 +603,74 @@ async function updateOpencodeDevDependencies(
 
 	// Ensure manifest files are tracked by git
 	await ensureManifestFilesAreTracked(opencodeDir)
+}
+
+// ============================================================================
+// Dependency Conflict Detection
+// ============================================================================
+
+/**
+ * Reads existing dependencies from .opencode/package.json.
+ * Returns empty object if file doesn't exist or is invalid.
+ */
+async function getExistingDevDependencies(cwd: string): Promise<Record<string, string>> {
+	const pkgPath = join(cwd, ".opencode", "package.json")
+	try {
+		const content = await Bun.file(pkgPath).text()
+		const pkg = JSON.parse(content)
+		return { ...pkg.dependencies, ...pkg.devDependencies }
+	} catch {
+		return {} // File doesn't exist or is invalid
+	}
+}
+
+/**
+ * Detects version conflicts between resolved dependencies and existing package.json.
+ * Returns conflicts grouped: component conflicts first, then package.json conflicts.
+ */
+export function detectVersionConflicts(
+	resolved: ResolvedNpmDependency[],
+	existing: Record<string, string>,
+): DependencyConflict[] {
+	// Group versions by package name
+	const byName = new Map<string, Array<{ version: string; source: string }>>()
+
+	// Collect versions from resolved deps
+	for (const dep of resolved) {
+		if (dep.kind === "bare") continue // bare deps accept any version
+		const entries = byName.get(dep.name) ?? []
+		entries.push({
+			version: dep.version,
+			source: dep.declaredBy + (dep.kind === "catalog" ? ` via catalog:${dep.catalogKey}` : ""),
+		})
+		byName.set(dep.name, entries)
+	}
+
+	// Add existing package.json versions
+	for (const [name, version] of Object.entries(existing)) {
+		const entries = byName.get(name)
+		if (entries) {
+			entries.push({ version, source: ".opencode/package.json" })
+		}
+	}
+
+	// Find conflicts (different versions for same package)
+	const conflicts: DependencyConflict[] = []
+	for (const [packageName, versions] of byName) {
+		const uniqueVersions = [...new Set(versions.map((v) => v.version.trim()))]
+		if (uniqueVersions.length > 1) {
+			conflicts.push({ packageName, versions })
+		}
+	}
+
+	// Sort: component conflicts first, then package.json conflicts
+	return conflicts.sort((a, b) => {
+		const aHasPkgJson = a.versions.some((v) => v.source.includes("package.json"))
+		const bHasPkgJson = b.versions.some((v) => v.source.includes("package.json"))
+		if (aHasPkgJson && !bHasPkgJson) return 1
+		if (!aHasPkgJson && bHasPkgJson) return -1
+		return a.packageName.localeCompare(b.packageName)
+	})
 }
 
 /**

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -12,10 +12,20 @@ import {
 	normalizeComponentManifest,
 	type OpencodeConfig,
 	parseQualifiedComponent,
+	type RegistryIndex,
 } from "../schemas/registry.js"
 import { ConfigError, OCXError, ValidationError } from "../utils/errors.js"
 import { fetchComponent } from "./fetcher.js"
 import { mergeOpencodeConfig } from "./merge.js"
+
+/**
+ * Resolved npm dependency with source tracking.
+ * Discriminated union ensures illegal states are unrepresentable (Law 2).
+ */
+export type ResolvedNpmDependency =
+	| { kind: "catalog"; name: string; version: string; catalogKey: string; declaredBy: string }
+	| { kind: "pinned"; name: string; version: string; declaredBy: string }
+	| { kind: "bare"; name: string; declaredBy: string }
 
 /**
  * Parse a component reference into namespace and component name.
@@ -40,6 +50,55 @@ export function parseComponentRef(
 	throw new ValidationError(`Component '${ref}' must include a namespace (e.g., 'kdco/${ref}')`)
 }
 
+/**
+ * Resolves a dependency specifier to a ResolvedNpmDependency.
+ * Handles catalog:X, pinned (name@version), and bare (name) formats.
+ *
+ * @throws ValidationError if catalog:X references non-existent catalog entry (Law 1: Early Exit)
+ */
+export function resolveDependencySpec(
+	spec: string,
+	catalog: Record<string, string> | undefined,
+	declaredBy: string,
+): ResolvedNpmDependency {
+	// Guard clause: catalog reference
+	if (spec.startsWith("catalog:")) {
+		const catalogKey = spec.slice(8)
+		if (!catalog?.[catalogKey]) {
+			const available = catalog ? Object.keys(catalog).join(", ") : "none"
+			throw new ValidationError(
+				`Catalog reference "${spec}" not found in registry. Available catalog entries: ${available}`,
+			)
+		}
+		return {
+			kind: "catalog",
+			name: catalogKey,
+			version: catalog[catalogKey],
+			catalogKey,
+			declaredBy,
+		}
+	}
+
+	// Parse pinned or bare
+	const atIndex = spec.lastIndexOf("@")
+	if (atIndex > 0) {
+		// Pinned: name@version
+		const name = spec.slice(0, atIndex)
+		const version = spec.slice(atIndex + 1)
+
+		// Guard: version must be non-empty (Law 4: Fail Fast)
+		if (!version) {
+			throw new ValidationError(
+				`Invalid dependency specifier "${spec}": version is empty after "@". Use bare name "${name}" or specify a version.`,
+			)
+		}
+		return { kind: "pinned", name, version, declaredBy }
+	}
+
+	// Bare: just the name
+	return { kind: "bare", name: spec, declaredBy }
+}
+
 export interface ResolvedComponent extends NormalizedComponentManifest {
 	/** The namespace this component belongs to */
 	namespace: string
@@ -56,9 +115,9 @@ export interface ResolvedDependencies {
 	/** Install order (component names) */
 	installOrder: string[]
 	/** Aggregated npm dependencies from all components */
-	npmDependencies: string[]
+	npmDependencies: ResolvedNpmDependency[]
 	/** Aggregated npm dev dependencies from all components */
-	npmDevDependencies: string[]
+	npmDevDependencies: ResolvedNpmDependency[]
 	/** Merged opencode configuration from all components (deep merged) */
 	opencode: OpencodeConfig
 }
@@ -70,11 +129,12 @@ export interface ResolvedDependencies {
 export async function resolveDependencies(
 	registries: Record<string, RegistryConfig>,
 	componentNames: string[],
+	registryIndexes?: Map<string, RegistryIndex>,
 ): Promise<ResolvedDependencies> {
 	const resolved = new Map<string, ResolvedComponent>()
 	const visiting = new Set<string>()
-	const npmDeps = new Set<string>()
-	const npmDevDeps = new Set<string>()
+	const npmDeps = new Map<string, ResolvedNpmDependency>()
+	const npmDevDeps = new Map<string, ResolvedNpmDependency>()
 	let opencode: NormalizedOpencodeConfig = {}
 
 	async function resolve(
@@ -136,15 +196,20 @@ export async function resolveDependencies(
 		})
 		visiting.delete(qualifiedName)
 
-		// Collect npm dependencies
+		// Get catalog from registry index if available
+		const catalog = registryIndexes?.get(componentNamespace)?.catalog
+
+		// Collect npm dependencies (resolved through catalog if needed)
 		if (component.npmDependencies) {
 			for (const dep of component.npmDependencies) {
-				npmDeps.add(dep)
+				const resolved = resolveDependencySpec(dep, catalog, qualifiedName)
+				npmDeps.set(resolved.name, resolved)
 			}
 		}
 		if (component.npmDevDependencies) {
 			for (const dep of component.npmDevDependencies) {
-				npmDevDeps.add(dep)
+				const resolved = resolveDependencySpec(dep, catalog, qualifiedName)
+				npmDevDeps.set(resolved.name, resolved)
 			}
 		}
 
@@ -172,8 +237,8 @@ export async function resolveDependencies(
 	return {
 		components,
 		installOrder,
-		npmDependencies: Array.from(npmDeps),
-		npmDevDependencies: Array.from(npmDevDeps),
+		npmDependencies: Array.from(npmDeps.values()),
+		npmDevDependencies: Array.from(npmDevDeps.values()),
 		opencode,
 	}
 }

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -678,6 +678,15 @@ export const registrySchema = z
 			})
 			.optional(),
 
+		/**
+		 * Shared dependency versions for the registry.
+		 * Components can reference these using the "catalog:key" syntax in npmDependencies/npmDevDependencies.
+		 * Example: { "zod": "^4.3.5", "openai": "^4.73.0" }
+		 *
+		 * @see https://pnpm.io/catalogs for the pattern this follows
+		 */
+		catalog: z.record(z.string(), z.string()).optional(),
+
 		/** Components in this registry */
 		components: z.array(componentManifestSchema),
 	})
@@ -750,6 +759,15 @@ export const registryIndexSchema = z.object({
 			message: "OCX version must be valid semver",
 		})
 		.optional(),
+
+	/**
+	 * Shared dependency versions for the registry.
+	 * Components can reference these using the "catalog:key" syntax in npmDependencies/npmDevDependencies.
+	 * Example: { "zod": "^4.3.5", "openai": "^4.73.0" }
+	 *
+	 * @see https://pnpm.io/catalogs for the pattern this follows
+	 */
+	catalog: z.record(z.string(), z.string()).optional(),
 
 	/** Component summaries for search */
 	components: z.array(

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -11,6 +11,7 @@ export type ErrorCode =
 	| "CONFLICT"
 	| "PERMISSION_ERROR"
 	| "INTEGRITY_ERROR"
+	| "DEPENDENCY_CONFLICT"
 
 export const EXIT_CODES = {
 	SUCCESS: 0,
@@ -19,6 +20,7 @@ export const EXIT_CODES = {
 	NETWORK: 69,
 	CONFIG: 78,
 	INTEGRITY: 1, // Exit code for integrity failures
+	DEPENDENCY_CONFLICT: 1, // Exit code for dependency conflicts
 } as const
 
 export class OCXError extends Error {
@@ -77,5 +79,36 @@ export class IntegrityError extends OCXError {
 			`Use 'ocx update ${component}' to intentionally update this component.`
 		super(message, "INTEGRITY_ERROR", EXIT_CODES.INTEGRITY)
 		this.name = "IntegrityError"
+	}
+}
+
+export interface DependencyConflict {
+	packageName: string
+	versions: Array<{ version: string; source: string }>
+}
+
+function buildConflictMessage(conflicts: DependencyConflict[]): string {
+	const lines = ["Dependency version conflicts detected:", ""]
+
+	for (const conflict of conflicts) {
+		lines.push(`  ${conflict.packageName}`)
+		for (const v of conflict.versions) {
+			lines.push(`    → ${v.version} (from ${v.source})`)
+		}
+		lines.push("")
+	}
+
+	lines.push("Resolution options:")
+	lines.push("  1. Align versions in your component registries")
+	lines.push("  2. Override in .opencode/package.json manually")
+	lines.push("  3. Use --yes to force install (last declared wins)")
+
+	return lines.join("\n")
+}
+
+export class DependencyConflictError extends OCXError {
+	constructor(public conflicts: DependencyConflict[]) {
+		super(buildConflictMessage(conflicts), "DEPENDENCY_CONFLICT", EXIT_CODES.DEPENDENCY_CONFLICT)
+		this.name = "DependencyConflictError"
 	}
 }

--- a/packages/cli/tests/catalog-resolver.test.ts
+++ b/packages/cli/tests/catalog-resolver.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for catalog resolution in the dependency resolver
+ * Tests catalog:X expansion, pinned deps, bare deps, and scoped packages
+ */
+
+import { describe, expect, it } from "bun:test"
+import { resolveDependencySpec } from "../src/registry/resolver"
+import { ValidationError } from "../src/utils/errors"
+
+describe("catalog resolution", () => {
+	describe("resolveDependencySpec", () => {
+		it("should expand catalog:X to version from catalog", () => {
+			const catalog = { zod: "^4.3.5", lodash: "^4.17.21" }
+			const result = resolveDependencySpec("catalog:zod", catalog, "kdco/test-component")
+
+			expect(result.kind).toBe("catalog")
+			expect(result.name).toBe("zod")
+			if (result.kind === "catalog") {
+				expect(result.version).toBe("^4.3.5")
+				expect(result.catalogKey).toBe("zod")
+			}
+			expect(result.declaredBy).toBe("kdco/test-component")
+		})
+
+		it("should throw ValidationError for missing catalog entry", () => {
+			const catalog = { zod: "^4.3.5" }
+
+			expect(() => {
+				resolveDependencySpec("catalog:nonexistent", catalog, "kdco/test-component")
+			}).toThrow(ValidationError)
+
+			expect(() => {
+				resolveDependencySpec("catalog:nonexistent", catalog, "kdco/test-component")
+			}).toThrow('Catalog reference "catalog:nonexistent" not found in registry')
+		})
+
+		it("should throw ValidationError when catalog is undefined", () => {
+			expect(() => {
+				resolveDependencySpec("catalog:zod", undefined, "kdco/test-component")
+			}).toThrow(ValidationError)
+		})
+
+		it("should throw ValidationError when catalog is empty", () => {
+			expect(() => {
+				resolveDependencySpec("catalog:zod", {}, "kdco/test-component")
+			}).toThrow(ValidationError)
+
+			expect(() => {
+				resolveDependencySpec("catalog:zod", {}, "kdco/test-component")
+			}).toThrow("Available catalog entries:")
+		})
+
+		it("should parse pinned dependency (name@version)", () => {
+			const result = resolveDependencySpec("lodash@4.17.21", undefined, "kdco/test-component")
+
+			expect(result.kind).toBe("pinned")
+			expect(result.name).toBe("lodash")
+			if (result.kind === "pinned") {
+				expect(result.version).toBe("4.17.21")
+			}
+			expect(result.declaredBy).toBe("kdco/test-component")
+		})
+
+		it("should parse pinned dependency with semver range", () => {
+			const result = resolveDependencySpec("zod@^4.3.5", undefined, "kdco/test-component")
+
+			expect(result.kind).toBe("pinned")
+			expect(result.name).toBe("zod")
+			if (result.kind === "pinned") {
+				expect(result.version).toBe("^4.3.5")
+			}
+		})
+
+		it("should parse bare dependency (name only)", () => {
+			const result = resolveDependencySpec("lodash", undefined, "kdco/test-component")
+
+			expect(result.kind).toBe("bare")
+			expect(result.name).toBe("lodash")
+			expect(result.declaredBy).toBe("kdco/test-component")
+		})
+
+		it("should handle scoped packages with pinned version", () => {
+			const result = resolveDependencySpec("@types/node@20.0.0", undefined, "kdco/test-component")
+
+			expect(result.kind).toBe("pinned")
+			expect(result.name).toBe("@types/node")
+			if (result.kind === "pinned") {
+				expect(result.version).toBe("20.0.0")
+			}
+		})
+
+		it("should handle scoped packages with semver range", () => {
+			const result = resolveDependencySpec(
+				"@ai-sdk/openai@^1.0.0",
+				undefined,
+				"kdco/test-component",
+			)
+
+			expect(result.kind).toBe("pinned")
+			expect(result.name).toBe("@ai-sdk/openai")
+			if (result.kind === "pinned") {
+				expect(result.version).toBe("^1.0.0")
+			}
+		})
+
+		it("should handle bare scoped packages", () => {
+			const result = resolveDependencySpec("@types/node", undefined, "kdco/test-component")
+
+			expect(result.kind).toBe("bare")
+			expect(result.name).toBe("@types/node")
+		})
+
+		it("should list available catalog entries in error message", () => {
+			const catalog = { zod: "^4.3.5", lodash: "^4.17.21", react: "^19.0.0" }
+
+			try {
+				resolveDependencySpec("catalog:nonexistent", catalog, "kdco/test-component")
+				expect.unreachable("Should have thrown")
+			} catch (error) {
+				expect(error).toBeInstanceOf(ValidationError)
+				const message = (error as ValidationError).message
+				expect(message).toContain("zod")
+				expect(message).toContain("lodash")
+				expect(message).toContain("react")
+			}
+		})
+
+		it("should throw ValidationError for empty version in pinned dep", () => {
+			expect(() => {
+				resolveDependencySpec("lodash@", undefined, "kdco/test")
+			}).toThrow("Invalid dependency specifier")
+		})
+
+		it("should throw ValidationError for empty version in scoped package", () => {
+			expect(() => {
+				resolveDependencySpec("@types/node@", undefined, "kdco/test")
+			}).toThrow("Invalid dependency specifier")
+		})
+	})
+})

--- a/packages/cli/tests/conflict-detector.test.ts
+++ b/packages/cli/tests/conflict-detector.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for dependency version conflict detection
+ * Tests component conflicts, package.json conflicts, and sorting behavior
+ */
+
+import { describe, expect, it } from "bun:test"
+import { detectVersionConflicts } from "../src/commands/add"
+import type { ResolvedNpmDependency } from "../src/registry/resolver"
+
+describe("detectVersionConflicts", () => {
+	it("should return empty array when no conflicts", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^4.3.5", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "zod", version: "^4.3.5", declaredBy: "kdco/component-b" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toEqual([])
+	})
+
+	it("should detect conflict between resolved components", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^3.0.0", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "zod", version: "^4.0.0", declaredBy: "kdco/component-b" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toHaveLength(1)
+		expect(conflicts[0].packageName).toBe("zod")
+		expect(conflicts[0].versions).toHaveLength(2)
+		expect(conflicts[0].versions.map((v) => v.version)).toContain("^3.0.0")
+		expect(conflicts[0].versions.map((v) => v.version)).toContain("^4.0.0")
+	})
+
+	it("should detect conflict with existing package.json", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^4.0.0", declaredBy: "kdco/component-a" },
+		]
+		const existing = { zod: "^3.0.0" }
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toHaveLength(1)
+		expect(conflicts[0].packageName).toBe("zod")
+		expect(conflicts[0].versions).toHaveLength(2)
+		expect(conflicts[0].versions.some((v) => v.source.includes("package.json"))).toBe(true)
+	})
+
+	it("should not flag bare deps as conflicts", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "bare", name: "zod", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "zod", version: "^4.0.0", declaredBy: "kdco/component-b" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		// bare deps don't have versions, so they shouldn't cause conflicts
+		expect(conflicts).toEqual([])
+	})
+
+	it("should not flag bare deps against existing package.json", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "bare", name: "zod", declaredBy: "kdco/component-a" },
+		]
+		const existing = { zod: "^4.0.0" }
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toEqual([])
+	})
+
+	it("should sort component conflicts before package.json conflicts", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			// Component-only conflict (lodash)
+			{ kind: "pinned", name: "lodash", version: "^4.17.0", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "lodash", version: "^4.18.0", declaredBy: "kdco/component-b" },
+			// Package.json conflict (react)
+			{ kind: "pinned", name: "react", version: "^19.0.0", declaredBy: "kdco/component-c" },
+		]
+		const existing = { react: "^18.0.0" }
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toHaveLength(2)
+		// Component-only conflict should come first
+		expect(conflicts[0].packageName).toBe("lodash")
+		// Package.json conflict should come second
+		expect(conflicts[1].packageName).toBe("react")
+	})
+
+	it("should handle catalog deps the same as pinned deps", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{
+				kind: "catalog",
+				name: "zod",
+				version: "^4.3.5",
+				catalogKey: "zod",
+				declaredBy: "kdco/component-a",
+			},
+			{ kind: "pinned", name: "zod", version: "^3.0.0", declaredBy: "kdco/component-b" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toHaveLength(1)
+		expect(conflicts[0].packageName).toBe("zod")
+		// Should include catalog source in the version info
+		expect(conflicts[0].versions.some((v) => v.source.includes("catalog:"))).toBe(true)
+	})
+
+	it("should handle multiple packages with conflicts", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^3.0.0", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "zod", version: "^4.0.0", declaredBy: "kdco/component-b" },
+			{ kind: "pinned", name: "react", version: "^18.0.0", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "react", version: "^19.0.0", declaredBy: "kdco/component-c" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toHaveLength(2)
+		const packageNames = conflicts.map((c) => c.packageName).sort()
+		expect(packageNames).toEqual(["react", "zod"])
+	})
+
+	it("should not flag identical versions as conflicts", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^4.3.5", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "zod", version: "^4.3.5", declaredBy: "kdco/component-b" },
+		]
+		const existing = { zod: "^4.3.5" }
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toEqual([])
+	})
+
+	it("should handle empty resolved array", () => {
+		const resolved: ResolvedNpmDependency[] = []
+		const existing = { zod: "^4.3.5" }
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toEqual([])
+	})
+
+	it("should handle empty existing deps", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^4.3.5", declaredBy: "kdco/component-a" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toEqual([])
+	})
+
+	it("should sort conflicts alphabetically within each group", () => {
+		const resolved: ResolvedNpmDependency[] = [
+			{ kind: "pinned", name: "zod", version: "^3.0.0", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "zod", version: "^4.0.0", declaredBy: "kdco/component-b" },
+			{ kind: "pinned", name: "axios", version: "^1.0.0", declaredBy: "kdco/component-a" },
+			{ kind: "pinned", name: "axios", version: "^2.0.0", declaredBy: "kdco/component-b" },
+		]
+		const existing = {}
+
+		const conflicts = detectVersionConflicts(resolved, existing)
+
+		expect(conflicts).toHaveLength(2)
+		// Component conflicts should be sorted alphabetically
+		expect(conflicts[0].packageName).toBe("axios")
+		expect(conflicts[1].packageName).toBe("zod")
+	})
+})


### PR DESCRIPTION
## Summary

Implements issue #19: Flexible npm dependency versioning with registry-level catalogs.

### Features

- **Registry Catalogs**: Define shared dependency versions at registry level
- **Catalog References**: Components use `catalog:name` syntax in npmDependencies
- **Conflict Detection**: Atomic detection of version conflicts between components and existing package.json
- **Fail Fast**: Clear error messages with resolution options (use `--yes` to override)
- **Enhanced Dry-Run**: Shows catalog resolution details

### Implementation Details

- Follows pnpm/Bun catalog pattern
- Discriminated union types for type safety (Law 2)
- Structured error messages with resolution options (Law 4)
- Parallel registry fetching for performance
- 290 tests passing (25 new)

### Files Changed

- `packages/cli/src/utils/errors.ts` - DependencyConflictError
- `packages/cli/src/schemas/registry.ts` - catalog field
- `packages/cli/src/registry/resolver.ts` - catalog resolution
- `packages/cli/src/commands/add.ts` - conflict detection, parallel fetch
- `docs/` - Updated documentation
- `packages/cli/tests/` - New test files

Closes #19