### PR TITLE
feat(ghost): add option to disable terminal window renaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,7 @@ Ghost mode enables working in repositories without modifying them:
    - If user's `include` pattern matches a file, project version is used (not profile overlay)
 4. Sets `GIT_WORK_TREE` and `GIT_DIR` so Git sees real project
 5. Sets terminal/tmux window name to `ghost[profile]:repo/branch` for session identification
+   - Disabled with `--no-rename` flag or `renameWindow: false` in ghost config
 6. Spawns OpenCode from temp dir with `OCX_PROFILE` env var set
 7. Cleans up temp dir on exit
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Or use the `OCX_PROFILE` environment variable to temporarily switch profiles.
 | `ocx ghost search <query>` | `ocx g search` | Search ghost registries |
 | `ocx ghost opencode [args...]` | `ocx g opencode` | Run OpenCode with ghost config |
 
-> **How it works:** Ghost mode uses symlink isolation to run OpenCode without seeing the project's config. Ghost mode also sets informative terminal names (`ghost[profile]:repo/branch`) for easy session identification. Git, LSPs, and file editing all work normally—changes go directly to the real project files.
+> **How it works:** Ghost mode uses symlink isolation to run OpenCode without seeing the project's config. Ghost mode also sets informative terminal names (`ghost[profile]:repo/branch`) for easy session identification (configurable via `renameWindow` or `--no-rename`). Git, LSPs, and file editing all work normally—changes go directly to the real project files.
 
 #### Config Location
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -872,12 +872,13 @@ Ghost mode uses multi-profile configuration with configuration files stored at `
 
 #### Schema
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `registries` | `object` | Registry name → URL mapping |
-| `componentPath` | `string` | Where to install components (default: `.opencode`) |
-| `include` | `string[]` | Glob patterns for project files to include in ghost sessions |
-| `exclude` | `string[]` | Glob patterns to filter out from include results |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `registries` | `object` | `{}` | Registry name → URL mapping |
+| `componentPath` | `string` | `.opencode` | Where to install components |
+| `include` | `string[]` | `[]` | Glob patterns for project files to include in ghost sessions |
+| `exclude` | `string[]` | `[]` | Glob patterns to filter out from include results |
+| `renameWindow` | `boolean` | `true` | Set terminal/tmux window name when launching OpenCode |
 
 #### Include/Exclude Patterns
 
@@ -1302,6 +1303,7 @@ ocx ghost opencode [args...] [options]
 | Option | Description |
 |--------|-------------|
 | `--profile, -p <name>` | Specify ghost profile to use |
+| `--no-rename` | Disable terminal/tmux window renaming |
 
 #### Examples
 
@@ -1323,7 +1325,7 @@ ocx ghost opencode -- /path/to/file.md
 3. **Apply Filters**: Uses `include`/`exclude` patterns from ghost config
 4. **Symlink Farm**: Creates temporary directory with symlinks to filtered files
 5. **Git Integration**: Sets `GIT_WORK_TREE` and `GIT_DIR` to see real project
-6. **Terminal Naming**: Sets terminal/tmux window name to `ghost[profile]:repo/branch` for session identification
+6. **Terminal Naming**: Sets terminal/tmux window name to `ghost[profile]:repo/branch` for session identification (unless disabled via `--no-rename` flag or `renameWindow: false` in config)
 7. **Spawn OpenCode**: Runs OpenCode from temp directory with ghost config via env vars
 8. **Cleanup**: Removes temp directory on exit
 

--- a/docs/schemas/ghost.schema.json
+++ b/docs/schemas/ghost.schema.json
@@ -49,6 +49,11 @@
 			"type": "array",
 			"items": { "type": "string", "minLength": 1 },
 			"description": "Glob patterns to exclude from include results"
+		},
+		"renameWindow": {
+			"type": "boolean",
+			"default": true,
+			"description": "Set terminal/tmux window name when launching OpenCode. Set to false to preserve your existing terminal title."
 		}
 	}
 }

--- a/packages/cli/src/commands/ghost/opencode.ts
+++ b/packages/cli/src/commands/ghost/opencode.ts
@@ -35,6 +35,7 @@ interface GhostOpenCodeOptions {
 	json?: boolean
 	quiet?: boolean
 	profile?: string
+	rename?: boolean
 }
 
 export function registerGhostOpenCodeCommand(parent: Command): void {
@@ -42,6 +43,7 @@ export function registerGhostOpenCodeCommand(parent: Command): void {
 		.command("opencode")
 		.description("Launch OpenCode with ghost mode configuration")
 		.option("-p, --profile <name>", "Use specific profile")
+		.option("--no-rename", "Disable terminal/tmux window renaming")
 		.addOption(sharedOptions.json())
 		.addOption(sharedOptions.quiet())
 		.allowUnknownOption()
@@ -109,6 +111,10 @@ async function runGhostOpenCode(args: string[], options: GhostOpenCodeOptions): 
 	// This includes opencode.jsonc, AGENTS.md, .opencode/, etc.
 	await injectProfileOverlay(tempDir, profileDir, ghostConfig.include)
 
+	// Determine if terminal should be renamed (Law 1: compute once, use in closure)
+	// Precedence: CLI flag > config > default(true)
+	const shouldRename = options.rename !== false && ghostConfig.renameWindow !== false
+
 	// Track cleanup state to prevent double cleanup
 	let cleanupDone = false
 	const performCleanup = async () => {
@@ -121,10 +127,10 @@ async function runGhostOpenCode(args: string[], options: GhostOpenCodeOptions): 
 	// This ensures SIGKILL resilience: if rename succeeds but rm is interrupted,
 	// the -removing directory will be cleaned up on next startup
 	const exitHandler = () => {
-		// REQUIREMENT: Restore terminal title FIRST in exit handler.
-		// Must run before any other cleanup while stdout is still valid.
-		// This pops the saved title from the terminal's title stack.
-		restoreTerminalTitle()
+		// Only restore if we renamed (Law 3: Atomic Predictability)
+		if (shouldRename) {
+			restoreTerminalTitle()
+		}
 
 		if (!cleanupDone && tempDir) {
 			try {
@@ -148,14 +154,12 @@ async function runGhostOpenCode(args: string[], options: GhostOpenCodeOptions): 
 	process.on("SIGINT", sigintHandler)
 	process.on("SIGTERM", sigtermHandler)
 
-	// REQUIREMENT: Save terminal title BEFORE setting ghost title.
-	// This pushes the current title to the terminal's title stack so it can be
-	// restored when OpenCode exits. Must happen before setTerminalName().
-	saveTerminalTitle()
-
-	// Set terminal name for easy identification in tmux/terminal tabs
-	const gitInfo = await getGitInfo(cwd)
-	setTerminalName(formatTerminalName(cwd, profileName, gitInfo))
+	// Set terminal name only if enabled (Law 1: Early Exit pattern)
+	if (shouldRename) {
+		saveTerminalTitle()
+		const gitInfo = await getGitInfo(cwd)
+		setTerminalName(formatTerminalName(cwd, profileName, gitInfo))
+	}
 
 	// Spawn opencode from the temp directory with config passed via environment
 	// Only set GIT_DIR/GIT_WORK_TREE when actually in a git repository

--- a/packages/cli/src/profile/manager.ts
+++ b/packages/cli/src/profile/manager.ts
@@ -38,6 +38,7 @@ const DEFAULT_GHOST_CONFIG: GhostConfig = {
 		"opencode.json",
 	],
 	include: [],
+	renameWindow: true,
 }
 
 /**

--- a/packages/cli/src/schemas/ghost.ts
+++ b/packages/cli/src/schemas/ghost.ts
@@ -102,6 +102,15 @@ export const ghostConfigSchema = z.object({
 		.array(globPatternSchema)
 		.default([])
 		.describe("Glob patterns to re-include from excluded set (for power users)"),
+
+	/**
+	 * Whether to set terminal/tmux window name when launching OpenCode.
+	 * Set to false to preserve your existing terminal title.
+	 */
+	renameWindow: z
+		.boolean()
+		.default(true)
+		.describe("Set terminal/tmux window name when launching OpenCode"),
 })
 
 export type GhostConfig = z.infer<typeof ghostConfigSchema>

--- a/packages/cli/src/utils/terminal-title.ts
+++ b/packages/cli/src/utils/terminal-title.ts
@@ -3,6 +3,9 @@
  *
  * Provides cross-environment terminal identification by setting both
  * the terminal title (via ANSI OSC escape) and tmux window name (if applicable).
+ *
+ * Terminal renaming can be disabled via ghost config (`renameWindow: false`)
+ * or the `--no-rename` CLI flag for `ocx ghost opencode`.
  */
 
 import path from "node:path"

--- a/packages/cli/tests/ghost/ghost-opencode.test.ts
+++ b/packages/cli/tests/ghost/ghost-opencode.test.ts
@@ -200,6 +200,26 @@ describe("ocx ghost opencode", () => {
 		expect(output).toContain("--message")
 		expect(output).toContain("hello world")
 	})
+
+	it("should accept --no-rename flag without error", async () => {
+		// Write ghost.jsonc (required for ghost mode)
+		const configPath = getGhostConfigPath()
+		await Bun.write(configPath, '{"registries": {}}')
+
+		// Write empty opencode.jsonc
+		const opencodeConfigPath = getGhostOpencodeConfigPath()
+		await Bun.write(opencodeConfigPath, "{}")
+
+		const { stderr } = await runGhostCLI(["opencode", "--no-rename"], {
+			XDG_CONFIG_HOME: testDir,
+			PATH: `${mockBinDir}:${process.env.PATH}`,
+		})
+
+		// The command should parse the flag without error
+		// It will still run because we have a mock opencode binary, but the flag should be recognized
+		expect(stderr).not.toContain("unknown option")
+		expect(stderr).not.toContain("--no-rename")
+	})
 })
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds configuration option and CLI flag to disable tmux/terminal window renaming in ghost mode.

## Changes

### New Config Option
```jsonc
// ~/.config/opencode/profiles/default/ghost.jsonc
{
  "renameWindow": false
}
```

### New CLI Flag
```bash
ocx ghost opencode --no-rename
```

### Precedence
CLI flag > config > default(true)

## Files Changed
- `packages/cli/src/schemas/ghost.ts` - Added `renameWindow` field
- `packages/cli/src/profile/manager.ts` - Added to DEFAULT_GHOST_CONFIG
- `packages/cli/src/commands/ghost/opencode.ts` - Added flag + conditional logic
- `docs/schemas/ghost.schema.json` - JSON schema for IDE support
- `docs/CLI.md` - Updated documentation
- `AGENTS.md` - Updated ghost opencode docs
- `README.md` - Updated Ghost Mode section
- `packages/cli/src/utils/terminal-title.ts` - Updated JSDoc
- `packages/cli/tests/ghost/ghost-opencode.test.ts` - Added test

## Testing
- ✅ `bun run check` passes
- ✅ `bun test` passes (674 tests)
- ✅ Manual verification complete

Closes #43