### PR TITLE
fix(cli): Fix --registry template path for release version

### DIFF
--- a/packages/cli/tests/init-dist.test.ts
+++ b/packages/cli/tests/init-dist.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Smoke tests against the built dist/index.js artifact.
+ *
+ * These tests verify the CLI works when bundled (catches packaging bugs).
+ *
+ * Prerequisites: Run `bun run build` first.
+ * To run: OCX_DIST_TESTS=1 bun test init-dist.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
+import { join } from "node:path"
+
+const DIST_CLI = join(import.meta.dir, "../dist/index.js")
+const SKIP = process.env.OCX_DIST_TESTS !== "1"
+
+;(SKIP ? describe.skip : describe)("init --registry (dist)", () => {
+	const testDir = join(import.meta.dir, "fixtures/tmp-dist-test")
+
+	beforeAll(() => {
+		if (!existsSync(DIST_CLI)) {
+			throw new Error(
+				"dist/index.js not found. Run 'bun run build' before running dist tests.\n" +
+					"Then run: OCX_DIST_TESTS=1 bun test init-dist.test.ts",
+			)
+		}
+		// Clean up any previous test artifacts
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true })
+		}
+		mkdirSync(testDir, { recursive: true })
+	})
+
+	afterAll(() => {
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true })
+		}
+	})
+
+	it("should scaffold registry from release template (no --canary)", async () => {
+		const registryDir = join(testDir, "release-registry")
+
+		const result = Bun.spawnSync(
+			[
+				"bun",
+				"run",
+				DIST_CLI,
+				"init",
+				"--registry",
+				"release-registry",
+				"--namespace",
+				"test-ns",
+				"--author",
+				"test",
+			],
+			{ cwd: testDir },
+		)
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(join(registryDir, "registry.jsonc"))).toBe(true)
+		expect(existsSync(join(registryDir, "package.json"))).toBe(true)
+	}, 30000)
+
+	it("should scaffold registry with --canary flag", async () => {
+		const registryDir = join(testDir, "canary-registry")
+
+		const result = Bun.spawnSync(
+			[
+				"bun",
+				"run",
+				DIST_CLI,
+				"init",
+				"--registry",
+				"canary-registry",
+				"--namespace",
+				"test-ns",
+				"--author",
+				"test",
+				"--canary",
+			],
+			{ cwd: testDir },
+		)
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(join(registryDir, "registry.jsonc"))).toBe(true)
+	}, 30000)
+})

--- a/packages/cli/tests/init-integration.test.ts
+++ b/packages/cli/tests/init-integration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Integration tests for init --registry template fetching.
+ *
+ * These tests make real network requests to GitHub.
+ *
+ * To run: OCX_INTEGRATION_TESTS=1 bun test init-integration.test.ts
+ *
+ * For rate limit avoidance, set GITHUB_TOKEN in your environment.
+ * Tests have 30s timeout to handle slow network conditions.
+ */
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { cleanupTempDir, createTempDir, runCLI } from "./helpers"
+
+const SKIP = process.env.OCX_INTEGRATION_TESTS !== "1"
+
+;(SKIP ? describe.skip : describe)("init --registry integration", () => {
+	let testDir: string
+
+	afterEach(async () => {
+		if (testDir) await cleanupTempDir(testDir)
+	})
+
+	it("should scaffold registry from canary template (--canary)", async () => {
+		testDir = await createTempDir("integration-canary")
+
+		const result = await runCLI(
+			[
+				"init",
+				"--registry",
+				"test-registry",
+				"--namespace",
+				"test-ns",
+				"--author",
+				"test",
+				"--canary",
+			],
+			testDir,
+		)
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(join(testDir, "test-registry", "registry.jsonc"))).toBe(true)
+		expect(existsSync(join(testDir, "test-registry", "package.json"))).toBe(true)
+	}, 30000)
+
+	it("should fail gracefully in dev mode without --canary", async () => {
+		testDir = await createTempDir("integration-release")
+
+		// In dev/test mode, __VERSION__ is not defined, so this should fail
+		// with a helpful error message directing user to use --canary
+		const result = await runCLI(
+			["init", "--registry", "test-registry", "--namespace", "test-ns", "--author", "test"],
+			testDir,
+		)
+
+		expect(result.exitCode).not.toBe(0)
+		expect(result.output).toContain("--canary")
+	}, 30000)
+})


### PR DESCRIPTION
## Summary

Fixes `ocx init --registry` failing without `--canary` flag due to incorrect path resolution when running from bundled dist.

### Problem

The release template fetching was using `import.meta.url` to read `package.json`, which fails in bundled mode:
```
ERROR: ENOENT: no such file or directory, open '/Users/.../packages/package.json'
```

### Solution

- Replace file-based version reading with `__VERSION__` build-time constant
- Rename `getLatestVersion()` to `getReleaseTag()` with fail-fast behavior
- Extract `getTemplateUrl()` as pure function for deterministic testing
- Export `TEMPLATE_REPO` constant for DRY test assertions

### Philosophy Compliance

| Law | Status |
|-----|--------|
| Early Exit | ✅ PASS |
| Parse Don't Validate | ✅ PASS |
| Atomic Predictability | ✅ PASS |
| Fail Fast, Fail Loud | ✅ PASS |
| Intentional Naming | ✅ PASS |

### Dev Mode Behavior

In development mode (source), `getReleaseTag()` now throws with guidance to use `--canary` flag, preventing confusing 404 errors.

### Test Coverage

- Unit tests for `getReleaseTag()` and `getTemplateUrl()`
- Fixed sentinel test (was false positive)
- Gated integration tests (`OCX_INTEGRATION_TESTS=1`)
- Gated dist smoke tests (`OCX_DIST_TESTS=1`)

### Verification

- [x] `bun run build` - PASS
- [x] `bun run check` - PASS
- [x] Unit tests (18) - PASS
- [x] Integration tests (2) - PASS
- [x] Dist smoke tests (2) - PASS
- [x] Manual test - PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ocx init --registry failing without --canary when running from the bundled dist. Release template fetching now uses a build-time version and a deterministic GitHub URL; dev mode fails fast with guidance to use --canary.

- **Bug Fixes**
  - Use __VERSION__ build-time constant instead of reading package.json via import.meta.url.
  - Replace getLatestVersion() with getReleaseTag() and throw in dev mode without --canary.
  - Build template tarball URL with getTemplateUrl() to avoid path issues.

- **Refactors**
  - Export TEMPLATE_REPO and extract getTemplateUrl(version) for simpler, deterministic tests.
  - Add gated dist smoke and integration tests; fix sentinel test by asserting exitCode.

<sup>Written for commit 763a601a5e633fb01980f1e60a00f6154522c58c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

