### PR TITLE
feat: Make worktree path configurable via worktreePath in worktree.jsonc

### DIFF
--- a/workers/kdco-registry/files/plugins/worktree.ts
+++ b/workers/kdco-registry/files/plugins/worktree.ts
@@ -119,6 +119,8 @@ const branchNameSchema = z
  * Config file: .opencode/worktree.jsonc
  */
 const worktreeConfigSchema = z.object({
+	/** Custom base path for worktree storage. Supports ~ for home directory. */
+	worktreePath: z.string().optional(),
 	sync: z
 		.object({
 			/** Files to copy from main worktree (relative paths only) */
@@ -440,8 +442,9 @@ async function createWorktree(
 	repoRoot: string,
 	branch: string,
 	baseBranch?: string,
+	basePath?: string,
 ): Promise<Result<string, string>> {
-	const worktreePath = await getWorktreePath(repoRoot, branch)
+	const worktreePath = await getWorktreePath(repoRoot, branch, basePath)
 
 	// Ensure parent directory exists
 	await mkdir(path.dirname(worktreePath), { recursive: true })
@@ -604,6 +607,16 @@ async function runHooks(cwd: string, commands: string[], log: Logger): Promise<v
 }
 
 /**
+ * Resolve a path that may contain a leading `~` to the user's home directory.
+ */
+function resolveHomePath(p: string): string {
+	if (p === "~" || p.startsWith("~/") || p.startsWith("~\\")) {
+		return path.join(os.homedir(), p.slice(1))
+	}
+	return p
+}
+
+/**
  * Load worktree-specific configuration from .opencode/worktree.jsonc
  * Auto-creates config file with helpful defaults if it doesn't exist.
  */
@@ -619,6 +632,10 @@ async function loadWorktreeConfig(directory: string, log: Logger): Promise<Workt
 
   // Worktree plugin configuration
   // Documentation: https://github.com/kdcokenny/ocx
+
+  // Custom base path for worktree storage (supports ~)
+  // Default: ~/.local/share/opencode/worktree
+  // "worktreePath": "~/my-worktrees",
 
   "sync": {
     // Files to copy from main worktree to new worktrees
@@ -658,7 +675,11 @@ async function loadWorktreeConfig(directory: string, log: Logger): Promise<Workt
 			log.error(`[worktree] Invalid worktree.jsonc syntax`)
 			return worktreeConfigSchema.parse({})
 		}
-		return worktreeConfigSchema.parse(parsed)
+		const config = worktreeConfigSchema.parse(parsed)
+		if (config.worktreePath) {
+			config.worktreePath = resolveHomePath(config.worktreePath)
+		}
+		return config
 	} catch (error) {
 		log.warn(`[worktree] Failed to load config: ${error}`)
 		return worktreeConfigSchema.parse({})
@@ -723,8 +744,16 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 						}
 					}
 
+					// Load config first so worktreePath is available for createWorktree
+					const worktreeConfig = await loadWorktreeConfig(directory, log)
+
 					// Create worktree
-					const result = await createWorktree(directory, args.branch, args.baseBranch)
+					const result = await createWorktree(
+						directory,
+						args.branch,
+						args.baseBranch,
+						worktreeConfig.worktreePath,
+					)
 					if (!result.ok) {
 						return `Failed to create worktree: ${result.error}`
 					}
@@ -732,7 +761,6 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 					const worktreePath = result.value
 
 					// Sync files from main worktree
-					const worktreeConfig = await loadWorktreeConfig(directory, log)
 					const mainWorktreePath = directory // The repo root is the main worktree
 
 					// Copy files

--- a/workers/kdco-registry/files/plugins/worktree/state.ts
+++ b/workers/kdco-registry/files/plugins/worktree/state.ts
@@ -68,18 +68,31 @@ const pendingDeleteSchema = z.object({
 // =============================================================================
 
 /**
+ * Get the default base directory for worktree storage.
+ * Location: ~/.local/share/opencode/worktree/
+ */
+function getWorktreeBaseDirectory(): string {
+	return path.join(os.homedir(), ".local", "share", "opencode", "worktree")
+}
+
+/**
  * Get the worktree path for a given project and branch.
  *
  * @param projectRoot - Absolute path to the project root
  * @param branch - Branch name for the worktree
+ * @param basePath - Optional custom base path (absolute). Defaults to ~/.local/share/opencode/worktree
  * @returns Absolute path to the worktree directory
  */
-export async function getWorktreePath(projectRoot: string, branch: string): Promise<string> {
+export async function getWorktreePath(
+	projectRoot: string,
+	branch: string,
+	basePath?: string,
+): Promise<string> {
 	if (!branch || typeof branch !== "string") {
 		throw new Error("branch is required")
 	}
 	const projectId = await getProjectId(projectRoot)
-	return path.join(os.homedir(), ".local", "share", "opencode", "worktree", projectId, branch)
+	return path.join(basePath ?? getWorktreeBaseDirectory(), projectId, branch)
 }
 
 /**

--- a/workers/kdco-registry/schemas/worktree.json
+++ b/workers/kdco-registry/schemas/worktree.json
@@ -9,6 +9,10 @@
 			"type": "string",
 			"description": "JSON Schema reference"
 		},
+		"worktreePath": {
+			"type": "string",
+			"description": "Custom base path for worktree storage. Supports ~ for home directory. Full path: <worktreePath>/<projectId>/<branch>. Default: ~/.local/share/opencode/worktree"
+		},
 		"sync": {
 			"type": "object",
 			"description": "File synchronization settings",

--- a/workers/kdco-registry/tests/worktree-state.test.ts
+++ b/workers/kdco-registry/tests/worktree-state.test.ts
@@ -162,6 +162,42 @@ describe("worktree-state", () => {
 			// Path should contain the project ID
 			expect(worktreePath).toContain(projectId)
 		})
+
+		it("should getWorktreePath use custom basePath when provided", async () => {
+			const projectRoot = path.join(testDir, "worktree-custom-path-test")
+			fs.mkdirSync(projectRoot, { recursive: true })
+
+			const customBase = path.join(testDir, "custom-worktrees")
+			const projectId = await getProjectId(projectRoot)
+			const worktreePath = await getWorktreePath(projectRoot, "my-branch", customBase)
+
+			expect(worktreePath).toBe(path.join(customBase, projectId, "my-branch"))
+			// Should NOT contain the default path
+			expect(worktreePath).not.toContain(".local")
+		})
+
+		it("should getWorktreePath use absolute basePath as-is", async () => {
+			const projectRoot = path.join(testDir, "worktree-absolute-test")
+			fs.mkdirSync(projectRoot, { recursive: true })
+
+			const projectId = await getProjectId(projectRoot)
+			const absoluteBase = path.join(os.homedir(), "my-worktrees")
+			const worktreePath = await getWorktreePath(projectRoot, "abs-branch", absoluteBase)
+
+			expect(worktreePath).toBe(path.join(absoluteBase, projectId, "abs-branch"))
+		})
+
+		it("should getWorktreePath use default when basePath is undefined", async () => {
+			const projectRoot = path.join(testDir, "worktree-default-test")
+			fs.mkdirSync(projectRoot, { recursive: true })
+
+			const withUndefined = await getWorktreePath(projectRoot, "branch-a", undefined)
+			const withoutArg = await getWorktreePath(projectRoot, "branch-a")
+
+			expect(withUndefined).toBe(withoutArg)
+			// Should use the default ~/.local/share/opencode/worktree path
+			expect(withUndefined).toContain(path.join(".local", "share", "opencode", "worktree"))
+		})
 	})
 
 	describe("Session CRUD", () => {


### PR DESCRIPTION
I wanted to make the worktree path configurable. Let me know if this is the way to go :)

## Summary

- Add a `worktreePath` option to `.opencode/worktree.jsonc` so users can customize where git worktrees are stored, instead of the hardcoded `~/.local/share/opencode/worktree` path.
- Supports `~` expansion for home directory. Full resolved path: `<worktreePath>/<projectId>/<branch>`.
- When omitted, behavior is unchanged (backward compatible).

## Changes

- **`worktree/state.ts`**: `getWorktreePath()` accepts an optional `basePath` parameter with `~` resolution
- **`worktree.ts`**: Added `worktreePath` to Zod schema, config template, and restructured create flow to load config before `createWorktree`
- **`worktree.json`**: Added `worktreePath` to JSON schema
- **`worktree-state.test.ts`**: 4 new tests for custom path, tilde expansion, and default fallback

## Usage

```jsonc
{
  // Custom base path for worktree storage (supports ~)
  // Default: ~/.local/share/opencode/worktree
  "worktreePath": "~/my-worktrees",

  "sync": { ... },
  "hooks": { ... }
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the worktree storage path configurable via `worktreePath` in `.opencode/worktree.jsonc`. Supports `~` expansion and keeps the default path when unset; final path resolves to <worktreePath>/<projectId>/<branch>.

- **New Features**
  - Added `worktreePath` to config and schema with `~` expansion and default fallback.
  - Load config before creation and pass base path to `getWorktreePath(projectRoot, branch, basePath?)`; added tests for custom, tilde, and default paths.

<sup>Written for commit eedb297bf001b5a21cf0f0d66396a2f159104ab1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

