### PR TITLE
fix(cli): Make init --global create documented file structure

### DIFF
--- a/.opencode/bun.lock
+++ b/.opencode/bun.lock
@@ -4,14 +4,14 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.1.31",
+        "@opencode-ai/plugin": "1.1.32",
       },
     },
   },
   "packages": {
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.31", "", { "dependencies": { "@opencode-ai/sdk": "1.1.31", "zod": "4.1.8" } }, "sha512-9ArzJjHIKzmph3ySM5+hm5yNy9K6Xlkq4mtgDKdj0KIAHJyIShbxeWopzzpfZ2mvbCg1W0B7UuJ9KR13MxIaUQ=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.32", "", { "dependencies": { "@opencode-ai/sdk": "1.1.32", "zod": "4.1.8" } }, "sha512-zrq6qMA5zLx2YPc38Q40CKL0RKBTW6I0EeHRcl51ryOSHeeipL/AadxRr8gv6dzRaVBse74YECF8K2qe/iGu3g=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.31", "", {}, "sha512-u273CSLeNEqmE3suulCrXDLzJzW1dfFeRheUjnfwSvmhSpf6UqM4em4MpV2CBB2WoyC0VvWg8rNwSkvDzPmEdw=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.32", "", {}, "sha512-BsEzZvXUYwtZNgJBiwbkhmov1LBW0Cwxn3WWjGw9xK1HJGK9NdZqfYqYbdQG9aen3j7gshqxcU5jTSZTzOSn1A=="],
 
     "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
   }

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.1.31"
+    "@opencode-ai/plugin": "1.1.32"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,7 +412,7 @@ ocx profile add work
 ocx profile config work  # Edit settings
 
 # Install profile from registry (requires global registry config)
-ocx registry add kdco https://registry.kdco.dev --global
+ocx registry add https://registry.kdco.dev --name kdco --global
 ocx profile add minimal --from kdco/minimal
 
 # Force overwrite existing profile

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ ocx profile add work        # Create a work profile
 ocx profile config work     # Edit your profile settings
 
 # Install pre-configured profile from registry (optional)
-ocx registry add kdco https://registry.kdco.dev --global
+ocx registry add https://registry.kdco.dev --name kdco --global
 ocx profile add minimal --from kdco/minimal
 
 # Use in any repo (without touching it)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1042,7 +1042,7 @@ ocx profile add work
 ocx profile add client-x --from work
 
 # Install from registry (requires global registry config)
-ocx registry add kdco https://registry.kdco.dev --global
+ocx registry add https://registry.kdco.dev --name kdco --global
 ocx profile add minimal --from kdco/minimal
 
 # Force overwrite existing profile

