### PR TITLE
docs: add version and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OCX
 
 [![CI](https://github.com/kdcokenny/ocx/actions/workflows/ci.yml/badge.svg)](https://github.com/kdcokenny/ocx/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/ocx.svg)](https://www.npmjs.com/package/ocx)
+[![License](https://img.shields.io/github/license/kdcokenny/ocx.svg)](https://github.com/kdcokenny/ocx/blob/main/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kdcokenny/ocx)
 
 The missing package manager for OpenCode extensions.


### PR DESCRIPTION
Adds balanced badge set to README following best practices from popular OSS projects.

**Badges added:**
- npm version badge
- License badge

**Existing badges kept:**
- CI status
- DeepWiki documentation

Reference: Follows patterns from Vite, TypeScript, and similar CLI tools.