### PR TITLE
fix(cli): remove interactive confirmation from profile rm

### DIFF
--- a/packages/cli/src/commands/ghost/profile/remove.ts
+++ b/packages/cli/src/commands/ghost/profile/remove.ts
@@ -2,13 +2,12 @@
  * Ghost Profile Remove Command
  *
  * Delete a ghost profile.
- * Requires confirmation unless --force is provided.
+ * Uses Cargo-style CLI pattern: no interactive confirmation.
  */
 
 import type { Command } from "commander"
 import { ProfileManager } from "../../../profile/manager.js"
-import { isTTY } from "../../../utils/env.js"
-import { ProfileNotFoundError, ValidationError } from "../../../utils/errors.js"
+import { ProfileNotFoundError } from "../../../utils/errors.js"
 import { handleError, logger } from "../../../utils/index.js"
 
 interface ProfileRemoveOptions {
@@ -20,7 +19,7 @@ export function registerProfileRemoveCommand(parent: Command): void {
 		.command("remove <name>")
 		.alias("rm")
 		.description("Delete a ghost profile")
-		.option("-f, --force", "Skip confirmation and allow deleting current profile")
+		.option("-f, --force", "Allow deleting current profile")
 		.action(async (name: string, options: ProfileRemoveOptions) => {
 			try {
 				await runProfileRemove(name, options)
@@ -38,31 +37,6 @@ async function runProfileRemove(name: string, options: ProfileRemoveOptions): Pr
 		throw new ProfileNotFoundError(name)
 	}
 
-	// Confirmation required unless --force
-	if (!options.force) {
-		// Fail fast in non-interactive environments
-		if (!isTTY) {
-			throw new ValidationError(
-				"Cannot confirm deletion in non-interactive mode. Use --force to delete without confirmation.",
-			)
-		}
-
-		const confirmed = confirmDeletion(name)
-		if (!confirmed) {
-			console.log("Aborted.")
-			return
-		}
-	}
-
-	await manager.remove(name, options.force)
+	await manager.remove(name, options.force ?? false)
 	logger.success(`Deleted profile "${name}"`)
-}
-
-/**
- * Prompt user to confirm profile deletion.
- * Uses Bun's global prompt() which is a Web API.
- */
-function confirmDeletion(name: string): boolean {
-	const answer = prompt(`Delete profile "${name}"? This cannot be undone. [y/N]`)
-	return answer?.toLowerCase() === "y"
 }

--- a/packages/cli/tests/ghost/profile-commands.test.ts
+++ b/packages/cli/tests/ghost/profile-commands.test.ts
@@ -261,6 +261,17 @@ describe("ocx ghost profile remove", () => {
 		await cleanupTempDir(testDir)
 	})
 
+	it("should delete a non-current profile without --force", async () => {
+		await runGhostCLI(["profile", "add", "toremove"], { XDG_CONFIG_HOME: testDir })
+
+		const { exitCode, output } = await runGhostCLI(["profile", "remove", "toremove"], {
+			XDG_CONFIG_HOME: testDir,
+		})
+
+		expect(exitCode).toBe(0)
+		expect(output).toContain("Deleted profile")
+	})
+
 	it("should delete a profile with --force", async () => {
 		await runGhostCLI(["profile", "add", "toremove"], { XDG_CONFIG_HOME: testDir })
 
@@ -304,13 +315,13 @@ describe("ocx ghost profile remove", () => {
 	it("should fail deleting current profile without --force", async () => {
 		await runGhostCLI(["profile", "add", "backup"], { XDG_CONFIG_HOME: testDir })
 
-		// Without --force, should require interactive confirmation (which fails in test)
+		// Without --force, should fail with "cannot delete current profile" error
 		const { exitCode, output } = await runGhostCLI(["profile", "remove", "default"], {
 			XDG_CONFIG_HOME: testDir,
 		})
 
 		expect(exitCode).not.toBe(0)
-		expect(output).toContain("non-interactive")
+		expect(output).toContain("Cannot delete current profile")
 	})
 
 	it("should allow deleting current profile with --force", async () => {


### PR DESCRIPTION
## Summary

Removes the interactive confirmation prompt from `profile rm` to be consistent with other OCX commands (`add`, `init`) that follow the Cargo-style pattern.

## Changes

- **`packages/cli/src/commands/ghost/profile/remove.ts`**: Removed interactive confirmation logic (69 → 43 lines)
- **`packages/cli/tests/ghost/profile-commands.test.ts`**: Updated test expectations and added happy path test

## Behavior After

```bash
# Non-current profile: just works
$ ocx g p rm backup
Deleted profile "backup".

# Current profile: fail-fast, clear guidance
$ ocx g p rm Hi
Error: Cannot delete current profile "Hi". Use --force to override.

# With --force: works, auto-switches
$ ocx g p rm Hi --force
Deleted profile "Hi". Switched to "default".
```

## Testing

- ✅ All 30 tests pass
- ✅ Lint and types pass

Closes #38