### PR TITLE
feat(registry): Support custom component types

### DIFF
--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -7,6 +7,7 @@ import { posix as posixPath } from "node:path"
 import { z } from "zod"
 import type { ComponentManifest, McpServer, RegistryIndex } from "../schemas/registry"
 import {
+	builtinComponentTypeSchema,
 	classifyRegistrySchemaIssue,
 	componentManifestSchema,
 	componentTypeSchema,
@@ -87,13 +88,18 @@ function mapLegacyComponentType(type: unknown, context: string): string {
 		throw new ValidationError(`Invalid ${context}: expected string, got ${typeof type}`)
 	}
 
+	// Map legacy "ocx:" prefixed types to their canonical equivalents
 	const mappedType =
 		LEGACY_COMPONENT_TYPE_ALIAS_MAP[type as keyof typeof LEGACY_COMPONENT_TYPE_ALIAS_MAP] ?? type
+
+	// Validate against the full schema (built-ins + custom types)
 	const parsedType = componentTypeSchema.safeParse(mappedType)
 	if (!parsedType.success) {
+		// Provide a helpful error — custom types must follow the naming convention
 		throw new ValidationError(
-			`Unsupported component type "${type}" in ${context}. ` +
-				`Expected one of: ${componentTypeSchema.options.join(", ")}`,
+			`Invalid component type "${type}" in ${context}. ` +
+				`Use a built-in type (${builtinComponentTypeSchema.options.join(", ")}) ` +
+				`or a custom type (lowercase alphanumeric with hyphens, e.g. "react-component").`,
 		)
 	}
 

--- a/packages/cli/src/schemas/index.ts
+++ b/packages/cli/src/schemas/index.ts
@@ -39,6 +39,11 @@ export {
 	type AgentConfig,
 	agentConfigSchema,
 	aliasSchema,
+	// Built-in type helpers
+	BUILTIN_COMPONENT_TYPES,
+	type BuiltinComponentType,
+	builtinComponentTypeSchema,
+	isBuiltinComponentType,
 	type ComponentFile,
 	type ComponentFileObject,
 	type ComponentManifest,

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -150,7 +150,11 @@ export const dependencyRefSchema = z.string().refine(
 // FILE TARGET SCHEMAS
 // =============================================================================
 
-export const componentTypeSchema = z.enum([
+/**
+ * The canonical built-in component types shipped with OCX.
+ * Used for legacy mapping, docs-contract tests, and display hints.
+ */
+export const BUILTIN_COMPONENT_TYPES = [
 	"agent",
 	"skill",
 	"plugin",
@@ -158,9 +162,53 @@ export const componentTypeSchema = z.enum([
 	"tool",
 	"bundle",
 	"profile",
+] as const
+
+export type BuiltinComponentType = (typeof BUILTIN_COMPONENT_TYPES)[number]
+
+/**
+ * Built-in type enum — used internally for legacy type mapping and
+ * any logic that needs to distinguish known types from custom ones.
+ */
+export const builtinComponentTypeSchema = z.enum(BUILTIN_COMPONENT_TYPES)
+
+/**
+ * Prototype-pollution attack vectors that must never be valid type labels.
+ * These keys exist on every object's prototype chain and could be used to
+ * corrupt the LEGACY_COMPONENT_TYPE_ALIAS_MAP lookup or downstream objects.
+ */
+const BLOCKED_TYPE_NAMES = new Set(["__proto__", "constructor", "prototype", "toString", "valueOf"])
+
+/**
+ * Component type schema.
+ * Accepts all built-in types AND any arbitrary custom string (e.g. "react-component",
+ * "database-migration", "my-thing"). Custom types are treated as opaque labels —
+ * files are installed exactly as declared with no special path inference.
+ *
+ * Use `isBuiltinComponentType()` to check whether a type is a known built-in.
+ */
+export const componentTypeSchema = z.union([
+	builtinComponentTypeSchema,
+	z
+		.string()
+		.min(1, "Component type cannot be empty")
+		.regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
+			message:
+				"Custom component type must be lowercase alphanumeric with hyphens (e.g. 'react-component', 'my-type')",
+		})
+		.refine((val) => !BLOCKED_TYPE_NAMES.has(val), {
+			message: "Component type name is reserved and cannot be used as a custom type",
+		}),
 ])
 
 export type ComponentType = z.infer<typeof componentTypeSchema>
+
+/**
+ * Returns true if the given type is a known built-in OCX component type.
+ */
+export function isBuiltinComponentType(type: string): type is BuiltinComponentType {
+	return (BUILTIN_COMPONENT_TYPES as readonly string[]).includes(type)
+}
 
 /** Reserved targets (installer-owned files) */
 const RESERVED_TARGETS = new Set([".ocx", "ocx.lock"])

--- a/packages/cli/tests/docs-contract.registry.test.ts
+++ b/packages/cli/tests/docs-contract.registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "bun:test"
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { runRegistryListCore } from "../src/commands/registry"
-import { componentTypeSchema } from "../src/schemas/registry"
+import { BUILTIN_COMPONENT_TYPES } from "../src/schemas/registry"
 import { cleanupTempDir, createTempDir, expectStrictJsonSuccess, runCLIIsolated } from "./helpers"
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..")
@@ -447,8 +447,8 @@ function extractComponentTypesTable(markdown: string, fileLabel: string): string
 }
 
 function assertComponentTypeTableParity(markdown: string, fileLabel: string): void {
-	const runtimeTypes = [...componentTypeSchema.options] as string[]
-	assertCanonicalV2TypeList(runtimeTypes, "runtime componentTypeSchema")
+	const runtimeTypes = [...BUILTIN_COMPONENT_TYPES] as string[]
+	assertCanonicalV2TypeList(runtimeTypes, "runtime BUILTIN_COMPONENT_TYPES")
 
 	const documentedTypes = extractComponentTypesTable(markdown, fileLabel)
 	assertCanonicalV2TypeList(documentedTypes, `${fileLabel} component types table`)
@@ -494,8 +494,8 @@ function assertCanonicalV2TypeList(types: string[], label: string): void {
 describe("registry docs/runtime contracts", () => {
 	it("runtime component types are canonical unprefixed V2 values", () => {
 		assertCanonicalV2TypeList(
-			[...componentTypeSchema.options] as string[],
-			"runtime componentTypeSchema",
+			[...BUILTIN_COMPONENT_TYPES] as string[],
+			"runtime BUILTIN_COMPONENT_TYPES",
 		)
 	})
 

--- a/packages/cli/tests/schemas.test.ts
+++ b/packages/cli/tests/schemas.test.ts
@@ -8,9 +8,13 @@ import { parseCanonicalId } from "../src/schemas/config"
 import {
 	agentConfigSchema,
 	aliasSchema,
+	BUILTIN_COMPONENT_TYPES,
+	builtinComponentTypeSchema,
+	componentTypeSchema,
 	createQualifiedComponent,
 	dependencyRefSchema,
 	inferTargetPath,
+	isBuiltinComponentType,
 	namespaceSchema,
 	normalizeFile,
 	normalizeMcpServer,
@@ -565,6 +569,105 @@ describe("schemas", () => {
 		it("should throw for missing namespace separator", () => {
 			const id = "https://registry.example.com::component@1.0.0"
 			expect(() => parseCanonicalId(id)).toThrow("qualified")
+		})
+	})
+
+	describe("componentTypeSchema (custom type support)", () => {
+		it("should accept all built-in types", () => {
+			for (const type of BUILTIN_COMPONENT_TYPES) {
+				expect(() => componentTypeSchema.parse(type)).not.toThrow()
+			}
+		})
+
+		it("should accept custom types with valid naming", () => {
+			expect(() => componentTypeSchema.parse("react-component")).not.toThrow()
+			expect(() => componentTypeSchema.parse("database-migration")).not.toThrow()
+			expect(() => componentTypeSchema.parse("my-thing")).not.toThrow()
+			expect(() => componentTypeSchema.parse("boilerplate")).not.toThrow()
+			expect(() => componentTypeSchema.parse("starter")).not.toThrow()
+		})
+
+		it("should reject types with uppercase letters", () => {
+			expect(() => componentTypeSchema.parse("ReactComponent")).toThrow()
+			expect(() => componentTypeSchema.parse("MyType")).toThrow()
+		})
+
+		it("should reject types with spaces or special chars", () => {
+			expect(() => componentTypeSchema.parse("my type")).toThrow()
+			expect(() => componentTypeSchema.parse("my_type")).toThrow()
+			expect(() => componentTypeSchema.parse("my.type")).toThrow()
+			expect(() => componentTypeSchema.parse("")).toThrow()
+		})
+
+		it("should reject types starting or ending with a hyphen", () => {
+			expect(() => componentTypeSchema.parse("-mytype")).toThrow()
+			expect(() => componentTypeSchema.parse("mytype-")).toThrow()
+		})
+
+		it("should reject reserved prototype-pollution names", () => {
+			expect(() => componentTypeSchema.parse("constructor")).toThrow()
+			expect(() => componentTypeSchema.parse("prototype")).toThrow()
+		})
+	})
+
+	describe("isBuiltinComponentType()", () => {
+		it("should return true for all built-in types", () => {
+			for (const type of BUILTIN_COMPONENT_TYPES) {
+				expect(isBuiltinComponentType(type)).toBe(true)
+			}
+		})
+
+		it("should return false for custom types", () => {
+			expect(isBuiltinComponentType("react-component")).toBe(false)
+			expect(isBuiltinComponentType("my-thing")).toBe(false)
+			expect(isBuiltinComponentType("boilerplate")).toBe(false)
+		})
+	})
+
+	describe("builtinComponentTypeSchema", () => {
+		it("should reject custom types", () => {
+			expect(() => builtinComponentTypeSchema.parse("react-component")).toThrow()
+			expect(() => builtinComponentTypeSchema.parse("my-thing")).toThrow()
+		})
+	})
+
+	describe("registrySchema with custom types", () => {
+		const baseRegistry = {
+			$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+			name: "test-registry",
+			version: "1.0.0",
+			author: "test",
+			components: [],
+		}
+
+		it("should accept a component with a custom type", () => {
+			const registry = {
+				...baseRegistry,
+				components: [
+					{
+						name: "my-boilerplate",
+						type: "react-component",
+						description: "A reusable React component boilerplate",
+						files: ["src/MyComponent.tsx"],
+					},
+				],
+			}
+			expect(() => registrySchema.parse(registry)).not.toThrow()
+		})
+
+		it("should reject a component with an invalid custom type format", () => {
+			const registry = {
+				...baseRegistry,
+				components: [
+					{
+						name: "my-component",
+						type: "React_Component",
+						description: "Invalid type",
+						files: [],
+					},
+				],
+			}
+			expect(() => registrySchema.parse(registry)).toThrow()
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Allow registry authors to use any component type — not just the 7 built-in ones.

**Before:** `type` must be one of `agent`, `skill`, `plugin`, `command`, `tool`, `bundle`, `profile`. Anything else fails validation.

**After:** `type` accepts any lowercase-alphanumeric-with-hyphens string. Built-in types still work exactly the same. Custom types (e.g. `automation`, `api-client`, `workflow`) are treated as opaque labels — files install where declared, no special handling.

## Why

OCX is fundamentally a file copier with integrity checking. There's no reason to restrict what those files represent. A team should be able to publish a full project — agents, tools, API clients, configs, source code, the whole thing — as a single installable registry component.

## Example

A full outbound sales automation distributed as one component:

```jsonc
{
  "name": "outbound-automation",
  "type": "automation",
  "description": "Full outbound sales automation — lead enrichment, email sequences, CRM sync",
  "files": [
    "agents/outbound-agent.md",
    "skills/lead-enrichment/SKILL.md",
    "skills/email-sequences/SKILL.md",
    "tools/crm-sync.ts",
    "tools/email-sender.ts",
    "commands/run-campaign.md",
    "commands/enrich-leads.md",
    "src/lib/lead-scorer.ts",
    "src/lib/sequence-engine.ts",
    "src/lib/crm-client.ts",
    "src/config/templates.json"
  ],
  "opencode": {
    "mcp": {
      "crm-server": "https://mcp.example.com/crm"
    }
  }
}
```

```sh
ocx add myreg/outbound-automation
```

One command — agent, skills, tools, commands, source code, configs, and MCP server config all land in your repo.

## Changes

- `componentTypeSchema` → `z.union([builtinEnum, customString])` instead of `z.enum([...])`
- `BUILTIN_COMPONENT_TYPES` + `isBuiltinComponentType()` exported for internal use
- Prototype-pollution names (`constructor`, `prototype`) blocked
- Fetcher error messages updated to mention custom type support
- Full test coverage added

## Tests

1221 pass, 0 fail across 56 files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow registries to define custom component types. `type` now accepts any lowercase-alphanumeric-with-hyphens label; built-in types stay supported and unchanged.

- **New Features**
  - `componentTypeSchema` now allows custom types (validated regex) alongside built-ins; exports `BUILTIN_COMPONENT_TYPES`, `builtinComponentTypeSchema`, and `isBuiltinComponentType`.
  - Fetcher errors guide custom type naming and list built-ins; legacy `ocx:` aliases still map correctly.
  - Blocks prototype-pollution names (`__proto__`, `constructor`, `prototype`, etc.) for safety.

<sup>Written for commit 771658bf3df76121e6a42aa68643f1f018d13bb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

