### PR TITLE
fix(profile): Update registry URL in ocx.jsonc

### DIFF
--- a/workers/ocx-kit/files/profiles/ws/ocx.jsonc
+++ b/workers/ocx-kit/files/profiles/ws/ocx.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://ocx.kdco.dev/schemas/profile.json",
 	"registries": {
-		"kdco": { "url": "http://localhost:8787" }
+		"kdco": { "url": "https://registry.kdco.dev" }
 	},
 	"renameWindow": true,
 	"exclude": [


### PR DESCRIPTION
changed from localhost to actual kdco registry url

Fixes #146 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the `kdco` registry URL in the ws profile from `http://localhost:8787` to `https://registry.kdco.dev` so it uses the production registry. Fixes #146.

<sup>Written for commit b8128ebc8621683fe33c825a358a895c24151282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

