### PR TITLE
feat(cli): add ocx ghost update command

### DIFF
--- a/packages/cli/src/commands/ghost/index.ts
+++ b/packages/cli/src/commands/ghost/index.ts
@@ -16,6 +16,7 @@ import { registerGhostOpenCodeCommand } from "./opencode.js"
 import { registerGhostProfileCommand } from "./profile/index.js"
 import { registerGhostRegistryCommand } from "./registry.js"
 import { registerGhostSearchCommand } from "./search.js"
+import { registerGhostUpdateCommand } from "./update.js"
 
 export function registerGhostCommand(program: Command): void {
 	const ghost = program
@@ -31,4 +32,5 @@ export function registerGhostCommand(program: Command): void {
 	registerGhostSearchCommand(ghost)
 	registerGhostOpenCodeCommand(ghost)
 	registerGhostProfileCommand(ghost)
+	registerGhostUpdateCommand(ghost)
 }

--- a/packages/cli/src/commands/ghost/update.ts
+++ b/packages/cli/src/commands/ghost/update.ts
@@ -1,0 +1,32 @@
+/**
+ * OCX Ghost Mode - update command
+ *
+ * Update installed components using ghost mode configuration.
+ * Thin wrapper around the core update logic using GhostConfigProvider.
+ */
+
+import type { Command } from "commander"
+import { GhostConfigProvider } from "../../config/provider.js"
+import { handleError } from "../../utils/index.js"
+import { runUpdateCore, type UpdateOptions } from "../update.js"
+
+export function registerGhostUpdateCommand(parent: Command): void {
+	parent
+		.command("update [components...]")
+		.description("Update installed components (use @version suffix to pin)")
+		.option("--all", "Update all installed components")
+		.option("--registry <name>", "Update all components from a specific registry")
+		.option("--dry-run", "Preview changes without applying")
+		.option("--cwd <path>", "Working directory", process.cwd())
+		.option("-q, --quiet", "Suppress output")
+		.option("-v, --verbose", "Verbose output")
+		.option("--json", "Output as JSON")
+		.action(async (components: string[], options: UpdateOptions) => {
+			try {
+				const provider = await GhostConfigProvider.create(options.cwd ?? process.cwd())
+				await runUpdateCore(components, options, provider)
+			} catch (error) {
+				handleError(error, { json: options.json })
+			}
+		})
+}


### PR DESCRIPTION
## Summary
Adds `ocx ghost update` command to mirror existing `ocx update` functionality for ghost mode profiles.

## Changes
- Refactored `update.ts` to export `runUpdateCore` with ConfigProvider parameter
- Created `ghost/update.ts` thin wrapper using GhostConfigProvider
- Registered command in `ghost/index.ts`
- Fixed import ordering to satisfy Biome linting

## Testing
- `bun check:types` passes
- `bun check:biome` passes