### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OCX
 
 [![CI](https://github.com/kdcokenny/ocx/actions/workflows/ci.yml/badge.svg)](https://github.com/kdcokenny/ocx/actions/workflows/ci.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kdcokenny/ocx)
 
 The missing package manager for OpenCode extensions.
 


### PR DESCRIPTION
Adds [DeepWiki](https://deepwiki.com/kdcokenny/ocx) badge to the README for AI-powered documentation access.

Benefits:
- Provides quick access to AI-generated documentation
- Enables automatic weekly documentation refresh on DeepWiki