--- a/packages/cli/src/commands/config/edit.ts
+++ b/packages/cli/src/commands/config/edit.ts
@@ -45,8 +45,7 @@ async function runConfigEdit(options: ConfigEditOptions): Promise<void> {
 		configPath = getGlobalConfig()
 		if (!existsSync(configPath)) {
 			throw new ConfigError(
-				`Global config not found at ${configPath}.\n` +
-					"Run 'opencode' once to initialize, then retry.",
+				`Global config not found at ${configPath}.\nRun 'ocx init --global' first.`,
 			)
 		}
 	} else {

--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -129,7 +129,7 @@ async function requireGlobalRegistry(
 		throw new ConfigError(
 			`Registry "${namespace}" is not configured globally.\n\n` +
 				`Profile installation requires global registry configuration.\n` +
-				`Run: ocx registry add ${namespace} <url> --global`,
+				`Run: ocx registry add <url> --name ${namespace} --global`,
 		)
 	}
 
@@ -139,7 +139,7 @@ async function requireGlobalRegistry(
 		throw new ConfigError(
 			`Registry "${namespace}" is not configured globally.\n\n` +
 				`Profile installation requires global registry configuration.\n` +
-				`Run: ocx registry add ${namespace} <url> --global`,
+				`Run: ocx registry add <url> --name ${namespace} --global`,
 		)
 	}
 

--- a/packages/cli/src/commands/registry.ts
+++ b/packages/cli/src/commands/registry.ts
@@ -147,7 +147,7 @@ export function registerRegistryCommand(program: Command): void {
 					configPath = found.path
 					const cfg = await readOcxConfig(configDir)
 					if (!cfg) {
-						logger.error("Global config not found. Run 'opencode' once to initialize.")
+						logger.error("Global config not found. Run 'ocx init --global' first.")
 						process.exit(1)
 					}
 					return cfg
@@ -217,7 +217,7 @@ export function registerRegistryCommand(program: Command): void {
 					configPath = found.path
 					const cfg = await readOcxConfig(configDir)
 					if (!cfg) {
-						logger.error("Global config not found. Run 'opencode' once to initialize.")
+						logger.error("Global config not found. Run 'ocx init --global' first.")
 						process.exit(1)
 					}
 					return cfg
@@ -277,7 +277,7 @@ export function registerRegistryCommand(program: Command): void {
 					configDir = getGlobalConfigPath()
 					const cfg = await readOcxConfig(configDir)
 					if (!cfg) {
-						logger.warn("Global config not found. Run 'opencode' once to initialize.")
+						logger.warn("Global config not found. Run 'ocx init --global' first.")
 						return null
 					}
 					return cfg

--- a/packages/cli/src/config/provider.ts
+++ b/packages/cli/src/config/provider.ts
@@ -114,9 +114,7 @@ export class GlobalConfigProvider implements ConfigProvider {
 
 		// Guard: Global directory must exist (Law 1: Early Exit)
 		if (!(await globalDirectoryExists())) {
-			throw new ConfigError(
-				"Global config not found. Run 'opencode' once to initialize, then retry.",
-			)
+			throw new ConfigError("Global config not found. Run 'ocx init --global' first.")
 		}
 
 		// Load ocx.jsonc if it exists (returns null if not found)

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -123,7 +123,7 @@ export class InvalidProfileNameError extends OCXError {
 export class ProfilesNotInitializedError extends OCXError {
 	constructor() {
 		super(
-			"Profiles not initialized. Run 'ocx profile add default' first.",
+			"Profiles not initialized. Run 'ocx init --global' first.",
 			"NOT_FOUND",
 			EXIT_CODES.NOT_FOUND,
 		)

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from "bun:test"
-import { existsSync } from "node:fs"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, realpathSync } from "node:fs"
 import { mkdir, readFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { cleanupTempDir, createTempDir, parseJsonc, runCLI } from "./helpers"
@@ -144,5 +144,228 @@ describe("init --registry", () => {
 
 		// Negative: template placeholder should be gone
 		expect(content).not.toContain('"name": "my-registry"')
+	})
+})
+
+describe("init --global", () => {
+	let testDir: string
+
+	beforeEach(async () => {
+		testDir = await createTempDir("init-global")
+	})
+
+	afterEach(async () => {
+		await cleanupTempDir(testDir)
+	})
+
+	// 4.1: Test creates all 4 files with correct CONTENT
+	it("should create all 4 files with correct content", async () => {
+		const { exitCode } = await runCLI(["init", "--global"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		expect(exitCode).toBe(0)
+
+		const configDir = join(testDir, "opencode")
+
+		// Check global config exists and has correct content
+		const globalConfigPath = join(configDir, "ocx.jsonc")
+		expect(existsSync(globalConfigPath)).toBe(true)
+		const globalConfig = parseJsonc(await Bun.file(globalConfigPath).text()) as {
+			$schema?: string
+			registries?: Record<string, unknown>
+		}
+		expect(globalConfig.$schema).toBe("https://ocx.kdco.dev/schemas/ocx.json")
+		expect(globalConfig.registries).toEqual({})
+
+		// Check profile ocx.jsonc
+		const profileOcxPath = join(configDir, "profiles/default/ocx.jsonc")
+		expect(existsSync(profileOcxPath)).toBe(true)
+		const profileOcx = parseJsonc(await Bun.file(profileOcxPath).text()) as {
+			$schema?: string
+			registries?: Record<string, unknown>
+		}
+		expect(profileOcx.$schema).toBeDefined()
+		expect(profileOcx.registries).toEqual({})
+
+		// Check profile opencode.jsonc
+		const profileOpencodePath = join(configDir, "profiles/default/opencode.jsonc")
+		expect(existsSync(profileOpencodePath)).toBe(true)
+		const profileOpencode = parseJsonc(await Bun.file(profileOpencodePath).text())
+		expect(profileOpencode).toEqual({})
+
+		// Check profile AGENTS.md
+		const agentsPath = join(configDir, "profiles/default/AGENTS.md")
+		expect(existsSync(agentsPath)).toBe(true)
+		const agentsContent = await Bun.file(agentsPath).text()
+		expect(agentsContent).toContain("# Profile Instructions")
+	})
+
+	// 4.2: Test idempotency with SENTINEL content
+	it("should not overwrite existing files (sentinel test)", async () => {
+		const configDir = join(testDir, "opencode")
+		const profileDir = join(configDir, "profiles/default")
+
+		// Pre-create directories
+		await mkdir(profileDir, { recursive: true })
+
+		// Pre-create files with SENTINEL content
+		const globalConfigPath = join(configDir, "ocx.jsonc")
+		const sentinelGlobal = {
+			$schema: "SENTINEL",
+			registries: { SENTINEL: { url: "https://sentinel.test" } },
+		}
+		await Bun.write(globalConfigPath, JSON.stringify(sentinelGlobal, null, 2))
+
+		const profileOcxPath = join(profileDir, "ocx.jsonc")
+		const sentinelProfileOcx = { SENTINEL_PROFILE: true }
+		await Bun.write(profileOcxPath, JSON.stringify(sentinelProfileOcx, null, 2))
+
+		const profileOpencodePath = join(profileDir, "opencode.jsonc")
+		const sentinelOpencode = { SENTINEL_OPENCODE: true }
+		await Bun.write(profileOpencodePath, JSON.stringify(sentinelOpencode, null, 2))
+
+		const agentsPath = join(profileDir, "AGENTS.md")
+		const sentinelAgents = "SENTINEL_DO_NOT_REMOVE\n"
+		await Bun.write(agentsPath, sentinelAgents)
+
+		// Run init --global TWICE
+		await runCLI(["init", "--global"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		await runCLI(["init", "--global"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+
+		// Verify all files are BYTE-FOR-BYTE unchanged
+		expect(await Bun.file(globalConfigPath).text()).toBe(JSON.stringify(sentinelGlobal, null, 2))
+		expect(await Bun.file(profileOcxPath).text()).toBe(JSON.stringify(sentinelProfileOcx, null, 2))
+		expect(await Bun.file(profileOpencodePath).text()).toBe(
+			JSON.stringify(sentinelOpencode, null, 2),
+		)
+		expect(await Bun.file(agentsPath).text()).toBe(sentinelAgents)
+	})
+
+	// 4.3: Test partial convergence
+	it("should create only missing files (partial convergence)", async () => {
+		const configDir = join(testDir, "opencode")
+		const profileDir = join(configDir, "profiles/default")
+
+		// Pre-create ONLY global config with sentinel
+		await mkdir(configDir, { recursive: true })
+		const globalConfigPath = join(configDir, "ocx.jsonc")
+		const sentinelGlobal = { SENTINEL: "global" }
+		await Bun.write(globalConfigPath, JSON.stringify(sentinelGlobal, null, 2))
+
+		// Run init --global
+		const { exitCode } = await runCLI(["init", "--global"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		expect(exitCode).toBe(0)
+
+		// Verify global config unchanged (sentinel preserved)
+		const globalContent = await Bun.file(globalConfigPath).text()
+		expect(globalContent).toBe(JSON.stringify(sentinelGlobal, null, 2))
+
+		// Verify profile files were created
+		expect(existsSync(join(profileDir, "ocx.jsonc"))).toBe(true)
+		expect(existsSync(join(profileDir, "opencode.jsonc"))).toBe(true)
+		expect(existsSync(join(profileDir, "AGENTS.md"))).toBe(true)
+	})
+
+	// 4.4: Test --json output with filesystem cross-check
+	it("should output correct JSON that matches filesystem", async () => {
+		const { exitCode, output } = await runCLI(["init", "--global", "--json"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		expect(exitCode).toBe(0)
+
+		const json = JSON.parse(output) as {
+			success: boolean
+			files: {
+				globalConfig: string
+				profileOcx: string
+				profileOpencode: string
+				profileAgents: string
+			}
+			created: string[]
+			existed: string[]
+		}
+		expect(json.success).toBe(true)
+
+		// Verify files object has all 4 paths
+		expect(json.files.globalConfig).toBeDefined()
+		expect(json.files.profileOcx).toBeDefined()
+		expect(json.files.profileOpencode).toBeDefined()
+		expect(json.files.profileAgents).toBeDefined()
+
+		// Cross-check: all files should exist
+		expect(existsSync(json.files.globalConfig)).toBe(true)
+		expect(existsSync(json.files.profileOcx)).toBe(true)
+		expect(existsSync(json.files.profileOpencode)).toBe(true)
+		expect(existsSync(json.files.profileAgents)).toBe(true)
+
+		// All should be created (fresh run)
+		expect(json.created).toContain("globalConfig")
+		expect(json.created).toContain("profileOcx")
+		expect(json.created).toContain("profileOpencode")
+		expect(json.created).toContain("profileAgents")
+		expect(json.existed).toEqual([])
+
+		// Run again - should all be "existed"
+		const { output: output2 } = await runCLI(["init", "--global", "--json"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		const json2 = JSON.parse(output2) as { created: string[]; existed: string[] }
+		expect(json2.created).toEqual([])
+		expect(json2.existed).toContain("globalConfig")
+		expect(json2.existed).toContain("profileOcx")
+		expect(json2.existed).toContain("profileOpencode")
+		expect(json2.existed).toContain("profileAgents")
+	})
+
+	// 4.5: Test --quiet produces no stdout
+	it("should produce no stdout with --quiet", async () => {
+		const { exitCode, output } = await runCLI(["init", "--global", "--quiet"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		expect(exitCode).toBe(0)
+		expect(output.trim()).toBe("")
+
+		// Files should still be created
+		const configDir = join(testDir, "opencode")
+		expect(existsSync(join(configDir, "ocx.jsonc"))).toBe(true)
+	})
+
+	// 4.6: Test --quiet --json precedence (--json still outputs)
+	it("should output JSON even with --quiet flag", async () => {
+		const { exitCode, output } = await runCLI(["init", "--global", "--quiet", "--json"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		expect(exitCode).toBe(0)
+
+		// JSON output should still be present (--json wins for structured output)
+		const json = JSON.parse(output) as { success: boolean }
+		expect(json.success).toBe(true)
+
+		// Files should still be created
+		const configDir = join(testDir, "opencode")
+		expect(existsSync(join(configDir, "ocx.jsonc"))).toBe(true)
+	})
+
+	// 4.7: Test path isolation
+	it("should only create files under XDG_CONFIG_HOME", async () => {
+		const { exitCode } = await runCLI(["init", "--global"], testDir, {
+			env: { XDG_CONFIG_HOME: testDir },
+		})
+		expect(exitCode).toBe(0)
+
+		// All created paths should be under testDir
+		const configDir = join(testDir, "opencode")
+		const globalConfigPath = join(configDir, "ocx.jsonc")
+		const profileOcxPath = join(configDir, "profiles/default/ocx.jsonc")
+
+		// Verify paths start with XDG_CONFIG_HOME
+		expect(realpathSync(globalConfigPath).startsWith(realpathSync(testDir))).toBe(true)
+		expect(realpathSync(profileOcxPath).startsWith(realpathSync(testDir))).toBe(true)
 	})
 })

--- a/packages/cli/tests/profile/manager.test.ts
+++ b/packages/cli/tests/profile/manager.test.ts
@@ -284,13 +284,14 @@ describe("ProfileManager.get", () => {
 		expect(profile.hasAgents).toBe(true)
 	})
 
-	it("should detect hasAgents correctly when AGENTS.md does not exist", async () => {
+	it("should detect hasAgents correctly when AGENTS.md exists (created by default)", async () => {
 		const manager = ProfileManager.create()
 		await manager.initialize()
 
 		const profile = await manager.get("default")
 
-		expect(profile.hasAgents).toBe(false)
+		// AGENTS.md is now created by default in new profiles
+		expect(profile.hasAgents).toBe(true)
 	})
 
 	it("should load opencode.jsonc when present", async () => {


### PR DESCRIPTION
## Summary

This PR fixes `ocx init --global` to create the complete documented file structure and fixes all related error messages and documentation.

## Problem

`ocx init --global` was only creating `~/.config/opencode/profiles/default/ocx.jsonc` but the documentation claims it creates:
- `~/.config/opencode/ocx.jsonc` (global base config)
- `~/.config/opencode/profiles/default/ocx.jsonc`
- `~/.config/opencode/profiles/default/opencode.jsonc`
- `~/.config/opencode/profiles/default/AGENTS.md`

Additionally:
- Error messages referenced wrong commands ("Run 'opencode'" or "--profile default")
- Documentation had wrong `registry add` syntax

## Solution

### Phase 1: File Creation
- `init --global` now creates all 4 documented files
- All files use create-if-missing semantics (never overwrite existing)
- Command is fully idempotent (safe to re-run)
- JSON output includes `created`/`existed` arrays for each file

### Phase 2: Error Messages
- Fixed `ProfilesNotInitializedError` to say "Run 'ocx init --global'"
- Fixed 6 other error messages in registry.ts, config/edit.ts, config/provider.ts

### Phase 3: Documentation
- Fixed `registry add` syntax in README.md, CLI.md, AGENTS.md, profile/add.ts
- Correct syntax: `ocx registry add <url> --name <name> --global`

### Phase 4: Tests
Added 7 bulletproof tests:
- Creates all 4 files with correct content
- Sentinel test verifies existing files are NOT overwritten
- Partial convergence (creates only missing files)
- JSON output cross-checked with filesystem
- `--quiet` and `--json` flag behavior
- Path isolation verification

## Testing

```bash
bun test packages/cli/tests/init.test.ts
```

All 569 tests pass.

## Files Changed (14)

- `packages/cli/src/commands/init.ts` - Main implementation
- `packages/cli/src/profile/manager.ts` - Create-if-missing helpers
- `packages/cli/src/utils/errors.ts` - Error message fix
- `packages/cli/src/commands/registry.ts` - Error message fixes
- `packages/cli/src/commands/config/edit.ts` - Error message fix
- `packages/cli/src/config/provider.ts` - Error message fix
- `packages/cli/src/commands/profile/add.ts` - Registry syntax fix
- `packages/cli/tests/init.test.ts` - 7 new tests
- `README.md`, `docs/CLI.md`, `AGENTS.md` - Documentation fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ocx init --global to create the full documented config structure and align error messages and docs. Safe to re-run with create-if-missing; --json now reports created/existed files.

- **Bug Fixes**
  - Creates all four files: ~/.config/opencode/ocx.jsonc, profiles/default/ocx.jsonc, profiles/default/opencode.jsonc, profiles/default/AGENTS.md.
  - Never overwrites existing files; command is idempotent.
  - --json returns a files map and created/existed arrays.
  - Error messages now say: Run 'ocx init --global'; help/docs use: ocx registry add <url> --name <name> --global.
  - Tests cover creation, non-overwrite, partial convergence, --json/--quiet, and path isolation.

- **Dependencies**
  - Bump @opencode-ai/plugin to 1.1.32.

<sup>Written for commit e33e1dfb3b657ff93d8dc4815f5ab86ef84d1001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

