### PR TITLE
fix(cli): Run bun install after writing npm dependencies in ocx add

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -594,6 +594,24 @@ async function runRegistryAddCore(
 				npmSpin?.fail(`Failed to update ${packageJsonPath}`)
 				throw error
 			}
+
+			// Run bun install to actually install the dependencies
+			const packageDir = isFlattened ? cwd : join(cwd, ".opencode")
+			const installSpin2 = options.quiet
+				? null
+				: createSpinner({ text: "Installing npm dependencies..." })
+			installSpin2?.start()
+
+			try {
+				await runBunInstall(packageDir)
+				installSpin2?.succeed("Installed npm dependencies")
+			} catch (_error) {
+				installSpin2?.fail("Failed to install npm dependencies")
+				logger.warn(
+					`Could not run 'bun install' in ${packageDir}. ` +
+						"You may need to install dependencies manually.",
+				)
+			}
 		}
 
 		// Save lock file
@@ -883,6 +901,26 @@ async function updateOpencodeDevDependencies(
 	// Ensure manifest files are tracked by git (only for local mode)
 	if (!options.isFlattened) {
 		await ensureManifestFilesAreTracked(packageDir)
+	}
+}
+
+/**
+ * Run `bun install` in the given directory to install dependencies
+ * declared in package.json.
+ *
+ * @param cwd - Directory containing the package.json
+ * @throws Error if the install process exits with a non-zero code
+ */
+async function runBunInstall(cwd: string): Promise<void> {
+	const proc = Bun.spawn(["bun", "install"], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+	})
+	const exitCode = await proc.exited
+	if (exitCode !== 0) {
+		const stderr = await new Response(proc.stderr).text()
+		throw new Error(`bun install failed (exit ${exitCode}): ${stderr.trim()}`)
 	}
 }
 

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -225,6 +225,38 @@ describe("ocx add", () => {
 		expect(opencode.plugin).toContain("no-mcp-plugin")
 	})
 
+	it("should install npm dependencies after writing package.json", async () => {
+		testDir = await createTempDir("add-npm-install")
+
+		// Init and add registry
+		await runCLI(["init", "--force"], testDir)
+
+		const configPath = join(testDir, ".opencode", "ocx.jsonc")
+		const config = parseJsonc(await readFile(configPath, "utf-8"))
+		config.registries = {
+			kdco: { url: registry.url },
+		}
+		await writeFile(configPath, JSON.stringify(config, null, 2))
+
+		// Install component that has npmDependencies (test-plugin has lodash@^4.17.21)
+		const { exitCode, output } = await runCLI(["add", "kdco/test-plugin", "--force"], testDir)
+
+		if (exitCode !== 0) {
+			console.log(output)
+		}
+		expect(exitCode).toBe(0)
+
+		// Verify package.json was written
+		const packageJsonPath = join(testDir, ".opencode", "package.json")
+		expect(existsSync(packageJsonPath)).toBe(true)
+
+		// Verify node_modules was created (bun install ran)
+		expect(existsSync(join(testDir, ".opencode", "node_modules"))).toBe(true)
+
+		// Verify the dependency was actually installed
+		expect(existsSync(join(testDir, ".opencode", "node_modules", "lodash"))).toBe(true)
+	})
+
 	it("should fail if integrity check fails", async () => {
 		testDir = await createTempDir("add-integrity-fail")
 


### PR DESCRIPTION
## Problem

`ocx add` writes `npmDependencies` / `npmDevDependencies` to `package.json` but never
runs `bun install`. Plugins that import external packages (e.g. `jsonc-parser`, `zod`)
fail at runtime because the modules are not on disk.

This causes OpenCode to hang on startup with:
`Cannot find package 'jsonc-parser' from '~/.opencode/plugin/worktree.ts'`

Fixes #131

## Fix

Run `bun install` in the package directory immediately after writing `package.json`,
so dependencies are available before OpenCode tries to load the plugin.

A warning is logged if the install fails (e.g. no network), allowing the user to
install manually.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically run bun install after ocx add writes package.json so plugin npm dependencies are installed. Prevents startup hangs and “Cannot find package …” errors.

- **Bug Fixes**
  - Run bun install in the package directory (.opencode or cwd) right after writing npmDependencies/npmDevDependencies.
  - Show a spinner and log a warning if installation fails, allowing manual install.
  - Add runBunInstall helper using Bun.spawn with exit code checks.
  - Add tests to verify node_modules is created and dependencies (e.g., lodash) are installed.

<sup>Written for commit 6800faa65da378e5de48a059da2f746974df34e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

