### PR TITLE
feat(ci): add Codecov Test Analytics support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
           fail_ci_if_error: false
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/cli/junit.xml
+          report_type: test_results


### PR DESCRIPTION
## Summary
Adds Codecov Test Analytics to the CI workflow for test run insights.

## Changes
- Updated `bun test` command to output JUnit XML via `--reporter=junit --reporter-outfile=junit.xml`
- Added new step using `codecov/test-results-action@v1` to upload test results
- Uses `if: ${{ !cancelled() }}` to ensure results upload even on test failures

## Benefits
- View failed test reports in PR comments
- Access test analytics dashboard for run times and flaky test detection
- Helps decrease deployment failure risk