### PR TITLE
fix(cli): Prevent Bun from auto-loading project .env files causing env pollution

### DIFF
--- a/packages/cli/scripts/build-binary.ts
+++ b/packages/cli/scripts/build-binary.ts
@@ -40,6 +40,7 @@ async function buildBinary(build: { name: string; target: Bun.Build.Target }) {
 		compile: {
 			target: build.target,
 			outfile: outfile,
+			autoloadDotenv: false,
 		},
 		minify: true,
 		define: {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env -S bun --no-env-file
 /**
  * OCX CLI - OpenCode Extensions
  *


### PR DESCRIPTION
## Summary
- Disable Bun's automatic `.env` file loading for both npm and compiled binary distributions
- Prevents project environment variables from leaking into spawned OpenCode processes
- Ensures OCX remains an isolated CLI tool that does not consume local project configurations
Closes #125

## Problem
OCX should maintain strict environment isolation from the CWD. Currently, Bun's default behavior auto-loads `.env` files from the CWD into `process.env` before execution.
When OCX launches OpenCode via `Bun.spawn()`, this polluted `process.env` is inherited by the sub-process. This breaks **any Provider configured via environment variables** (e.g., OpenAI, Anthropic). 
For instance, a project-level `OPENAI_BASE_URL` will override OpenCode's internal configurations, leading to endpoint mismatches or OAuth failures.
**Basically, OCX shouldn't be picking up a project's local `.env` mess just because it's running there.**

## Solution
We must explicitly disable Bun's auto-loading behavior to ensure environment isolation.
Two changes to cover both distribution methods:
1. **Compiled binary** (`scripts/build-binary.ts`): Added [`autoloadDotenv: false`](https://bun.com/docs/runtime/environment-variables#configuring-bun-build-compile) to
   `Bun.build()` compile options — baked into the binary at build time.
2. **npm install** (`src/index.ts`): Changed shebang from `#!/usr/bin/env bun` to 
   `#!/usr/bin/env -S bun --no-env-file` — prevents `.env` loading when invoked via shell.

## Changes
- `packages/cli/scripts/build-binary.ts` — Add `autoloadDotenv: false` to compile options
- `packages/cli/src/index.ts` — Update shebang to include `--no-env-file`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Bun’s automatic .env loading for the OCX CLI to stop project env variables from leaking into spawned OpenCode processes. Ensures environment isolation for both npm and compiled binary builds.

- **Bug Fixes**
  - Binary build: set Bun.build compile option autoloadDotenv to false.
  - npm CLI: use shebang with --no-env-file to prevent .env autoloading.

<sup>Written for commit dc39e8e503c43b35ad938d90d6fc9c8110d4d430. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

