### PR TITLE
feat(cli): add --global flag for init and add commands

### DIFF
--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -1,0 +1,41 @@
+import { stat } from "node:fs/promises"
+import { homedir } from "node:os"
+import { isAbsolute, join } from "node:path"
+
+/**
+ * Returns the global OpenCode config directory path.
+ * Uses XDG_CONFIG_HOME if set and absolute, otherwise ~/.config/opencode
+ */
+export function getGlobalConfigPath(): string {
+	const xdg = process.env.XDG_CONFIG_HOME
+	const base = xdg && isAbsolute(xdg) ? xdg : join(homedir(), ".config")
+	return join(base, "opencode")
+}
+
+/**
+ * Checks if the global OpenCode config directory exists.
+ * Returns true if ~/.config/opencode/ (or XDG equivalent) is a directory.
+ */
+export async function globalDirectoryExists(): Promise<boolean> {
+	try {
+		const info = await stat(getGlobalConfigPath())
+		return info.isDirectory()
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Resolves a component target path for global or local mode.
+ * Registry targets start with ".opencode/" which should be stripped for global installs.
+ *
+ * @param target - The target path from registry (e.g., ".opencode/plugin/foo.ts")
+ * @param isGlobal - Whether installing globally
+ * @returns Resolved path (e.g., "plugin/foo.ts" for global, unchanged for local)
+ */
+export function resolveTargetPath(target: string, isGlobal: boolean): string {
+	if (isGlobal && target.startsWith(".opencode/")) {
+		return target.slice(".opencode/".length)
+	}
+	return target
+}

--- a/packages/cli/src/utils/shared-options.ts
+++ b/packages/cli/src/utils/shared-options.ts
@@ -7,6 +7,7 @@
  */
 
 import { Option } from "commander"
+import { ValidationError } from "./errors"
 
 // =============================================================================
 // OPTION FACTORIES
@@ -31,6 +32,9 @@ export const sharedOptions = {
 
 	/** Verbose output */
 	verbose: () => new Option("-v, --verbose", "Verbose output"),
+
+	/** Install to global OpenCode config */
+	global: new Option("-g, --global", "Install to global OpenCode config (~/.config/opencode)"),
 }
 
 // =============================================================================
@@ -96,4 +100,24 @@ export function addVerboseOption<T extends { addOption: (opt: Option) => T }>(cm
  */
 export function addOutputOptions<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
 	return cmd.addOption(sharedOptions.json()).addOption(sharedOptions.quiet())
+}
+
+/**
+ * Adds the --global option to a command.
+ */
+export function addGlobalOption<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
+	return cmd.addOption(sharedOptions.global)
+}
+
+/**
+ * Validates that --global and --profile are not used together.
+ * @throws ValidationError if both flags are set
+ */
+export function assertNoGlobalProfileConflict(
+	global: boolean | undefined,
+	profile: string | undefined,
+): void {
+	if (global && profile) {
+		throw new ValidationError("Using --global with --profile is not supported.")
+	}
 }

--- a/packages/cli/tests/global.test.ts
+++ b/packages/cli/tests/global.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, rmSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { getGlobalConfigPath, globalDirectoryExists, resolveTargetPath } from "../src/utils/paths"
+
+describe("global utilities", () => {
+	describe("getGlobalConfigPath", () => {
+		const originalXdg = process.env.XDG_CONFIG_HOME
+
+		afterEach(() => {
+			if (originalXdg) {
+				process.env.XDG_CONFIG_HOME = originalXdg
+			} else {
+				delete process.env.XDG_CONFIG_HOME
+			}
+		})
+
+		it("returns ~/.config/opencode by default", () => {
+			delete process.env.XDG_CONFIG_HOME
+			const result = getGlobalConfigPath()
+			expect(result).toBe(join(homedir(), ".config", "opencode"))
+		})
+
+		it("uses XDG_CONFIG_HOME when set and absolute", () => {
+			process.env.XDG_CONFIG_HOME = "/custom/config"
+			const result = getGlobalConfigPath()
+			expect(result).toBe("/custom/config/opencode")
+		})
+
+		it("ignores XDG_CONFIG_HOME when relative", () => {
+			process.env.XDG_CONFIG_HOME = "relative/path"
+			const result = getGlobalConfigPath()
+			expect(result).toBe(join(homedir(), ".config", "opencode"))
+		})
+	})
+
+	describe("globalDirectoryExists", () => {
+		const testDir = join(homedir(), ".config", "opencode-test-temp")
+
+		beforeEach(() => {
+			if (existsSync(testDir)) {
+				rmSync(testDir, { recursive: true })
+			}
+		})
+
+		afterEach(() => {
+			if (existsSync(testDir)) {
+				rmSync(testDir, { recursive: true })
+			}
+		})
+
+		it("returns false when directory does not exist", async () => {
+			// Point to non-existent dir via XDG
+			const originalXdg = process.env.XDG_CONFIG_HOME
+			process.env.XDG_CONFIG_HOME = join(homedir(), ".config", "nonexistent-test-dir")
+
+			const result = await globalDirectoryExists()
+			expect(result).toBe(false)
+
+			if (originalXdg) {
+				process.env.XDG_CONFIG_HOME = originalXdg
+			} else {
+				delete process.env.XDG_CONFIG_HOME
+			}
+		})
+	})
+
+	describe("resolveTargetPath", () => {
+		it("strips .opencode/ prefix when global", () => {
+			const result = resolveTargetPath(".opencode/plugin/foo.ts", true)
+			expect(result).toBe("plugin/foo.ts")
+		})
+
+		it("preserves path when local", () => {
+			const result = resolveTargetPath(".opencode/plugin/foo.ts", false)
+			expect(result).toBe(".opencode/plugin/foo.ts")
+		})
+
+		it("preserves path without .opencode/ prefix even when global", () => {
+			const result = resolveTargetPath("other/path.ts", true)
+			expect(result).toBe("other/path.ts")
+		})
+
+		it("handles nested paths correctly", () => {
+			const result = resolveTargetPath(".opencode/components/ui/button.tsx", true)
+			expect(result).toBe("components/ui/button.tsx")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Adds `--global` / `-g` flag to `ocx init` and `ocx add` commands for installing components to OpenCode's global config directory.

Closes #64

## Problem

When running `ocx add` in `~/.config/opencode`, OCX creates `.opencode/plugin/` but OpenCode expects global plugins at `~/.config/opencode/plugin/` directly.

## Solution

- Add `-g, --global` flag to `init` and `add` commands
- When global, install to `~/.config/opencode/` without the `.opencode/` prefix
- Require OpenCode to have been run first (global directory must exist)

## Usage

```bash
# Initialize global OCX config
ocx init --global

# Add component globally  
ocx add @kdco/mcp-tools --global

# Result: ~/.config/opencode/plugin/mcp-tools.ts
```

## Changes

| File | Change |
|------|--------|
| `src/utils/paths.ts` | **NEW** - Global path utilities |
| `src/config/provider.ts` | Added `GlobalConfigProvider` |
| `src/utils/shared-options.ts` | Added `addGlobalOption()`, validation |
| `src/commands/init.ts` | Added `--global` flag |
| `src/commands/add.ts` | Added `--global` flag, target path rewriting |
| `tests/global.test.ts` | **NEW** - Tests for global utilities |

## Testing

- ✅ Lint passes
- ✅ Type check passes  
- ✅ New tests pass (8/8)