### PR TITLE
feat: Support command arguments in profile bin field

### DIFF
--- a/packages/cli/src/schemas/ocx.ts
+++ b/packages/cli/src/schemas/ocx.ts
@@ -42,8 +42,13 @@ export const profileOcxConfigSchema = z.object({
 	/** Schema URL for IDE support */
 	$schema: z.string().optional(),
 
-	/** Path to OpenCode binary. Falls back to OPENCODE_BIN env var, then "opencode". */
-	bin: z.string().optional(),
+	/**
+	 * Path to OpenCode binary. Can be either:
+	 * - A string: "shuvcode" (simple executable path)
+	 * - An array: ["node", "serve", "--hostname", "0.0.0.0"] (executable with arguments)
+	 * Falls back to OPENCODE_BIN env var, then "opencode".
+	 */
+	bin: z.union([z.string(), z.array(z.string())]).optional(),
 
 	/**
 	 * Configured registries for OCX profiles


### PR DESCRIPTION
Enable profile ocx.jsonc bin field to accept either string or array format:
- String: \"shuvcode\" (simple executable)
- Array: [\"node\", \"serve\", \"--hostname\", \"0.0.0.0\"]

This fixes the issue where bin commands with arguments were treated as
single executable paths, causing 'Executable not found in $PATH' errors.

## Changes
- Update profileOcxConfigSchema to accept union type for bin field
- Modify resolveOpenCodeBinary to return string[] instead of string
- Update spawn command with spread operator for bin array
- Add comprehensive test cases for array format bin values
- Preserve backward compatibility with existing string bin values

Fixes: serveoss profile bin configuration with arguments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the profile ocx.jsonc bin field to be a string or an array, so commands with arguments spawn correctly. Fixes PATH errors when bin commands were treated as a single executable.

- **New Features**
  - bin supports string or string[] and still falls back to OPENCODE_BIN, then "opencode".
  - resolveOpenCodeBinary now returns string[]; Bun.spawn spreads [...bin, ...args]. Tests cover both formats.

<sup>Written for commit 5cbea042df6bb888c5f3a38efed829a4e32b2796. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

