### PR TITLE
feat(registry): Add --profile flag to registry commands

### DIFF
--- a/packages/cli/src/utils/shared-options.ts
+++ b/packages/cli/src/utils/shared-options.ts
@@ -7,6 +7,7 @@
  */
 
 import { Option } from "commander"
+import { InvalidProfileNameError } from "./errors"
 
 // =============================================================================
 // OPTION FACTORIES
@@ -25,6 +26,9 @@ export const sharedOptions = {
 
 	/** Output as JSON */
 	json: () => new Option("--json", "Output as JSON"),
+
+	/** Target a specific profile's config */
+	profile: () => new Option("-p, --profile <name>", "Target a specific profile's config"),
 
 	/** Skip confirmation prompts */
 	force: () => new Option("-f, --force", "Skip confirmation prompts"),
@@ -106,4 +110,40 @@ export function addOutputOptions<T extends { addOption: (opt: Option) => T }>(cm
  */
 export function addGlobalOption<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
 	return cmd.addOption(sharedOptions.global)
+}
+
+/**
+ * Adds the --profile option to a command.
+ */
+export function addProfileOption<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
+	return cmd.addOption(sharedOptions.profile())
+}
+
+// =============================================================================
+// VALIDATION HELPERS
+// =============================================================================
+
+/**
+ * Validates a profile name and throws if invalid.
+ * Profile names must:
+ * - Be non-empty
+ * - Be 32 characters or less
+ * - Start with a letter
+ * - Contain only letters, numbers, dots, underscores, or hyphens
+ *
+ * @throws InvalidProfileNameError if validation fails
+ */
+export function validateProfileName(name: string): void {
+	if (!name || name.length === 0) {
+		throw new InvalidProfileNameError(name, "cannot be empty")
+	}
+	if (name.length > 32) {
+		throw new InvalidProfileNameError(name, "must be 32 characters or less")
+	}
+	if (!/^[a-zA-Z][a-zA-Z0-9._-]*$/.test(name)) {
+		throw new InvalidProfileNameError(
+			name,
+			"must start with a letter and contain only alphanumeric characters, dots, underscores, or hyphens",
+		)
+	}
 }


### PR DESCRIPTION
## Summary

Allows users to manage registries for a specific profile without activating it:
- `ocx registry add <url> --profile <name>`
- `ocx registry list --profile <name>`
- `ocx registry remove <name> --profile <name>`

The `--profile` flag is mutually exclusive with `--global` and `--cwd`.

## Changes

- Add profile option factory and `validateProfileName()` to `shared-options.ts`
- Add `resolveRegistryTarget()` helper for unified scope resolution
- Add 10 tests covering all `--profile` behavior and edge cases
- Profile name validation matches canonical `profileNameSchema`

## Verification

- ✅ Lint: PASS
- ✅ Types: PASS
- ✅ Tests: PASS (all 10 new tests passing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a --profile flag to ocx registry add/list/remove so users can manage a specific profile’s registries without activating it. Improves scope resolution and validation for clearer, safer behavior.

- **New Features**
  - Support --profile for add/list/remove: ocx registry add <url> --profile <name>
  - --profile is mutually exclusive with --global and --cwd; OCX_PROFILE env var is ignored unless the flag is used
  - Validates profile names and errors when a profile or its ocx.jsonc is missing
  - Unified scope handling via resolveRegistryTarget for consistent behavior and messages
  - Added 10 tests covering profile flows and edge cases

<sup>Written for commit a31d9750c11dd888034851f7d5c3e01f0fdd323b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

