### PR TITLE
feat: Add cmux support to worktree workflow (#158)

### DIFF
--- a/docs/integrations/worktree.mdx
+++ b/docs/integrations/worktree.mdx
@@ -11,7 +11,7 @@ An OpenCode plugin that creates isolated git worktrees where each worktree autom
 
 Manual worktrees require setup: create the worktree, open a terminal, navigate to it, start OpenCode. This plugin eliminates that friction. When the AI calls `worktree_create`, your terminal spawns automatically, OpenCode is already running, and files are synchronized. When it calls `worktree_delete`, changes commit automatically and the worktree cleans itself up.
 
-Works great standalone, but pairs especially well with **[cmux](https://www.cmux.dev/)** for agentic workflows. cmux provides native workspace management and programmatic control designed for automated development workflows. tmux is also supported for traditional multiplexer setups, and remains runtime-priority when already inside a tmux session.
+Works great standalone, but pairs especially well with **[cmux](https://www.cmux.dev/)** for agentic workflows. cmux provides native workspace management and programmatic control designed for automated development workflows. Each worktree launch opens a new cmux workspace (no current-workspace reuse). tmux is also supported for traditional multiplexer setups, and remains runtime-priority when already inside a tmux session.
 
 ## When to Use This
 
@@ -57,7 +57,7 @@ Worktrees are stored in `~/.local/share/opencode/worktree/<project-id>/<branch>/
 | **macOS** | Ghostty, iTerm2, Kitty, WezTerm, Alacritty, Warp, Terminal.app |
 | **Linux** | Kitty, WezTerm, Alacritty, Ghostty, Foot, GNOME Terminal, Konsole, xterm |
 | **Windows** | Windows Terminal (wt.exe), cmd.exe fallback |
-| **cmux** | Uses native cmux workflow when `CMUX_WORKSPACE_ID`/cmux control env is available, then falls back safely |
+| **cmux** | Uses native cmux workflow when `CMUX_WORKSPACE_ID`/cmux control env is available; each worktree launch opens a new cmux workspace, then falls back safely |
 | **tmux** | Creates new tmux window (supported on all platforms) |
 | **WSL** | Windows Terminal via wt.exe interop |
 

--- a/facades/opencode-worktree/README.md
+++ b/facades/opencode-worktree/README.md
@@ -103,14 +103,14 @@ The plugin detects your terminal automatically:
 | **macOS** | Ghostty, iTerm2, Kitty, WezTerm, Alacritty, Warp, Terminal.app |
 | **Linux** | Kitty, WezTerm, Alacritty, Ghostty, Foot, GNOME Terminal, Konsole, XFCE4 Terminal, xterm |
 | **Windows** | Windows Terminal (wt.exe), cmd.exe fallback |
-| **cmux** | **Uses native cmux workflow** when `CMUX_WORKSPACE_ID` is present or socket control is explicitly enabled (`CMUX_SOCKET_PATH` + `CMUX_SOCKET_MODE=allowAll`); falls back safely when unavailable |
+| **cmux** | **Uses native cmux workflow** when `CMUX_WORKSPACE_ID` is present or socket control is explicitly enabled (`CMUX_SOCKET_PATH` + `CMUX_SOCKET_MODE=allowAll`); each worktree launch opens a new cmux workspace and falls back safely when unavailable |
 | **tmux** | Creates new tmux window (supported on all platforms) |
 | **WSL** | Windows Terminal via wt.exe interop |
 
 ### Detection Priority
 
 1. **tmux** - Runtime priority on all platforms when already inside tmux. Creates new tmux windows instead of spawning separate terminal applications.
-2. **cmux** - **Recommended for new agentic workflows**. Uses native cmux launch flow when available via `CMUX_WORKSPACE_ID` or explicit socket control (`CMUX_SOCKET_PATH` with `CMUX_SOCKET_MODE=allowAll`), then falls back safely when cmux context is unavailable.
+2. **cmux** - **Recommended for new agentic workflows**. Uses native cmux launch flow when available via `CMUX_WORKSPACE_ID` or explicit socket control (`CMUX_SOCKET_PATH` with `CMUX_SOCKET_MODE=allowAll`). Worktree launches always create a new cmux workspace (no current-workspace reuse), then fall back safely when cmux context is unavailable.
 3. **WSL** - Uses Windows Terminal for Linux subsystem
 4. **Environment vars** - Checks `TERM_PROGRAM`, `KITTY_WINDOW_ID`, `GHOSTTY_RESOURCES_DIR`, etc.
 5. **Fallback** - System defaults (Terminal.app, xterm, cmd.exe)

--- a/workers/kdco-registry/files/plugins/worktree/terminal.ts
+++ b/workers/kdco-registry/files/plugins/worktree/terminal.ts
@@ -411,6 +411,8 @@ export function buildCmuxCommandSequence(
 	cwd: string,
 	command?: string,
 ): string[][] {
+	// Product policy: each worktree launch gets a new cmux workspace.
+	// We intentionally do not reuse the current workspace context.
 	const cmuxArgs = ["new-workspace", "--cwd", cwd]
 
 	if (command) {

--- a/workers/kdco-registry/tests/worktree-terminal.test.ts
+++ b/workers/kdco-registry/tests/worktree-terminal.test.ts
@@ -432,7 +432,7 @@ setInterval(() => {}, 1000)
 			expect(canUse).toBe(false)
 		})
 
-		it("builds workspace-targeted cmux command sequence", () => {
+		it("always builds new-workspace cmux command even with workspace context", () => {
 			const commands = buildCmuxCommandSequence(
 				{ workspaceID: "workspace-123" },
 				"/tmp/worktree",
@@ -442,6 +442,7 @@ setInterval(() => {}, 1000)
 			expect(commands).toEqual([
 				["new-workspace", "--cwd", "/tmp/worktree", "--command", "opencode --session abc"],
 			])
+			expect(commands.some((args) => args[0] === "select-workspace")).toBe(false)
 		})
 
 		it("builds fallback cmux command sequence without workspace context", () => {
@@ -450,7 +451,7 @@ setInterval(() => {}, 1000)
 			expect(commands).toEqual([["new-workspace", "--cwd", "/tmp/worktree"]])
 		})
 
-		it("executes cmux command sequence when workspace context is available", async () => {
+		it("executes new-workspace cmux command when workspace context is available", async () => {
 			const executed: string[][] = []
 
 			const result = await openCmuxTerminal("/tmp/worktree", "opencode --session abc", {
@@ -466,6 +467,7 @@ setInterval(() => {}, 1000)
 			expect(executed).toEqual([
 				["new-workspace", "--cwd", "/tmp/worktree", "--command", "opencode --session abc"],
 			])
+			expect(executed.some((args) => args[0] === "select-workspace")).toBe(false)
 		})
 
 		it("returns failure when cmux command exits non-zero", async () => {


### PR DESCRIPTION
## Summary
- Add first-class `cmux` terminal workflow support in the worktree launcher, including context detection and command sequencing when cmux control environment is available.
- Keep the rollout intentionally reduced in scope: Ghostty behavior remains simple and window-based (no new Ghostty-specific session orchestration).
- Add safe fallback behavior so terminal launch only falls back to platform flow when cmux fails before state mutation, and update related docs/tests accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class `cmux` workflow to the worktree terminal launcher with safe fallback and per-command timeouts. Launch flow uses `new-workspace` with optional inline command, creating a fresh `cmux` workspace per worktree; docs recommend `cmux` for agentic workflows and `tmux` remains runtime-priority.

- **New Features**
  - Detects `cmux` via `CMUX_WORKSPACE_ID` or `CMUX_SOCKET_PATH` + `CMUX_SOCKET_MODE=allowAll`, and verifies the binary (supports a custom `cmux` path).
  - Priority: `tmux` > `cmux` > WSL/platform terminals.
  - Runs `cmux` as: `new-workspace --cwd <dir> [--command <startup>]` (always creates a new workspace; no reuse).
  - Safe fallback: if `cmux` fails before any mutation, we launch the platform terminal; after mutation or timeout, we surface the error.
  - Docs updated to recommend `cmux`, clarify detection order, and note per-worktree workspace creation; tests cover env/socket detection, custom binary preflight, command sequencing, fallback in `openTerminal`, timeouts with process cleanup, and `tmux` precedence.

- **Bug Fixes**
  - Adds a 1.5s timeout per `cmux` command with best-effort process termination; timeouts are treated as indeterminate mutations to prevent unsafe fallback.

<sup>Written for commit 35296689505027ffd429f6e1613c629a145e8fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

