### PR TITLE
CLIProxy plugin: add TODO for registry target limitation

### DIFF
--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -147,6 +147,7 @@ const PROFILE_RESERVED_TARGETS = new Set(["ocx.lock", ".opencode"])
 
 /**
  * Target path must be inside .opencode/ with valid subdirectory
+ * TODO: Consider allowing root-level .opencode/<file> targets for config files
  */
 export const targetPathSchema = z
 	.string()


### PR DESCRIPTION
## Summary

Adds a TODO comment near the registry target validation logic to track a future enhancement for CLIProxy plugin installation.

## Context

When we implement the ability to install the CLIProxy plugin config file to the registry target, we'll need to revisit the current validation that restricts registry targets to `"global"` only.

## Changes

- Added TODO comment documenting the registry target limitation
- No behavior changes in this PR
- Related to future CLIProxy plugin config file installation support

---

**Draft Status:** Keeping as draft until we're ready to implement the actual feature.