### PR TITLE
feat(registry): Enforce plugin loadability checks across validation

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -43,6 +43,7 @@ import { ConfigError, ConflictError, IntegrityError, ValidationError } from "../
 import { handleError } from "../utils/handle-error"
 import { outputJson } from "../utils/json-output"
 import { logger } from "../utils/logger"
+import { mergeNpmDependencySpecifiers, type NpmDependency } from "../utils/npm-dependencies"
 import {
 	extractPackageName,
 	fetchPackageVersion,
@@ -1362,11 +1363,6 @@ async function installComponent(
 // NPM Dependency Management
 // ============================================================================
 
-interface NpmDependency {
-	name: string
-	version: string
-}
-
 interface OpencodePackageJson {
 	name?: string
 	private?: boolean
@@ -1379,33 +1375,6 @@ const DEFAULT_PACKAGE_JSON: OpencodePackageJson = {
 	name: "opencode-plugins",
 	private: true,
 	type: "module",
-}
-
-/**
- * Parses an npm dependency spec into name and version.
- * Handles: "lodash", "lodash@4.0.0", "@types/node", "@types/node@1.0.0"
- */
-function parseNpmDependency(spec: string): NpmDependency {
-	// Guard: invalid input
-	if (!spec?.trim()) {
-		throw new ValidationError(`Invalid npm dependency: expected non-empty string, got "${spec}"`)
-	}
-
-	const trimmed = spec.trim()
-	const lastAt = trimmed.lastIndexOf("@")
-
-	// Has version: "lodash@4.0.0" or "@types/node@1.0.0"
-	if (lastAt > 0) {
-		const name = trimmed.slice(0, lastAt)
-		const version = trimmed.slice(lastAt + 1)
-		if (!version) {
-			throw new ValidationError(`Invalid npm dependency: missing version after @ in "${spec}"`)
-		}
-		return { name, version }
-	}
-
-	// No version: "lodash" or "@types/node" → use "*"
-	return { name: trimmed, version: "*" }
 }
 
 /**
@@ -1518,19 +1487,15 @@ async function updateOpencodePackageDeps(
 	// Ensure directory exists
 	await mkdir(packageDir, { recursive: true })
 
-	// Parse all deps - fails fast on invalid (Law 4)
-	const prodDeps = npmDeps.map(parseNpmDependency)
-	const devDeps = npmDevDeps.map(parseNpmDependency)
-
-	// Law 4 (Fail Loud): Check for conflicts - same package in both lists
-	const prodNames = new Set(prodDeps.map((d) => d.name))
-	const conflicts = devDeps.filter((d) => prodNames.has(d.name))
-	if (conflicts.length > 0) {
-		throw new ConflictError(
-			`Package(s) appear in both dependencies and devDependencies: ${conflicts.map((c) => c.name).join(", ")}.\n` +
-				"A package cannot be in both fields. Remove from one list manually before adding.",
-		)
-	}
+	const mergedDependencySpecs = mergeNpmDependencySpecifiers(npmDeps, npmDevDeps)
+	const prodDeps: NpmDependency[] = Array.from(
+		mergedDependencySpecs.dependencies.entries(),
+		([name, version]) => ({ name, version }),
+	)
+	const devDeps: NpmDependency[] = Array.from(
+		mergedDependencySpecs.devDependencies.entries(),
+		([name, version]) => ({ name, version }),
+	)
 
 	// Read → merge → write
 	const existing = await readOpencodePackageJson(packageDir)

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,7 +9,7 @@ import type { Command } from "commander"
 import kleur from "kleur"
 import { BuildRegistryError, type BuildRegistryResult, buildRegistry } from "../lib/build-registry"
 import { runCompleteValidation } from "../lib/validation-runner"
-import type { LoadRegistryErrorKind } from "../lib/validators"
+import type { LoadRegistryErrorKind, RegistryValidationIssue } from "../lib/validators"
 import { outputDryRun } from "../utils/dry-run"
 import {
 	EXIT_CODES,
@@ -47,15 +47,20 @@ function createLoadValidationError(message: string, errorKind?: LoadRegistryErro
 
 function createValidationFailureError(
 	errors: string[],
+	warnings: string[],
+	issues: RegistryValidationIssue[],
 	failureType: "schema" | "rules",
 ): ValidationFailedError {
 	const summary = summarizeValidationErrors(errors, {
 		schemaErrors: failureType === "schema" ? errors.length : 0,
+		issues,
 	})
 
 	const details: ValidationFailureDetails = {
 		valid: false,
 		errors,
+		warnings,
+		issues,
 		summary: {
 			valid: false,
 			totalErrors: summary.totalErrors,
@@ -63,6 +68,7 @@ function createValidationFailureError(
 			sourceFileErrors: summary.sourceFileErrors,
 			circularDependencyErrors: summary.circularDependencyErrors,
 			duplicateTargetErrors: summary.duplicateTargetErrors,
+			pluginLoadabilityErrors: summary.pluginLoadabilityErrors,
 			otherErrors: summary.otherErrors,
 		},
 	}
@@ -101,6 +107,13 @@ function outputValidationFailures(errors: string[], failureType: "schema" | "rul
 			console.log(kleur.red(`  ${error}`))
 		}
 	}
+
+	if (categorized.pluginLoadability.length > 0) {
+		logger.error("✗ Plugin loadability")
+		for (const error of categorized.pluginLoadability) {
+			console.log(kleur.red(`  ${error}`))
+		}
+	}
 }
 
 export function registerBuildCommand(program: Command): void {
@@ -136,9 +149,15 @@ export function registerBuildCommand(program: Command): void {
 							throw createLoadValidationError(firstError, validationResult.loadErrorKind)
 						}
 
+						if (validationResult.failureType === "operational") {
+							throw new BuildRegistryError(firstError, validationResult.errors.slice(1))
+						}
+
 						const failureType = validationResult.failureType === "schema" ? "schema" : "rules"
 						const validationError = createValidationFailureError(
 							validationResult.errors,
+							validationResult.warnings,
+							validationResult.issues,
 							failureType,
 						)
 
@@ -158,6 +177,10 @@ export function registerBuildCommand(program: Command): void {
 						logger.success("✓ Source files")
 						logger.success("✓ No circular dependencies")
 						logger.success("✓ No duplicate targets")
+						logger.success("✓ Plugin loadability")
+						for (const warning of validationResult.warnings) {
+							logger.warn(`  ${warning}`)
+						}
 						console.log("")
 					}
 				}
@@ -178,6 +201,9 @@ export function registerBuildCommand(program: Command): void {
 				if ("dryRun" in result && result.dryRun) {
 					if (!options.json) spinner.stop()
 					outputDryRun(result, { json: options.json, quiet: options.quiet })
+					if (!result.validation.passed) {
+						process.exit(EXIT_CODES.CONFIG)
+					}
 					return
 				}
 
@@ -202,6 +228,22 @@ export function registerBuildCommand(program: Command): void {
 					})
 				}
 			} catch (error) {
+				if (error instanceof ValidationFailedError) {
+					if (options.json) {
+						handleError(error, { json: true })
+					}
+
+					if (!options.quiet) {
+						logger.error(error.message)
+						outputValidationFailures(error.details.errors, "rules")
+						for (const warning of error.details.warnings ?? []) {
+							console.log(kleur.yellow(`  ${warning}`))
+						}
+					}
+
+					process.exit(error.exitCode)
+				}
+
 				if (error instanceof BuildRegistryError) {
 					if (options.json) {
 						handleError(error, { json: true })

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -7,8 +7,9 @@
 import { resolve } from "node:path"
 import type { Command } from "commander"
 import kleur from "kleur"
+import { BuildRegistryError } from "../lib/build-registry"
 import { runCompleteValidation } from "../lib/validation-runner"
-import type { LoadRegistryErrorKind } from "../lib/validators"
+import type { LoadRegistryErrorKind, RegistryValidationIssue } from "../lib/validators"
 import {
 	EXIT_CODES,
 	NotFoundError,
@@ -42,15 +43,20 @@ function createLoadValidationError(message: string, errorKind?: LoadRegistryErro
 
 function createValidationFailureError(
 	errors: string[],
+	warnings: string[],
+	issues: RegistryValidationIssue[],
 	failureType: "schema" | "rules",
 ): ValidationFailedError {
 	const summary = summarizeValidationErrors(errors, {
 		schemaErrors: failureType === "schema" ? errors.length : 0,
+		issues,
 	})
 
 	const details: ValidationFailureDetails = {
 		valid: false,
 		errors,
+		warnings,
+		issues,
 		summary: {
 			valid: false,
 			totalErrors: summary.totalErrors,
@@ -58,6 +64,7 @@ function createValidationFailureError(
 			sourceFileErrors: summary.sourceFileErrors,
 			circularDependencyErrors: summary.circularDependencyErrors,
 			duplicateTargetErrors: summary.duplicateTargetErrors,
+			pluginLoadabilityErrors: summary.pluginLoadabilityErrors,
 			otherErrors: summary.otherErrors,
 		},
 	}
@@ -68,6 +75,12 @@ function createValidationFailureError(
 function outputValidationErrors(errors: string[]): void {
 	for (const error of errors) {
 		console.log(kleur.red(`  ${error}`))
+	}
+}
+
+function outputValidationWarnings(warnings: string[]): void {
+	for (const warning of warnings) {
+		console.log(kleur.yellow(`  ${warning}`))
 	}
 }
 
@@ -101,8 +114,14 @@ export function registerValidateCommand(program: Command): void {
 						throw loadError
 					}
 
+					if (validationResult.failureType === "operational") {
+						throw new BuildRegistryError(firstError, validationResult.errors.slice(1))
+					}
+
 					const validationError = createValidationFailureError(
 						validationResult.errors,
+						validationResult.warnings,
+						validationResult.issues,
 						validationResult.failureType === "schema" ? "schema" : "rules",
 					)
 
@@ -113,6 +132,10 @@ export function registerValidateCommand(program: Command): void {
 					if (!options.quiet) {
 						logger.error(validationError.message)
 						outputValidationErrors(validationResult.errors)
+						if (validationResult.warnings.length > 0) {
+							logger.warn("Validation warnings:")
+							outputValidationWarnings(validationResult.warnings)
+						}
 					}
 
 					process.exit(validationError.exitCode)
@@ -121,15 +144,24 @@ export function registerValidateCommand(program: Command): void {
 				// All validations passed
 				if (!options.quiet && !options.json) {
 					logger.success("✓ Registry source is valid")
+					if (validationResult.warnings.length > 0) {
+						logger.warn("Validation warnings:")
+						outputValidationWarnings(validationResult.warnings)
+					}
 				}
 
 				if (options.json) {
+					const summary = summarizeValidationErrors([], {
+						issues: validationResult.issues,
+					})
 					outputJson({
 						success: true,
 						data: {
 							valid: true,
 							errors: [],
-							summary: summarizeValidationErrors([]),
+							warnings: validationResult.warnings,
+							issues: validationResult.issues,
+							summary,
 						},
 					})
 				}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -171,6 +171,19 @@ export function registerValidateCommand(program: Command): void {
 					process.exit(exitCode)
 				}
 
+				if (error instanceof BuildRegistryError) {
+					if (options.json) {
+						handleError(error, { json: true })
+					}
+
+					if (!options.quiet) {
+						logger.error(error.message)
+						outputValidationErrors(error.errors)
+					}
+
+					process.exit(EXIT_CODES.GENERAL)
+				}
+
 				handleError(error, { json: options.json })
 			}
 		})

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ async function runCliEntryPoint(): Promise<void> {
 }
 
 export {
+	BuildRegistryError,
 	type BuildRegistryOptions,
 	type BuildRegistryResult,
 	buildRegistry,
@@ -28,4 +29,5 @@ export {
 	packumentSchema,
 	type Registry,
 	registrySchema,
+	ValidationFailedError,
 } from "./programmatic-exports"

--- a/packages/cli/src/lib/build-registry.ts
+++ b/packages/cli/src/lib/build-registry.ts
@@ -151,7 +151,7 @@ export async function buildRegistry(
 	const { source: sourcePath, out: outPath } = options
 
 	const validationResult = await runCompleteValidation(sourcePath, {
-		skipDuplicateTargets: false,
+		skipDuplicateTargets: true,
 	})
 
 	if (!validationResult.success) {

--- a/packages/cli/src/lib/build-registry.ts
+++ b/packages/cli/src/lib/build-registry.ts
@@ -25,6 +25,13 @@ export interface BuildRegistryOptions {
 	out: string
 	/** Dry-run mode: validate and show what would be built */
 	dryRun?: boolean
+	/**
+	 * Skip duplicate target validation.
+	 *
+	 * Defaults to false so build-time validation catches conflicting targets.
+	 * Set true only for registries that intentionally reuse targets.
+	 */
+	skipDuplicateTargets?: boolean
 }
 
 export interface BuildRegistryResult {
@@ -151,7 +158,7 @@ export async function buildRegistry(
 	const { source: sourcePath, out: outPath } = options
 
 	const validationResult = await runCompleteValidation(sourcePath, {
-		skipDuplicateTargets: true,
+		skipDuplicateTargets: options.skipDuplicateTargets === true,
 	})
 
 	if (!validationResult.success) {

--- a/packages/cli/src/lib/build-registry.ts
+++ b/packages/cli/src/lib/build-registry.ts
@@ -7,9 +7,16 @@
 
 import { mkdir } from "node:fs/promises"
 import { dirname, join } from "node:path"
-import { parse as parseJsonc } from "jsonc-parser"
-import { classifyRegistrySchemaIssue, normalizeFile, registrySchema } from "../schemas/registry"
+import type { Registry } from "../schemas/registry"
+import { normalizeFile } from "../schemas/registry"
 import type { DryRunResult } from "../utils/dry-run"
+import {
+	ValidationFailedError,
+	type ValidationFailureDetails,
+	type ValidationFailureSummary,
+} from "../utils/errors"
+import { summarizeValidationErrors } from "../utils/validation-errors"
+import { runCompleteValidation } from "./validation-runner"
 
 export interface BuildRegistryOptions {
 	/** Source directory containing registry.jsonc (or registry.json) and files/ */
@@ -37,116 +44,165 @@ export class BuildRegistryError extends Error {
 	}
 }
 
+function createValidationSummary(
+	errors: string[],
+	issues: ValidationFailureDetails["issues"] = [],
+	schemaErrors = 0,
+): ValidationFailureSummary {
+	const summary = summarizeValidationErrors(errors, {
+		schemaErrors,
+		issues: issues ?? [],
+	})
+
+	return {
+		valid: false,
+		totalErrors: summary.totalErrors,
+		schemaErrors: summary.schemaErrors,
+		sourceFileErrors: summary.sourceFileErrors,
+		circularDependencyErrors: summary.circularDependencyErrors,
+		duplicateTargetErrors: summary.duplicateTargetErrors,
+		pluginLoadabilityErrors: summary.pluginLoadabilityErrors,
+		otherErrors: summary.otherErrors,
+	}
+}
+
+function toValidationFailureDetails(input: {
+	errors: string[]
+	warnings: string[]
+	issues: ValidationFailureDetails["issues"]
+	schemaErrors?: number
+}): ValidationFailureDetails {
+	return {
+		valid: false,
+		errors: input.errors,
+		warnings: input.warnings,
+		issues: input.issues,
+		summary: createValidationSummary(input.errors, input.issues, input.schemaErrors ?? 0),
+	}
+}
+
+function createDryRunActions(registry: Registry, sourcePath: string): DryRunResult["wouldPerform"] {
+	const actions: DryRunResult["wouldPerform"] = []
+
+	for (const component of registry.components) {
+		actions.push({
+			action: "create",
+			target: `file:components/${component.name}.json`,
+			details: { type: "packument" },
+		})
+
+		for (const rawFile of component.files) {
+			const file = normalizeFile(rawFile, component.type)
+			actions.push({
+				action: "create",
+				target: `file:components/${component.name}/${file.path}`,
+				details: { source: join(sourcePath, "files", file.path) },
+			})
+		}
+	}
+
+	actions.push({
+		action: "create",
+		target: "file:index.json",
+		details: { type: "registry index" },
+	})
+
+	actions.push({
+		action: "create",
+		target: "file:.well-known/ocx.json",
+		details: { type: "discovery file" },
+	})
+
+	return actions
+}
+
+function createBuildValidationDryRunResult(input: {
+	sourcePath: string
+	outPath: string
+	registry: Registry
+	validationPassed: boolean
+	validationErrors: string[]
+	validationWarnings: string[]
+	validationIssues: ValidationFailureDetails["issues"]
+}): DryRunResult {
+	const actions = createDryRunActions(input.registry, input.sourcePath)
+	const totalFiles = actions.filter((action) => action.action === "create").length
+
+	return {
+		dryRun: true,
+		command: "build",
+		wouldPerform: actions,
+		validation: {
+			passed: input.validationPassed,
+			...(input.validationErrors.length > 0 ? { errors: input.validationErrors } : {}),
+			...(input.validationWarnings.length > 0 ? { warnings: input.validationWarnings } : {}),
+			issues: input.validationIssues,
+		},
+		summary: `Would build ${input.registry.components.length} components, ${totalFiles} files to ${input.outPath}`,
+	}
+}
+
 /**
  * Build a registry from source.
- *
- * @param options - Build options
- * @returns Build result with metadata or DryRunResult
- * @throws {BuildRegistryError} If validation fails or files are missing
  */
 export async function buildRegistry(
 	options: BuildRegistryOptions,
 ): Promise<BuildRegistryResult | DryRunResult> {
 	const { source: sourcePath, out: outPath } = options
 
-	// Read registry file from source (prefer .jsonc over .json)
-	const jsoncFile = Bun.file(join(sourcePath, "registry.jsonc"))
-	const jsonFile = Bun.file(join(sourcePath, "registry.json"))
-	const jsoncExists = await jsoncFile.exists()
-	const jsonExists = await jsonFile.exists()
+	const validationResult = await runCompleteValidation(sourcePath, {
+		skipDuplicateTargets: false,
+	})
 
-	if (!jsoncExists && !jsonExists) {
-		throw new BuildRegistryError("No registry.jsonc or registry.json found in source directory")
-	}
-
-	const registryFile = jsoncExists ? jsoncFile : jsonFile
-	const content = await registryFile.text()
-	const registryData = parseJsonc(content, [], { allowTrailingComma: true })
-	const schemaIssue = classifyRegistrySchemaIssue(registryData)
-	if (schemaIssue) {
-		throw new BuildRegistryError(`Registry schema compatibility failed (${schemaIssue.issue})`, [
-			schemaIssue.remediation,
-			...(schemaIssue.schemaUrl !== undefined ? [`Invalid $schema: ${schemaIssue.schemaUrl}`] : []),
-		])
-	}
-
-	// Validate registry schema
-	const parseResult = registrySchema.safeParse(registryData)
-	if (!parseResult.success) {
-		const errors = parseResult.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`)
-		throw new BuildRegistryError("Registry validation failed", errors)
-	}
-
-	const registry = parseResult.data
-	const validationErrors: string[] = []
-
-	// Dry-run: Calculate what would be built without creating files
-	if (options.dryRun) {
-		const actions = []
-
-		// Check for missing source files
-		for (const component of registry.components) {
-			// Would create packument file
-			actions.push({
-				action: "create" as const,
-				target: `file:components/${component.name}.json`,
-				details: { type: "packument" },
+	if (!validationResult.success) {
+		if (validationResult.failureType === "rules") {
+			const details = toValidationFailureDetails({
+				errors: validationResult.errors,
+				warnings: validationResult.warnings,
+				issues: validationResult.issues,
 			})
 
-			// Check source files exist
-			for (const rawFile of component.files) {
-				const file = normalizeFile(rawFile, component.type)
-				const sourceFilePath = join(sourcePath, "files", file.path)
-
-				if (!(await Bun.file(sourceFilePath).exists())) {
-					validationErrors.push(`${component.name}: Source file not found at ${sourceFilePath}`)
-					continue
-				}
-
-				// Would copy file
-				actions.push({
-					action: "create" as const,
-					target: `file:components/${component.name}/${file.path}`,
-					details: { source: sourceFilePath },
+			if (options.dryRun && validationResult.registry) {
+				return createBuildValidationDryRunResult({
+					sourcePath,
+					outPath,
+					registry: validationResult.registry,
+					validationPassed: false,
+					validationErrors: validationResult.errors,
+					validationWarnings: validationResult.warnings,
+					validationIssues: validationResult.issues,
 				})
 			}
+
+			throw new ValidationFailedError(details)
 		}
 
-		// Would create index.json
-		actions.push({
-			action: "create" as const,
-			target: "file:index.json",
-			details: { type: "registry index" },
-		})
-
-		// Would create .well-known/ocx.json
-		actions.push({
-			action: "create" as const,
-			target: "file:.well-known/ocx.json",
-			details: { type: "discovery file" },
-		})
-
-		// Calculate total files
-		const totalFiles = actions.filter((a) => a.action === "create").length
-
-		return {
-			dryRun: true,
-			command: "build",
-			wouldPerform: actions,
-			validation: {
-				passed: validationErrors.length === 0,
-				errors: validationErrors.length > 0 ? validationErrors : undefined,
-			},
-			summary: `Would build ${registry.components.length} components, ${totalFiles} files to ${outPath}`,
-		}
+		const [firstError = "Registry build preflight failed", ...remainingErrors] =
+			validationResult.errors
+		throw new BuildRegistryError(firstError, remainingErrors)
 	}
 
-	// Normal mode: Create output directory structure
+	const registry = validationResult.registry
+	if (!registry) {
+		throw new BuildRegistryError("Registry validation succeeded but returned no parsed registry")
+	}
+
+	if (options.dryRun) {
+		return createBuildValidationDryRunResult({
+			sourcePath,
+			outPath,
+			registry,
+			validationPassed: true,
+			validationErrors: [],
+			validationWarnings: validationResult.warnings,
+			validationIssues: validationResult.issues,
+		})
+	}
+
 	const componentsDir = join(outPath, "components")
 	await mkdir(componentsDir, { recursive: true })
 
-	// V2: Generate packument and copy files for each component
-	// Use component-level versioning (default to 1.0.0)
+	const copyErrors: string[] = []
 	const DEFAULT_COMPONENT_VERSION = "1.0.0"
 
 	for (const component of registry.components) {
@@ -160,59 +216,51 @@ export async function buildRegistry(
 			},
 		}
 
-		// Write manifest to components/[name].json
 		const packumentPath = join(componentsDir, `${component.name}.json`)
 		await Bun.write(packumentPath, JSON.stringify(packument, null, 2))
 
-		// Copy files (if any - bundles may have no files, only dependencies)
 		for (const rawFile of component.files) {
 			const file = normalizeFile(rawFile, component.type)
 			const sourceFilePath = join(sourcePath, "files", file.path)
-			const destFilePath = join(componentsDir, component.name, file.path)
-			const destFileDir = dirname(destFilePath)
+			const destinationPath = join(componentsDir, component.name, file.path)
+			const destinationDirectory = dirname(destinationPath)
 
 			if (!(await Bun.file(sourceFilePath).exists())) {
-				validationErrors.push(`${component.name}: Source file not found at ${sourceFilePath}`)
+				copyErrors.push(`${component.name}: Source file not found at ${sourceFilePath}`)
 				continue
 			}
 
-			await mkdir(destFileDir, { recursive: true })
-			const sourceFile = Bun.file(sourceFilePath)
-			await Bun.write(destFilePath, sourceFile)
+			await mkdir(destinationDirectory, { recursive: true })
+			await Bun.write(destinationPath, Bun.file(sourceFilePath))
 		}
 	}
 
-	// Fail fast if source files were missing during copy
-	if (validationErrors.length > 0) {
-		throw new BuildRegistryError(
-			`Build failed with ${validationErrors.length} errors`,
-			validationErrors,
-		)
+	if (copyErrors.length > 0) {
+		throw new BuildRegistryError(`Build failed with ${copyErrors.length} errors`, copyErrors)
 	}
 
-	// V2: Generate index.json at the root (no registry version field)
 	const index = {
 		$schema: registry.$schema,
 		name: registry.name,
 		version: registry.version,
 		author: registry.author,
-		// Include version requirements for compatibility checking
-		...(registry.opencode && { opencode: registry.opencode }),
-		...(registry.ocx && { ocx: registry.ocx }),
-		components: registry.components.map((c) => ({
-			name: c.name,
-			type: c.type,
-			description: c.description,
+		...(registry.opencode ? { opencode: registry.opencode } : {}),
+		...(registry.ocx ? { ocx: registry.ocx } : {}),
+		components: registry.components.map((component) => ({
+			name: component.name,
+			type: component.type,
+			description: component.description,
 		})),
 	}
 
 	await Bun.write(join(outPath, "index.json"), JSON.stringify(index, null, 2))
 
-	// Generate .well-known/ocx.json for registry discovery
-	const wellKnownDir = join(outPath, ".well-known")
-	await mkdir(wellKnownDir, { recursive: true })
-	const discovery = { registry: "/index.json" }
-	await Bun.write(join(wellKnownDir, "ocx.json"), JSON.stringify(discovery, null, 2))
+	const wellKnownDirectory = join(outPath, ".well-known")
+	await mkdir(wellKnownDirectory, { recursive: true })
+	await Bun.write(
+		join(wellKnownDirectory, "ocx.json"),
+		JSON.stringify({ registry: "/index.json" }, null, 2),
+	)
 
 	return {
 		componentsCount: registry.components.length,

--- a/packages/cli/src/lib/host-runtime-packages.ts
+++ b/packages/cli/src/lib/host-runtime-packages.ts
@@ -1,0 +1,77 @@
+import { mkdir } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+interface HostRuntimePackageDefinition {
+	version: string
+	entrypoint: string
+	moduleSource: string
+}
+
+/**
+ * Minimal CLI-owned runtime package map used for plugin loadability validation.
+ *
+ * These packages are treated as host-provided in OpenCode runtime environments,
+ * so validation seeds deterministic local stubs instead of requiring network installs.
+ */
+export const HOST_RUNTIME_PACKAGES: Record<string, HostRuntimePackageDefinition> = {
+	"@opencode-ai/plugin": {
+		version: "0.0.0-ocx-host-runtime",
+		entrypoint: "index.js",
+		moduleSource: [
+			"const chain = {",
+			"  describe() { return chain },",
+			"  optional() { return chain },",
+			"  min() { return chain },",
+			"  max() { return chain },",
+			"}",
+			"export const tool = Object.assign((definition) => definition, {",
+			"  schema: {",
+			"    string: () => chain,",
+			"  },",
+			"})",
+			"export default { tool }",
+		].join("\n"),
+	},
+}
+
+export function isHostRuntimePackage(packageName: string): boolean {
+	return Object.hasOwn(HOST_RUNTIME_PACKAGES, packageName)
+}
+
+export async function seedHostRuntimePackages(
+	validationWorkspaceRoot: string,
+	packageNames: Iterable<string>,
+): Promise<void> {
+	const nodeModulesDirectory = join(validationWorkspaceRoot, "node_modules")
+
+	for (const packageName of packageNames) {
+		const runtimeDefinition = HOST_RUNTIME_PACKAGES[packageName]
+		if (!runtimeDefinition) {
+			continue
+		}
+
+		const packageDirectory = join(nodeModulesDirectory, packageName)
+		await mkdir(packageDirectory, { recursive: true })
+
+		const packageJsonPath = join(packageDirectory, "package.json")
+		await Bun.write(
+			packageJsonPath,
+			JSON.stringify(
+				{
+					name: packageName,
+					version: runtimeDefinition.version,
+					type: "module",
+					exports: {
+						".": `./${runtimeDefinition.entrypoint}`,
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const entrypointPath = join(packageDirectory, runtimeDefinition.entrypoint)
+		await mkdir(dirname(entrypointPath), { recursive: true })
+		await Bun.write(entrypointPath, runtimeDefinition.moduleSource)
+	}
+}

--- a/packages/cli/src/lib/index.ts
+++ b/packages/cli/src/lib/index.ts
@@ -4,6 +4,7 @@
  * Pure functions for programmatic use.
  */
 
+export { ValidationFailedError } from "../utils/errors"
 export {
 	BuildRegistryError,
 	type BuildRegistryOptions,

--- a/packages/cli/src/lib/plugin-loadability.ts
+++ b/packages/cli/src/lib/plugin-loadability.ts
@@ -1,0 +1,1067 @@
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, extname, join, relative, resolve } from "node:path"
+import ts from "typescript"
+import { dedupePluginsByCanonicalName, extractCanonicalPluginName } from "../registry/merge"
+import type { Registry } from "../schemas/registry"
+import { normalizeComponentManifest, normalizeFile } from "../schemas/registry"
+import {
+	mergeNpmDependencySpecifiers,
+	parseNpmDependencySpecifier,
+} from "../utils/npm-dependencies"
+import { resolveTargetPath } from "../utils/paths"
+import {
+	HOST_RUNTIME_PACKAGES,
+	isHostRuntimePackage,
+	seedHostRuntimePackages,
+} from "./host-runtime-packages"
+import type { PluginLoadabilityIssue, PluginLoadabilityValidationResult } from "./validators"
+
+const VALIDATION_ROOT_PREFIX = "ocx-plugin-validation-"
+const RUNTIME_SMOKE_RESULT_FILE_PREFIX = ".ocx-plugin-runtime-smoke-"
+
+const ENTRYPOINT_EXTENSIONS = new Set([".ts", ".js"])
+
+const LOCAL_RESOLUTION_EXTENSIONS = [
+	"",
+	".ts",
+	".tsx",
+	".js",
+	".jsx",
+	".mts",
+	".cts",
+	".mjs",
+	".cjs",
+	".json",
+]
+
+const INDEX_CANDIDATES = [
+	"index.ts",
+	"index.tsx",
+	"index.js",
+	"index.jsx",
+	"index.mts",
+	"index.cts",
+	"index.mjs",
+	"index.cjs",
+	"index.json",
+]
+
+const NON_DETERMINISTIC_PLUGIN_VERSIONS = new Set(["*", "latest"])
+
+interface PackagePluginSpec {
+	rawSpecifier: string
+	packageName: string
+	version: string
+	components: string[]
+	deterministic: boolean
+}
+
+interface StaticAnalysisContext {
+	stagedFileSet: Set<string>
+	componentOwnersByRelativePath: Map<string, Set<string>>
+	issues: PluginLoadabilityIssue[]
+	externalImportsByPackage: Map<string, { components: Set<string>; entrypoints: Set<string> }>
+	entrypointsBlockedFromRuntime: Set<string>
+}
+
+export class PluginLoadabilityOperationalError extends Error {
+	constructor(
+		message: string,
+		public readonly details: string[] = [],
+	) {
+		super(message)
+		this.name = "PluginLoadabilityOperationalError"
+	}
+}
+
+export async function runPluginLoadabilityValidation(
+	registry: Registry,
+	sourcePath: string,
+): Promise<PluginLoadabilityValidationResult> {
+	const validationRoot = await mkdtemp(join(tmpdir(), VALIDATION_ROOT_PREFIX))
+
+	try {
+		const { stagedFileSet, componentOwnersByRelativePath, fileBackedEntrypoints, workspaceRoot } =
+			await stageRegistryInstallTree(registry, sourcePath, validationRoot)
+
+		const issues: PluginLoadabilityIssue[] = []
+
+		const packagePluginSpecs = collectPackagePluginSpecs(registry, issues)
+
+		const analysisContext: StaticAnalysisContext = {
+			stagedFileSet,
+			componentOwnersByRelativePath,
+			issues,
+			externalImportsByPackage: new Map(),
+			entrypointsBlockedFromRuntime: new Set(),
+		}
+
+		for (const entrypoint of fileBackedEntrypoints) {
+			await analyzeEntrypointStaticImports(entrypoint, validationRoot, analysisContext)
+		}
+
+		const manifestDependencyMerge = collectManifestDependencyMaps(registry, issues)
+
+		const declaredPackageNames = new Set<string>()
+		for (const packageName of manifestDependencyMerge.dependencies.keys()) {
+			declaredPackageNames.add(packageName)
+		}
+		for (const packageName of manifestDependencyMerge.devDependencies.keys()) {
+			declaredPackageNames.add(packageName)
+		}
+		for (const packagePluginSpec of packagePluginSpecs) {
+			declaredPackageNames.add(packagePluginSpec.packageName)
+		}
+		for (const hostPackageName of Object.keys(HOST_RUNTIME_PACKAGES)) {
+			declaredPackageNames.add(hostPackageName)
+		}
+
+		for (const [packageName, usage] of analysisContext.externalImportsByPackage.entries()) {
+			if (declaredPackageNames.has(packageName)) {
+				continue
+			}
+
+			issues.push(
+				createIssue({
+					code: "plugin_external_dependency_undeclared",
+					severity: "error",
+					message:
+						`Package "${packageName}" is imported by plugin entrypoint(s) ` +
+						`${Array.from(usage.entrypoints).sort().join(", ")} but is not declared in npmDependencies/npmDevDependencies`,
+					affectedComponents: Array.from(usage.components).sort(),
+					affectedEntrypoints: Array.from(usage.entrypoints).sort(),
+				}),
+			)
+
+			for (const entrypoint of usage.entrypoints) {
+				analysisContext.entrypointsBlockedFromRuntime.add(entrypoint)
+			}
+		}
+
+		const deterministicPackagePlugins = packagePluginSpecs.filter((spec) => spec.deterministic)
+
+		const runtimeFileEntrypoints = fileBackedEntrypoints.filter(
+			(entrypoint) => !analysisContext.entrypointsBlockedFromRuntime.has(entrypoint),
+		)
+
+		const runtimeTargets = [
+			...runtimeFileEntrypoints.map((entrypoint) => `./${entrypoint.replace(/^\.opencode\//, "")}`),
+			...deterministicPackagePlugins.map((spec) => spec.packageName),
+		]
+
+		if (runtimeTargets.length > 0) {
+			await writeValidationWorkspacePackageJson(
+				workspaceRoot,
+				manifestDependencyMerge.dependencies,
+				manifestDependencyMerge.devDependencies,
+				deterministicPackagePlugins,
+			)
+
+			const hostPackagesToSeed = new Set<string>()
+			for (const packageName of declaredPackageNames) {
+				if (isHostRuntimePackage(packageName)) {
+					hostPackagesToSeed.add(packageName)
+				}
+			}
+
+			const shouldHydrateDependencies = shouldHydrateManifestDependencies(
+				manifestDependencyMerge.dependencies,
+				manifestDependencyMerge.devDependencies,
+				deterministicPackagePlugins,
+			)
+
+			if (shouldHydrateDependencies) {
+				await hydrateWorkspaceDependencies(workspaceRoot)
+			}
+
+			if (hostPackagesToSeed.size > 0) {
+				await seedHostRuntimePackages(workspaceRoot, hostPackagesToSeed)
+			}
+
+			const runtimeFailures = await runRuntimeSmokeImports(workspaceRoot, runtimeTargets)
+
+			for (const failure of runtimeFailures) {
+				if (failure.target.startsWith("./")) {
+					const relativeEntrypoint = `.opencode/${failure.target.slice(2).replace(/\\/g, "/")}`
+					issues.push(
+						createIssue({
+							code: "plugin_runtime_entrypoint_import_failed",
+							severity: "error",
+							message: `${relativeEntrypoint}: Runtime import failed - ${failure.message}`,
+							affectedComponents: getOwnersForRelativePath(
+								relativeEntrypoint,
+								componentOwnersByRelativePath,
+							),
+							affectedEntrypoints: [relativeEntrypoint],
+						}),
+					)
+					continue
+				}
+
+				const matchingPackagePlugin = deterministicPackagePlugins.find(
+					(spec) => spec.packageName === failure.target,
+				)
+				issues.push(
+					createIssue({
+						code: "plugin_runtime_package_import_failed",
+						severity: "error",
+						message: `Package plugin "${failure.target}" failed runtime import - ${failure.message}`,
+						affectedComponents: matchingPackagePlugin?.components ?? [],
+						affectedEntrypoints: [
+							`package:${matchingPackagePlugin?.rawSpecifier ?? failure.target}`,
+						],
+					}),
+				)
+			}
+		}
+
+		const errors = issues
+			.filter((issue) => issue.severity === "error")
+			.map((issue) => issue.rendered)
+		const warnings = issues
+			.filter((issue) => issue.severity === "warning")
+			.map((issue) => issue.rendered)
+
+		return {
+			valid: errors.length === 0,
+			errors,
+			warnings,
+			issues,
+		}
+	} finally {
+		await rm(validationRoot, { recursive: true, force: true })
+	}
+}
+
+function collectManifestDependencyMaps(
+	registry: Registry,
+	issues: PluginLoadabilityIssue[],
+): {
+	dependencies: Map<string, string>
+	devDependencies: Map<string, string>
+} {
+	const npmDependencies: string[] = []
+	const npmDevDependencies: string[] = []
+
+	for (const component of registry.components) {
+		if (component.npmDependencies) {
+			npmDependencies.push(...component.npmDependencies)
+		}
+		if (component.npmDevDependencies) {
+			npmDevDependencies.push(...component.npmDevDependencies)
+		}
+	}
+
+	try {
+		return mergeNpmDependencySpecifiers(npmDependencies, npmDevDependencies)
+	} catch (error) {
+		issues.push(
+			createIssue({
+				code: "plugin_manifest_dependency_conflict",
+				severity: "error",
+				message: error instanceof Error ? error.message : String(error),
+				affectedComponents: [],
+				affectedEntrypoints: [],
+			}),
+		)
+		return {
+			dependencies: new Map(),
+			devDependencies: new Map(),
+		}
+	}
+}
+
+function collectPackagePluginSpecs(
+	registry: Registry,
+	issues: PluginLoadabilityIssue[],
+): PackagePluginSpec[] {
+	const allPluginSpecifiers: string[] = []
+	const ownerByCanonicalName = new Map<string, Set<string>>()
+
+	for (const component of registry.components) {
+		const normalizedComponent = normalizeComponentManifest(component)
+		const pluginSpecifiers = normalizedComponent.opencode?.plugin ?? []
+		for (const pluginSpecifier of pluginSpecifiers) {
+			allPluginSpecifiers.push(pluginSpecifier)
+
+			const canonicalName = extractCanonicalPluginName(pluginSpecifier)
+			if (!ownerByCanonicalName.has(canonicalName)) {
+				ownerByCanonicalName.set(canonicalName, new Set())
+			}
+			ownerByCanonicalName.get(canonicalName)?.add(component.name)
+		}
+	}
+
+	const dedupedSpecifiers = dedupePluginsByCanonicalName(allPluginSpecifiers)
+
+	if (!dedupedSpecifiers || dedupedSpecifiers.length === 0) {
+		return []
+	}
+
+	const collectedSpecs: PackagePluginSpec[] = []
+	for (const rawSpecifier of dedupedSpecifiers) {
+		const trimmedSpecifier = rawSpecifier.trim()
+		const owners = Array.from(
+			ownerByCanonicalName.get(extractCanonicalPluginName(rawSpecifier)) ?? [],
+		).sort()
+
+		if (!trimmedSpecifier) {
+			issues.push(
+				createIssue({
+					code: "plugin_package_spec_invalid",
+					severity: "error",
+					message: "Encountered an empty opencode.plugin package specifier",
+					affectedComponents: owners,
+					affectedEntrypoints: ["package:<empty>"],
+				}),
+			)
+			continue
+		}
+
+		if (isQualifiedCrossRegistrySpecifier(trimmedSpecifier)) {
+			issues.push(
+				createIssue({
+					code: "plugin_package_cross_registry_unsupported",
+					severity: "error",
+					message:
+						`Unsupported qualified cross-registry plugin dependency "${trimmedSpecifier}" in opencode.plugin. ` +
+						"Use npm package specifiers instead.",
+					affectedComponents: owners,
+					affectedEntrypoints: [`package:${trimmedSpecifier}`],
+				}),
+			)
+			continue
+		}
+
+		const withoutNpmPrefix = trimmedSpecifier.startsWith("npm:")
+			? trimmedSpecifier.slice(4)
+			: trimmedSpecifier
+
+		let parsedSpecifier: ReturnType<typeof parseNpmDependencySpecifier>
+		try {
+			parsedSpecifier = parseNpmDependencySpecifier(withoutNpmPrefix)
+		} catch (error) {
+			issues.push(
+				createIssue({
+					code: "plugin_package_spec_invalid",
+					severity: "error",
+					message:
+						`Invalid package plugin specifier "${trimmedSpecifier}": ` +
+						`${error instanceof Error ? error.message : String(error)}`,
+					affectedComponents: owners,
+					affectedEntrypoints: [`package:${trimmedSpecifier}`],
+				}),
+			)
+			continue
+		}
+
+		const deterministic = isDeterministicPluginSpecifier(trimmedSpecifier, parsedSpecifier.version)
+
+		if (!deterministic) {
+			issues.push(
+				createIssue({
+					code: "plugin_package_spec_nondeterministic",
+					severity: "warning",
+					message:
+						`Package plugin specifier "${trimmedSpecifier}" is non-deterministic and cannot be fully prevalidated. ` +
+						"Prefer an exact pinned version.",
+					affectedComponents: owners,
+					affectedEntrypoints: [`package:${trimmedSpecifier}`],
+				}),
+			)
+		}
+
+		collectedSpecs.push({
+			rawSpecifier: trimmedSpecifier,
+			packageName: parsedSpecifier.name,
+			version: parsedSpecifier.version,
+			components: owners,
+			deterministic,
+		})
+	}
+
+	return collectedSpecs
+}
+
+function isDeterministicPluginSpecifier(specifier: string, parsedVersion: string): boolean {
+	const normalizedSpecifier = specifier.startsWith("npm:") ? specifier.slice(4) : specifier
+	const hasExplicitVersion = hasExplicitSpecifierVersion(normalizedSpecifier)
+
+	if (!hasExplicitVersion) {
+		return false
+	}
+
+	return !NON_DETERMINISTIC_PLUGIN_VERSIONS.has(parsedVersion.toLowerCase())
+}
+
+function hasExplicitSpecifierVersion(specifier: string): boolean {
+	if (!specifier) {
+		return false
+	}
+
+	if (specifier.startsWith("@")) {
+		const slashIndex = specifier.indexOf("/")
+		if (slashIndex === -1) {
+			return false
+		}
+		const packagePortion = specifier.slice(slashIndex + 1)
+		return packagePortion.includes("@")
+	}
+
+	return specifier.includes("@")
+}
+
+function isQualifiedCrossRegistrySpecifier(specifier: string): boolean {
+	if (specifier.startsWith("@") || specifier.startsWith("npm:")) {
+		return false
+	}
+
+	return /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*(?:@.+)?$/.test(specifier)
+}
+
+async function stageRegistryInstallTree(
+	registry: Registry,
+	sourcePath: string,
+	validationRoot: string,
+): Promise<{
+	stagedFileSet: Set<string>
+	componentOwnersByRelativePath: Map<string, Set<string>>
+	fileBackedEntrypoints: string[]
+	workspaceRoot: string
+}> {
+	const stagedFileSet = new Set<string>()
+	const componentOwnersByRelativePath = new Map<string, Set<string>>()
+
+	for (const component of registry.components) {
+		for (const rawFile of component.files) {
+			const file = normalizeFile(rawFile, component.type)
+			const sourceFilePath = join(sourcePath, "files", file.path)
+			if (!(await Bun.file(sourceFilePath).exists())) {
+				continue
+			}
+
+			const resolvedTarget = resolveTargetPath(file.target, false, validationRoot)
+			const targetPath = resolve(validationRoot, resolvedTarget)
+
+			await mkdir(dirname(targetPath), { recursive: true })
+			await Bun.write(targetPath, Bun.file(sourceFilePath))
+
+			const normalizedRelativePath = relative(validationRoot, targetPath).replace(/\\/g, "/")
+			stagedFileSet.add(resolve(targetPath))
+
+			if (!componentOwnersByRelativePath.has(normalizedRelativePath)) {
+				componentOwnersByRelativePath.set(normalizedRelativePath, new Set())
+			}
+			componentOwnersByRelativePath.get(normalizedRelativePath)?.add(component.name)
+		}
+	}
+
+	const workspaceRoot = join(validationRoot, ".opencode")
+	const fileBackedEntrypoints = await discoverFileBackedEntrypoints(workspaceRoot)
+
+	return {
+		stagedFileSet,
+		componentOwnersByRelativePath,
+		fileBackedEntrypoints,
+		workspaceRoot,
+	}
+}
+
+async function discoverFileBackedEntrypoints(workspaceRoot: string): Promise<string[]> {
+	const entrypoints: string[] = []
+	const pluginsDirectory = join(workspaceRoot, "plugins")
+
+	try {
+		await collectPluginEntrypointsRecursively(pluginsDirectory, pluginsDirectory, entrypoints)
+	} catch {
+		return entrypoints
+	}
+
+	return entrypoints.sort()
+}
+
+async function collectPluginEntrypointsRecursively(
+	currentDirectory: string,
+	pluginsRoot: string,
+	entrypoints: string[],
+): Promise<void> {
+	const directoryEntries = await readdir(currentDirectory, { withFileTypes: true })
+
+	for (const directoryEntry of directoryEntries) {
+		const entryPath = join(currentDirectory, directoryEntry.name)
+
+		if (directoryEntry.isDirectory()) {
+			await collectPluginEntrypointsRecursively(entryPath, pluginsRoot, entrypoints)
+			continue
+		}
+
+		if (!directoryEntry.isFile()) {
+			continue
+		}
+
+		const extension = extname(directoryEntry.name).toLowerCase()
+		if (!ENTRYPOINT_EXTENSIONS.has(extension)) {
+			continue
+		}
+
+		const pluginRelativePath = relative(pluginsRoot, entryPath).replace(/\\/g, "/")
+		entrypoints.push(`.opencode/plugins/${pluginRelativePath}`)
+	}
+}
+
+async function analyzeEntrypointStaticImports(
+	entrypointRelativePath: string,
+	validationRoot: string,
+	context: StaticAnalysisContext,
+): Promise<void> {
+	const entrypointAbsolutePath = resolve(validationRoot, entrypointRelativePath)
+	const queue: string[] = [entrypointAbsolutePath]
+	const visited = new Set<string>()
+
+	while (queue.length > 0) {
+		const currentPath = queue.shift()
+		if (!currentPath || visited.has(currentPath)) {
+			continue
+		}
+		visited.add(currentPath)
+
+		const sourceFile = Bun.file(currentPath)
+		if (!(await sourceFile.exists())) {
+			context.issues.push(
+				createIssue({
+					code: "plugin_entrypoint_missing_file",
+					severity: "error",
+					message: `${entrypointRelativePath}: Missing file "${toRelativeStagedPath(currentPath)}"`,
+					affectedComponents: getOwnersForAbsolutePath(
+						currentPath,
+						context.componentOwnersByRelativePath,
+					),
+					affectedEntrypoints: [entrypointRelativePath],
+				}),
+			)
+			context.entrypointsBlockedFromRuntime.add(entrypointRelativePath)
+			continue
+		}
+
+		const sourceContent = await sourceFile.text()
+		const parseResult = parseStaticValueSpecifiers(currentPath, sourceContent)
+		if (parseResult.parseError) {
+			context.issues.push(
+				createIssue({
+					code: "plugin_entrypoint_syntax_error",
+					severity: "error",
+					message:
+						`${entrypointRelativePath}: Invalid syntax in "${toRelativeStagedPath(currentPath)}" - ` +
+						`${parseResult.parseError}`,
+					affectedComponents: getOwnersForAbsolutePath(
+						currentPath,
+						context.componentOwnersByRelativePath,
+					),
+					affectedEntrypoints: [entrypointRelativePath],
+				}),
+			)
+			context.entrypointsBlockedFromRuntime.add(entrypointRelativePath)
+			continue
+		}
+
+		for (const specifier of parseResult.valueSpecifiers) {
+			if (isRelativeSpecifier(specifier)) {
+				const resolvedSpecifier = resolveRelativeSpecifier(
+					currentPath,
+					specifier,
+					context.stagedFileSet,
+				)
+				if (!resolvedSpecifier) {
+					context.issues.push(
+						createIssue({
+							code: "plugin_static_local_import_unresolved",
+							severity: "error",
+							message:
+								`${entrypointRelativePath}: Cannot resolve static import "${specifier}" ` +
+								`from "${toRelativeStagedPath(currentPath)}"`,
+							affectedComponents: getOwnersForAbsolutePath(
+								currentPath,
+								context.componentOwnersByRelativePath,
+							),
+							affectedEntrypoints: [entrypointRelativePath],
+						}),
+					)
+					context.entrypointsBlockedFromRuntime.add(entrypointRelativePath)
+					continue
+				}
+
+				if (!visited.has(resolvedSpecifier)) {
+					queue.push(resolvedSpecifier)
+				}
+				continue
+			}
+
+			const packageName = extractPackageNameFromImportSpecifier(specifier)
+			if (!packageName) {
+				continue
+			}
+
+			if (!context.externalImportsByPackage.has(packageName)) {
+				context.externalImportsByPackage.set(packageName, {
+					components: new Set(),
+					entrypoints: new Set(),
+				})
+			}
+
+			const usage = context.externalImportsByPackage.get(packageName)
+			usage?.entrypoints.add(entrypointRelativePath)
+			for (const owner of getOwnersForAbsolutePath(
+				currentPath,
+				context.componentOwnersByRelativePath,
+			)) {
+				usage?.components.add(owner)
+			}
+		}
+	}
+}
+
+function parseStaticValueSpecifiers(
+	filePath: string,
+	content: string,
+): { valueSpecifiers: string[]; parseError?: string } {
+	const sourceFile = ts.createSourceFile(
+		filePath,
+		content,
+		ts.ScriptTarget.Latest,
+		true,
+		getScriptKind(filePath),
+	)
+
+	const parseDiagnostics =
+		(sourceFile as { parseDiagnostics?: readonly ts.DiagnosticWithLocation[] }).parseDiagnostics ??
+		[]
+	if (parseDiagnostics.length > 0) {
+		const firstDiagnostic = parseDiagnostics[0]
+		if (firstDiagnostic) {
+			return {
+				valueSpecifiers: [],
+				parseError: ts.flattenDiagnosticMessageText(firstDiagnostic.messageText, "\n"),
+			}
+		}
+	}
+
+	const valueSpecifiers: string[] = []
+	for (const statement of sourceFile.statements) {
+		if (ts.isImportDeclaration(statement)) {
+			if (!hasRuntimeImportBinding(statement)) {
+				continue
+			}
+
+			if (ts.isStringLiteral(statement.moduleSpecifier)) {
+				valueSpecifiers.push(statement.moduleSpecifier.text)
+			}
+			continue
+		}
+
+		if (ts.isExportDeclaration(statement)) {
+			if (!hasRuntimeReExportBinding(statement)) {
+				continue
+			}
+
+			if (statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)) {
+				valueSpecifiers.push(statement.moduleSpecifier.text)
+			}
+			continue
+		}
+
+		if (ts.isImportEqualsDeclaration(statement)) {
+			if ((statement as { isTypeOnly?: boolean }).isTypeOnly) {
+				continue
+			}
+
+			if (ts.isExternalModuleReference(statement.moduleReference)) {
+				const expression = statement.moduleReference.expression
+				if (expression && ts.isStringLiteral(expression)) {
+					valueSpecifiers.push(expression.text)
+				}
+			}
+		}
+	}
+
+	return { valueSpecifiers }
+}
+
+function hasRuntimeImportBinding(importDeclaration: ts.ImportDeclaration): boolean {
+	const importClause = importDeclaration.importClause
+	if (!importClause) {
+		return true
+	}
+
+	if (importClause.isTypeOnly) {
+		return false
+	}
+
+	if (importClause.name) {
+		return true
+	}
+
+	if (!importClause.namedBindings) {
+		return false
+	}
+
+	if (ts.isNamespaceImport(importClause.namedBindings)) {
+		return true
+	}
+
+	if (importClause.namedBindings.elements.length === 0) {
+		return true
+	}
+
+	return importClause.namedBindings.elements.some((element) => !element.isTypeOnly)
+}
+
+function hasRuntimeReExportBinding(exportDeclaration: ts.ExportDeclaration): boolean {
+	if (exportDeclaration.isTypeOnly) {
+		return false
+	}
+
+	if (!exportDeclaration.exportClause) {
+		return true
+	}
+
+	if (!ts.isNamedExports(exportDeclaration.exportClause)) {
+		return true
+	}
+
+	if (exportDeclaration.exportClause.elements.length === 0) {
+		return true
+	}
+
+	return exportDeclaration.exportClause.elements.some((element) => !element.isTypeOnly)
+}
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+	const extension = extname(filePath).toLowerCase()
+	if (extension === ".js" || extension === ".mjs" || extension === ".cjs") {
+		return ts.ScriptKind.JS
+	}
+	if (extension === ".jsx") {
+		return ts.ScriptKind.JSX
+	}
+	if (extension === ".tsx") {
+		return ts.ScriptKind.TSX
+	}
+	return ts.ScriptKind.TS
+}
+
+function resolveRelativeSpecifier(
+	importerAbsolutePath: string,
+	importSpecifier: string,
+	stagedFileSet: Set<string>,
+): string | null {
+	const normalizedSpecifier = stripSpecifierQuery(importSpecifier)
+	const candidateBasePath = resolve(dirname(importerAbsolutePath), normalizedSpecifier)
+	const hasExplicitExtension = extname(normalizedSpecifier).length > 0
+
+	if (hasExplicitExtension) {
+		const explicitPath = resolve(candidateBasePath)
+		return stagedFileSet.has(explicitPath) ? explicitPath : null
+	}
+
+	for (const extension of LOCAL_RESOLUTION_EXTENSIONS) {
+		const candidatePath = resolve(`${candidateBasePath}${extension}`)
+		if (stagedFileSet.has(candidatePath)) {
+			return candidatePath
+		}
+	}
+
+	for (const indexCandidate of INDEX_CANDIDATES) {
+		const candidatePath = resolve(join(candidateBasePath, indexCandidate))
+		if (stagedFileSet.has(candidatePath)) {
+			return candidatePath
+		}
+	}
+
+	return null
+}
+
+function stripSpecifierQuery(specifier: string): string {
+	const queryIndex = specifier.indexOf("?")
+	const hashIndex = specifier.indexOf("#")
+
+	let endIndex = specifier.length
+	if (queryIndex >= 0) {
+		endIndex = Math.min(endIndex, queryIndex)
+	}
+	if (hashIndex >= 0) {
+		endIndex = Math.min(endIndex, hashIndex)
+	}
+
+	return specifier.slice(0, endIndex)
+}
+
+function isRelativeSpecifier(specifier: string): boolean {
+	return specifier.startsWith("./") || specifier.startsWith("../")
+}
+
+function extractPackageNameFromImportSpecifier(specifier: string): string | null {
+	if (!specifier) {
+		return null
+	}
+
+	const normalizedSpecifier = specifier.startsWith("npm:") ? specifier.slice(4) : specifier
+
+	if (
+		normalizedSpecifier.startsWith("./") ||
+		normalizedSpecifier.startsWith("../") ||
+		normalizedSpecifier.startsWith("/") ||
+		normalizedSpecifier.startsWith("node:") ||
+		normalizedSpecifier.startsWith("bun:") ||
+		normalizedSpecifier.startsWith("file:") ||
+		normalizedSpecifier.startsWith("data:") ||
+		normalizedSpecifier.startsWith("http:") ||
+		normalizedSpecifier.startsWith("https:") ||
+		normalizedSpecifier.startsWith("#")
+	) {
+		return null
+	}
+
+	if (normalizedSpecifier.startsWith("@")) {
+		const segments = normalizedSpecifier.split("/")
+		if (segments.length < 2) {
+			return normalizedSpecifier
+		}
+		return `${segments[0]}/${segments[1]}`
+	}
+
+	const [packageName] = normalizedSpecifier.split("/")
+	return packageName ?? null
+}
+
+async function writeValidationWorkspacePackageJson(
+	workspaceRoot: string,
+	manifestDependencies: Map<string, string>,
+	manifestDevDependencies: Map<string, string>,
+	packagePlugins: PackagePluginSpec[],
+): Promise<void> {
+	const dependencies = new Map(manifestDependencies)
+	const devDependencies = new Map(manifestDevDependencies)
+
+	for (const hostPackageName of Object.keys(HOST_RUNTIME_PACKAGES)) {
+		dependencies.delete(hostPackageName)
+		devDependencies.delete(hostPackageName)
+	}
+
+	for (const packagePlugin of packagePlugins) {
+		if (!packagePlugin.deterministic || isHostRuntimePackage(packagePlugin.packageName)) {
+			continue
+		}
+		dependencies.set(packagePlugin.packageName, packagePlugin.version)
+	}
+
+	const packageJson = {
+		name: "ocx-plugin-validation-workspace",
+		private: true,
+		type: "module",
+		dependencies: Object.fromEntries(dependencies),
+		devDependencies: Object.fromEntries(devDependencies),
+	}
+
+	await mkdir(workspaceRoot, { recursive: true })
+	await Bun.write(join(workspaceRoot, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`)
+}
+
+function shouldHydrateManifestDependencies(
+	manifestDependencies: Map<string, string>,
+	manifestDevDependencies: Map<string, string>,
+	packagePlugins: PackagePluginSpec[],
+): boolean {
+	for (const packageName of manifestDependencies.keys()) {
+		if (!isHostRuntimePackage(packageName)) {
+			return true
+		}
+	}
+
+	for (const packageName of manifestDevDependencies.keys()) {
+		if (!isHostRuntimePackage(packageName)) {
+			return true
+		}
+	}
+
+	for (const packagePlugin of packagePlugins) {
+		if (packagePlugin.deterministic && !isHostRuntimePackage(packagePlugin.packageName)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+async function hydrateWorkspaceDependencies(workspaceRoot: string): Promise<void> {
+	const installProcess = Bun.spawn(["bun", "install", "--ignore-scripts"], {
+		cwd: workspaceRoot,
+		env: {
+			...process.env,
+			NO_COLOR: "1",
+			FORCE_COLOR: "0",
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	})
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(installProcess.stdout).text(),
+		new Response(installProcess.stderr).text(),
+		installProcess.exited,
+	])
+
+	if (exitCode === 0) {
+		return
+	}
+
+	throw new PluginLoadabilityOperationalError(
+		"Failed to hydrate plugin validation dependencies in isolated workspace",
+		[
+			`exitCode=${exitCode}`,
+			...(stderr.trim() ? [stderr.trim()] : []),
+			...(stdout.trim() ? [stdout.trim()] : []),
+		],
+	)
+}
+
+async function runRuntimeSmokeImports(
+	workspaceRoot: string,
+	targets: string[],
+): Promise<Array<{ target: string; message: string }>> {
+	if (targets.length === 0) {
+		return []
+	}
+
+	const runtimeResultFilePath = join(
+		workspaceRoot,
+		`${RUNTIME_SMOKE_RESULT_FILE_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+	)
+
+	const runtimeScript = [
+		"const targets = JSON.parse(process.env.OCX_PLUGIN_RUNTIME_TARGETS ?? '[]')",
+		"const resultFilePath = process.env.OCX_PLUGIN_RUNTIME_RESULT_FILE",
+		"if (!resultFilePath) {",
+		"  throw new Error('Missing OCX_PLUGIN_RUNTIME_RESULT_FILE')",
+		"}",
+		"const failures = []",
+		"for (const target of targets) {",
+		"  try {",
+		"    await import(target)",
+		"  } catch (error) {",
+		"    failures.push({",
+		"      target,",
+		"      message: error instanceof Error ? error.message : String(error),",
+		"    })",
+		"  }",
+		"}",
+		"await Bun.write(resultFilePath, JSON.stringify({ failures }))",
+	].join("\n")
+
+	const runtimeProcess = Bun.spawn(["bun", "--eval", runtimeScript], {
+		cwd: workspaceRoot,
+		env: {
+			...process.env,
+			NO_COLOR: "1",
+			FORCE_COLOR: "0",
+			OCX_PLUGIN_RUNTIME_TARGETS: JSON.stringify(targets),
+			OCX_PLUGIN_RUNTIME_RESULT_FILE: runtimeResultFilePath,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	})
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(runtimeProcess.stdout).text(),
+		new Response(runtimeProcess.stderr).text(),
+		runtimeProcess.exited,
+	])
+
+	try {
+		if (exitCode !== 0) {
+			throw new PluginLoadabilityOperationalError(
+				"Failed to execute plugin runtime smoke imports in isolated workspace",
+				[
+					`exitCode=${exitCode}`,
+					...(stderr.trim() ? [stderr.trim()] : []),
+					...(stdout.trim() ? [stdout.trim()] : []),
+				],
+			)
+		}
+
+		const resultFile = Bun.file(runtimeResultFilePath)
+		if (!(await resultFile.exists())) {
+			throw new PluginLoadabilityOperationalError(
+				"Plugin runtime smoke imports did not produce a result file",
+				[
+					`resultFile=${runtimeResultFilePath}`,
+					...(stderr.trim() ? [stderr.trim()] : []),
+					...(stdout.trim() ? [stdout.trim()] : []),
+				],
+			)
+		}
+
+		const parsedOutput = JSON.parse(await resultFile.text()) as {
+			failures?: Array<{ target: string; message: string }>
+		}
+		return parsedOutput.failures ?? []
+	} catch (error) {
+		if (error instanceof PluginLoadabilityOperationalError) {
+			throw error
+		}
+
+		throw new PluginLoadabilityOperationalError("Failed to parse plugin runtime smoke output", [
+			`parseError=${error instanceof Error ? error.message : String(error)}`,
+			`resultFile=${runtimeResultFilePath}`,
+			...(stderr.trim() ? [stderr.trim()] : []),
+			...(stdout.trim() ? [stdout.trim()] : []),
+		])
+	} finally {
+		await rm(runtimeResultFilePath, { force: true }).catch(() => undefined)
+	}
+}
+
+function toRelativeStagedPath(absolutePath: string): string {
+	const normalized = absolutePath.replace(/\\/g, "/")
+	const marker = normalized.lastIndexOf("/.opencode/")
+	if (marker === -1) {
+		return normalized
+	}
+	return normalized.slice(marker + 1)
+}
+
+function getOwnersForAbsolutePath(
+	absPath: string,
+	componentOwnersByRelativePath: Map<string, Set<string>>,
+): string[] {
+	return getOwnersForRelativePath(toRelativeStagedPath(absPath), componentOwnersByRelativePath)
+}
+
+function getOwnersForRelativePath(
+	relativePath: string,
+	componentOwnersByRelativePath: Map<string, Set<string>>,
+): string[] {
+	const owners = componentOwnersByRelativePath.get(relativePath)
+	if (!owners) {
+		return []
+	}
+	return Array.from(owners).sort()
+}
+
+function createIssue(issue: {
+	code: PluginLoadabilityIssue["code"]
+	severity: PluginLoadabilityIssue["severity"]
+	message: string
+	affectedComponents: string[]
+	affectedEntrypoints: string[]
+}): PluginLoadabilityIssue {
+	return {
+		kind: "plugin_loadability",
+		code: issue.code,
+		severity: issue.severity,
+		message: issue.message,
+		rendered: `Plugin loadability: ${issue.message}`,
+		affectedComponents: issue.affectedComponents,
+		affectedEntrypoints: issue.affectedEntrypoints,
+	}
+}

--- a/packages/cli/src/lib/plugin-loadability.ts
+++ b/packages/cli/src/lib/plugin-loadability.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import { builtinModules } from "node:module"
 import { tmpdir } from "node:os"
 import { dirname, extname, join, relative, resolve } from "node:path"
 import ts from "typescript"
@@ -20,7 +21,16 @@ import type { PluginLoadabilityIssue, PluginLoadabilityValidationResult } from "
 const VALIDATION_ROOT_PREFIX = "ocx-plugin-validation-"
 const RUNTIME_SMOKE_RESULT_FILE_PREFIX = ".ocx-plugin-runtime-smoke-"
 
-const ENTRYPOINT_EXTENSIONS = new Set([".ts", ".js"])
+const ENTRYPOINT_EXTENSIONS = new Set([
+	".ts",
+	".js",
+	".mjs",
+	".cjs",
+	".mts",
+	".cts",
+	".tsx",
+	".jsx",
+])
 
 const LOCAL_RESOLUTION_EXTENSIONS = [
 	"",
@@ -48,6 +58,15 @@ const INDEX_CANDIDATES = [
 ]
 
 const NON_DETERMINISTIC_PLUGIN_VERSIONS = new Set(["*", "latest"])
+
+const EXACT_PINNED_SEMVER_VERSION =
+	/^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+
+const NODE_BUILTIN_PACKAGE_NAMES = new Set(
+	builtinModules
+		.map((moduleName) => (moduleName.startsWith("node:") ? moduleName.slice(5) : moduleName))
+		.map((moduleName) => moduleName.split("/")[0] ?? moduleName),
+)
 
 interface PackagePluginSpec {
 	rawSpecifier: string
@@ -392,7 +411,24 @@ function isDeterministicPluginSpecifier(specifier: string, parsedVersion: string
 		return false
 	}
 
-	return !NON_DETERMINISTIC_PLUGIN_VERSIONS.has(parsedVersion.toLowerCase())
+	return isDeterministicPluginVersion(parsedVersion)
+}
+
+function isDeterministicPluginVersion(version: string): boolean {
+	const normalizedVersion = version.trim()
+	if (!normalizedVersion) {
+		return false
+	}
+
+	if (normalizedVersion.startsWith("file:")) {
+		return true
+	}
+
+	if (NON_DETERMINISTIC_PLUGIN_VERSIONS.has(normalizedVersion.toLowerCase())) {
+		return false
+	}
+
+	return EXACT_PINNED_SEMVER_VERSION.test(normalizedVersion)
 }
 
 function hasExplicitSpecifierVersion(specifier: string): boolean {
@@ -805,7 +841,14 @@ function extractPackageNameFromImportSpecifier(specifier: string): string | null
 		return null
 	}
 
-	const normalizedSpecifier = specifier.startsWith("npm:") ? specifier.slice(4) : specifier
+	const isNpmProtocolImport = specifier.startsWith("npm:")
+	const normalizedSpecifier = stripSpecifierQuery(
+		isNpmProtocolImport ? specifier.slice(4) : specifier,
+	).trim()
+
+	if (!normalizedSpecifier) {
+		return null
+	}
 
 	if (
 		normalizedSpecifier.startsWith("./") ||
@@ -822,16 +865,59 @@ function extractPackageNameFromImportSpecifier(specifier: string): string | null
 		return null
 	}
 
+	if (isNpmProtocolImport) {
+		return extractNpmProtocolPackageName(normalizedSpecifier)
+	}
+
 	if (normalizedSpecifier.startsWith("@")) {
 		const segments = normalizedSpecifier.split("/")
 		if (segments.length < 2) {
 			return normalizedSpecifier
 		}
-		return `${segments[0]}/${segments[1]}`
+		const packageName = `${segments[0]}/${segments[1]}`
+		if (NODE_BUILTIN_PACKAGE_NAMES.has(packageName)) {
+			return null
+		}
+		return packageName
 	}
 
 	const [packageName] = normalizedSpecifier.split("/")
+	if (!packageName) {
+		return null
+	}
+
+	if (NODE_BUILTIN_PACKAGE_NAMES.has(packageName)) {
+		return null
+	}
+
 	return packageName ?? null
+}
+
+function extractNpmProtocolPackageName(specifier: string): string | null {
+	if (specifier.startsWith("@")) {
+		const segments = specifier.split("/")
+		if (segments.length < 2 || !segments[0] || !segments[1]) {
+			return null
+		}
+
+		const packageWithVersion = `${segments[0]}/${segments[1]}`
+		return safelyParseDependencyName(packageWithVersion)
+	}
+
+	const [packageWithVersion] = specifier.split("/")
+	if (!packageWithVersion) {
+		return null
+	}
+
+	return safelyParseDependencyName(packageWithVersion)
+}
+
+function safelyParseDependencyName(specifier: string): string {
+	try {
+		return parseNpmDependencySpecifier(specifier).name
+	} catch {
+		return specifier
+	}
 }
 
 async function writeValidationWorkspacePackageJson(

--- a/packages/cli/src/lib/validation-runner.ts
+++ b/packages/cli/src/lib/validation-runner.ts
@@ -8,16 +8,20 @@ import type { Registry } from "../schemas/registry"
 import {
 	type LoadRegistryErrorKind,
 	loadRegistrySource,
+	PluginLoadabilityOperationalError,
+	type RegistryValidationIssue,
 	type ValidateRegistryOptions,
+	validateRegistryRules,
 	validateRegistrySchema,
-	validateRegistryWithOptions,
 } from "./validators"
 
-export type ValidationFailureType = "load" | "schema" | "rules"
+export type ValidationFailureType = "load" | "schema" | "rules" | "operational"
 
 export interface CompleteValidationResult {
 	success: boolean
 	errors: string[]
+	warnings: string[]
+	issues: RegistryValidationIssue[]
 	registry?: Registry
 	failureType?: ValidationFailureType
 	loadErrorKind?: LoadRegistryErrorKind
@@ -25,59 +29,71 @@ export interface CompleteValidationResult {
 
 /**
  * Run complete validation workflow: load, validate schema, and run all validators.
- *
- * @param sourcePath - Path to the registry source directory
- * @param options - Validation options
- * @returns Validation result with registry data if successful
  */
 export async function runCompleteValidation(
 	sourcePath: string,
 	options: ValidateRegistryOptions = {},
 ): Promise<CompleteValidationResult> {
-	// Load registry file
 	const loadResult = await loadRegistrySource(sourcePath)
 	if (!loadResult.success) {
 		return {
 			success: false,
 			errors: [loadResult.error || "Failed to load registry"],
+			warnings: [],
+			issues: [],
 			failureType: "load",
 			loadErrorKind: loadResult.errorKind,
 		}
 	}
 
-	// Validate schema (compatibility + structure)
 	const schemaResult = validateRegistrySchema(loadResult.data, sourcePath)
 	if (!schemaResult.valid) {
 		return {
 			success: false,
 			errors: schemaResult.errors,
+			warnings: schemaResult.warnings ?? [],
+			issues: schemaResult.issues ?? [],
 			failureType: "schema",
 		}
 	}
 
-	// Use the parsed and validated registry data
 	const registry = schemaResult.data
 	if (!registry) {
 		throw new Error("Registry validation succeeded but returned no parsed data")
 	}
 
-	// Collect all validation errors
-	const validationErrors: string[] = []
-	for await (const error of validateRegistryWithOptions(registry, sourcePath, options)) {
-		validationErrors.push(error)
-	}
+	try {
+		const rulesResult = await validateRegistryRules(registry, sourcePath, options)
 
-	if (validationErrors.length > 0) {
-		return {
-			success: false,
-			errors: validationErrors,
-			failureType: "rules",
+		if (!rulesResult.valid) {
+			return {
+				success: false,
+				errors: rulesResult.errors,
+				warnings: rulesResult.warnings ?? [],
+				issues: rulesResult.issues ?? [],
+				registry,
+				failureType: "rules",
+			}
 		}
-	}
 
-	return {
-		success: true,
-		errors: [],
-		registry,
+		return {
+			success: true,
+			errors: [],
+			warnings: rulesResult.warnings ?? [],
+			issues: rulesResult.issues ?? [],
+			registry,
+		}
+	} catch (error) {
+		if (error instanceof PluginLoadabilityOperationalError) {
+			return {
+				success: false,
+				errors: [error.message, ...error.details],
+				warnings: [],
+				issues: [],
+				failureType: "operational",
+			}
+		}
+
+		throw error
 	}
 }

--- a/packages/cli/src/lib/validators.ts
+++ b/packages/cli/src/lib/validators.ts
@@ -9,11 +9,61 @@ import { join, posix } from "node:path"
 import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 import type { Registry } from "../schemas/registry"
 import { classifyRegistrySchemaIssue, normalizeFile, registrySchema } from "../schemas/registry"
+import {
+	PluginLoadabilityOperationalError,
+	runPluginLoadabilityValidation,
+} from "./plugin-loadability"
+
+export type ValidationIssueSeverity = "error" | "warning"
+
+export type ValidationIssueKind =
+	| "schema"
+	| "source_file"
+	| "circular_dependency"
+	| "duplicate_target"
+	| "plugin_loadability"
+
+export interface ValidationIssue {
+	kind: ValidationIssueKind
+	code: string
+	severity: ValidationIssueSeverity
+	message: string
+	rendered: string
+	affectedComponents: string[]
+	affectedEntrypoints: string[]
+}
+
+export type PluginLoadabilityIssueCode =
+	| "plugin_entrypoint_missing_file"
+	| "plugin_entrypoint_syntax_error"
+	| "plugin_static_local_import_unresolved"
+	| "plugin_external_dependency_undeclared"
+	| "plugin_manifest_dependency_conflict"
+	| "plugin_package_spec_invalid"
+	| "plugin_package_cross_registry_unsupported"
+	| "plugin_package_spec_nondeterministic"
+	| "plugin_runtime_entrypoint_import_failed"
+	| "plugin_runtime_package_import_failed"
+
+export interface PluginLoadabilityIssue extends ValidationIssue {
+	kind: "plugin_loadability"
+	code: PluginLoadabilityIssueCode
+}
+
+export interface PluginLoadabilityValidationResult {
+	valid: boolean
+	errors: string[]
+	warnings: string[]
+	issues: PluginLoadabilityIssue[]
+}
+
+export type RegistryValidationIssue = ValidationIssue | PluginLoadabilityIssue
 
 export interface ValidationResult<T = unknown> {
 	valid: boolean
 	errors: string[]
 	warnings?: string[]
+	issues?: RegistryValidationIssue[]
 	data?: T
 }
 
@@ -42,14 +92,46 @@ function formatJsoncParseError(parseErrors: ParseError[]): string {
 	return `${printParseErrorCode(firstError.error)} at offset ${firstError.offset}`
 }
 
+function createIssue(input: {
+	kind: ValidationIssueKind
+	code: string
+	severity?: ValidationIssueSeverity
+	message: string
+	rendered?: string
+	affectedComponents?: string[]
+	affectedEntrypoints?: string[]
+}): ValidationIssue {
+	const severity = input.severity ?? "error"
+	return {
+		kind: input.kind,
+		code: input.code,
+		severity,
+		message: input.message,
+		rendered: input.rendered ?? input.message,
+		affectedComponents: input.affectedComponents ?? [],
+		affectedEntrypoints: input.affectedEntrypoints ?? [],
+	}
+}
+
+function toValidationResultFromIssues(issues: RegistryValidationIssue[]): ValidationResult {
+	const errors = issues.filter((issue) => issue.severity === "error").map((issue) => issue.rendered)
+	const warnings = issues
+		.filter((issue) => issue.severity === "warning")
+		.map((issue) => issue.rendered)
+
+	return {
+		valid: errors.length === 0,
+		errors,
+		...(warnings.length > 0 ? { warnings } : {}),
+		issues,
+	}
+}
+
 /**
  * Load and parse a registry source file from a directory.
  *
  * Looks for registry.jsonc first, then registry.json.
  * Supports JSONC format with comments and trailing commas.
- *
- * @param sourcePath - Path to the directory containing the registry file
- * @returns Result with parsed data or error message
  */
 export async function loadRegistrySource(sourcePath: string): Promise<LoadRegistryResult> {
 	const jsoncFile = Bun.file(`${sourcePath}/registry.jsonc`)
@@ -89,37 +171,30 @@ export async function loadRegistrySource(sourcePath: string): Promise<LoadRegist
 
 /**
  * Validate a registry's schema compatibility and structure.
- *
- * This combines schema compatibility check (v1 vs v2) with schema validation.
- * It's a higher-level function that includes both checks.
- *
- * @param registryData - The parsed registry object
- * @param sourcePath - Path to the registry source (for error messages)
- * @returns Validation result with parsed data
  */
 export function validateRegistrySchema(
 	registryData: unknown,
-	sourcePath: string,
+	_sourcePath: string,
 ): ValidationResult<Registry> {
-	// Check schema compatibility first
 	const schemaIssue = classifyRegistrySchemaIssue(registryData)
 	if (schemaIssue) {
+		const issue = createIssue({
+			kind: "schema",
+			code: `schema_${schemaIssue.issue}`,
+			message: `Schema compatibility issue: ${schemaIssue.issue} - ${schemaIssue.remediation}`,
+		})
 		return {
 			valid: false,
-			errors: [`Schema compatibility issue: ${schemaIssue.issue} - ${schemaIssue.remediation}`],
+			errors: [issue.rendered],
+			issues: [issue],
 		}
 	}
 
-	// Then validate against the schema
-	return validateRegistrySource(registryData, sourcePath)
+	return validateRegistrySource(registryData, _sourcePath)
 }
 
 /**
  * Validate a registry source object against the schema.
- *
- * @param registryData - The parsed registry object
- * @param sourcePath - Path to the registry source (for error messages)
- * @returns Validation result with parsed data
  */
 export function validateRegistrySource(
 	registryData: unknown,
@@ -128,10 +203,21 @@ export function validateRegistrySource(
 	const parseResult = registrySchema.safeParse(registryData)
 
 	if (!parseResult.success) {
-		const errors = parseResult.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`)
+		const issues = parseResult.error.errors.map((error) => {
+			const message = `${error.path.join(".")}: ${error.message}`
+			return createIssue({
+				kind: "schema",
+				code: "schema_validation_error",
+				message,
+				affectedComponents: [],
+				affectedEntrypoints: [],
+			})
+		})
+
 		return {
 			valid: false,
-			errors,
+			errors: issues.map((issue) => issue.rendered),
+			issues,
 		}
 	}
 
@@ -139,21 +225,18 @@ export function validateRegistrySource(
 		valid: true,
 		errors: [],
 		data: parseResult.data,
+		issues: [],
 	}
 }
 
 /**
  * Validate that all source files referenced in the registry exist.
- *
- * @param registry - The validated registry object
- * @param sourcePath - Path to the registry source directory
- * @returns Validation result with file existence errors
  */
 export async function validateSourceFiles(
 	registry: Registry,
 	sourcePath: string,
 ): Promise<ValidationResult> {
-	const errors: string[] = []
+	const issues: ValidationIssue[] = []
 
 	for (const component of registry.components) {
 		for (const rawFile of component.files) {
@@ -161,29 +244,30 @@ export async function validateSourceFiles(
 			const sourceFilePath = join(sourcePath, "files", file.path)
 
 			if (!(await Bun.file(sourceFilePath).exists())) {
-				errors.push(`${component.name}: Source file not found at ${file.path}`)
+				const rendered = `${component.name}: Source file not found at ${file.path}`
+				issues.push(
+					createIssue({
+						kind: "source_file",
+						code: "source_file_missing",
+						message: rendered,
+						rendered,
+						affectedComponents: [component.name],
+						affectedEntrypoints: [file.target],
+					}),
+				)
 			}
 		}
 	}
 
-	return {
-		valid: errors.length === 0,
-		errors,
-	}
+	return toValidationResultFromIssues(issues)
 }
 
 /**
  * Validate that there are no circular dependencies in the registry.
- *
- * Uses depth-first search to detect cycles in the component dependency graph.
- * Only validates same-registry dependencies (bare names without "/").
- *
- * @param registry - The validated registry object
- * @returns Validation result with circular dependency errors
  */
 export function validateCircularDependencies(registry: Registry): ValidationResult {
-	const errors: string[] = []
-	const componentMap = new Map(registry.components.map((c) => [c.name, c]))
+	const issues: ValidationIssue[] = []
+	const componentMap = new Map(registry.components.map((component) => [component.name, component]))
 
 	function detectCycle(
 		componentName: string,
@@ -191,12 +275,10 @@ export function validateCircularDependencies(registry: Registry): ValidationResu
 		visited: Set<string>,
 		path: string[],
 	): string | null {
-		// If we're currently visiting this node, we found a cycle
 		if (visiting.has(componentName)) {
 			return [...path, componentName].join(" -> ")
 		}
 
-		// If already fully visited, no cycle from this path
 		if (visited.has(componentName)) {
 			return null
 		}
@@ -206,24 +288,20 @@ export function validateCircularDependencies(registry: Registry): ValidationResu
 			return null
 		}
 
-		// Mark as currently visiting
 		visiting.add(componentName)
 		path.push(componentName)
 
-		// Check all dependencies
-		for (const dep of component.dependencies) {
-			// Only check same-registry deps (bare names without "/")
-			if (dep.includes("/")) {
+		for (const dependency of component.dependencies) {
+			if (dependency.includes("/")) {
 				continue
 			}
 
-			const cycle = detectCycle(dep, visiting, visited, path)
+			const cycle = detectCycle(dependency, visiting, visited, path)
 			if (cycle) {
 				return cycle
 			}
 		}
 
-		// Done visiting this node
 		visiting.delete(componentName)
 		visited.add(componentName)
 		path.pop()
@@ -240,27 +318,29 @@ export function validateCircularDependencies(registry: Registry): ValidationResu
 
 		const cycle = detectCycle(component.name, new Set(), globalVisited, [])
 		if (cycle) {
-			errors.push(`Circular dependency detected: ${cycle}`)
-			// Only report the first cycle found
+			const rendered = `Circular dependency detected: ${cycle}`
+			issues.push(
+				createIssue({
+					kind: "circular_dependency",
+					code: "circular_dependency_detected",
+					message: rendered,
+					rendered,
+					affectedComponents: cycle.split(" -> "),
+				}),
+			)
 			break
 		}
 	}
 
-	return {
-		valid: errors.length === 0,
-		errors,
-	}
+	return toValidationResultFromIssues(issues)
 }
 
 /**
  * Validate that there are no duplicate target paths across components.
- *
- * @param registry - The validated registry object
- * @returns Validation result with duplicate target errors
  */
 export function validateDuplicateTargets(registry: Registry): ValidationResult {
-	const errors: string[] = []
-	const targetMap = new Map<string, { componentName: string }>()
+	const issues: ValidationIssue[] = []
+	const targetMap = new Map<string, { componentName: string; entrypoint: string }>()
 
 	const canonicalizeTargetForComparison = (target: string): string => {
 		const normalizedUnicode = target.normalize("NFC")
@@ -276,21 +356,30 @@ export function validateDuplicateTargets(registry: Registry): ValidationResult {
 			const existing = targetMap.get(canonicalTarget)
 
 			if (existing) {
-				errors.push(
-					`Duplicate target "${canonicalTarget}" in components "${existing.componentName}" and "${component.name}"`,
+				const rendered =
+					`Duplicate target "${canonicalTarget}" in components ` +
+					`"${existing.componentName}" and "${component.name}"`
+
+				issues.push(
+					createIssue({
+						kind: "duplicate_target",
+						code: "duplicate_target_detected",
+						message: rendered,
+						rendered,
+						affectedComponents: [existing.componentName, component.name],
+						affectedEntrypoints: [existing.entrypoint, file.target],
+					}),
 				)
 			} else {
 				targetMap.set(canonicalTarget, {
 					componentName: component.name,
+					entrypoint: file.target,
 				})
 			}
 		}
 	}
 
-	return {
-		valid: errors.length === 0,
-		errors,
-	}
+	return toValidationResultFromIssues(issues)
 }
 
 export interface ValidateRegistryOptions {
@@ -298,38 +387,56 @@ export interface ValidateRegistryOptions {
 }
 
 /**
+ * Typed plugin loadability boundary (single source of truth).
+ */
+export async function validatePluginLoadability(
+	registry: Registry,
+	sourcePath: string,
+): Promise<PluginLoadabilityValidationResult> {
+	return runPluginLoadabilityValidation(registry, sourcePath)
+}
+
+/**
+ * Validate all post-schema registry rules and return structured issues.
+ */
+export async function validateRegistryRules(
+	registry: Registry,
+	sourcePath: string,
+	options: ValidateRegistryOptions = {},
+): Promise<ValidationResult> {
+	const issues: RegistryValidationIssue[] = []
+
+	const filesResult = await validateSourceFiles(registry, sourcePath)
+	issues.push(...(filesResult.issues ?? []))
+
+	const circularResult = validateCircularDependencies(registry)
+	issues.push(...(circularResult.issues ?? []))
+
+	if (!options.skipDuplicateTargets) {
+		const duplicateTargetsResult = validateDuplicateTargets(registry)
+		issues.push(...(duplicateTargetsResult.issues ?? []))
+	}
+
+	const pluginLoadabilityResult = await validatePluginLoadability(registry, sourcePath)
+	issues.push(...pluginLoadabilityResult.issues)
+
+	return toValidationResultFromIssues(issues)
+}
+
+/**
  * Validate a registry's structure using a generator that yields errors.
  *
- * This generator runs all validators in order and yields each error as it's found.
- * This eliminates duplication of calling all validators in the correct order.
- *
- * @param registry - The validated registry object
- * @param sourcePath - Path to the registry source directory
- * @param options - Validation options
- * @yields Individual validation error messages
+ * Backward-compatible string API used by legacy tests/consumers.
  */
 export async function* validateRegistryWithOptions(
 	registry: Registry,
 	sourcePath: string,
 	options: ValidateRegistryOptions = {},
 ): AsyncGenerator<string, void, undefined> {
-	// Validate source files exist
-	const filesResult = await validateSourceFiles(registry, sourcePath)
-	for (const error of filesResult.errors) {
+	const result = await validateRegistryRules(registry, sourcePath, options)
+	for (const error of result.errors) {
 		yield error
-	}
-
-	// Validate no circular dependencies
-	const circularResult = validateCircularDependencies(registry)
-	for (const error of circularResult.errors) {
-		yield error
-	}
-
-	// Validate no duplicate targets (unless skipped)
-	if (!options.skipDuplicateTargets) {
-		const duplicateTargetsResult = validateDuplicateTargets(registry)
-		for (const error of duplicateTargetsResult.errors) {
-			yield error
-		}
 	}
 }
+
+export { PluginLoadabilityOperationalError }

--- a/packages/cli/src/programmatic-exports.ts
+++ b/packages/cli/src/programmatic-exports.ts
@@ -1,4 +1,10 @@
-export { type BuildRegistryOptions, type BuildRegistryResult, buildRegistry } from "./lib/index"
+export {
+	BuildRegistryError,
+	type BuildRegistryOptions,
+	type BuildRegistryResult,
+	buildRegistry,
+	ValidationFailedError,
+} from "./lib/index"
 
 export {
 	type ComponentManifest,

--- a/packages/cli/src/utils/dry-run.ts
+++ b/packages/cli/src/utils/dry-run.ts
@@ -16,6 +16,15 @@ export interface DryRunValidation {
 	passed: boolean
 	errors?: string[] // Fatal issues that would cause failure
 	warnings?: string[] // Non-fatal issues (e.g., modified files without --force)
+	issues?: Array<{
+		kind: string
+		code: string
+		severity: "error" | "warning"
+		message: string
+		rendered: string
+		affectedComponents: string[]
+		affectedEntrypoints: string[]
+	}>
 }
 
 /** Base result that all commands return */

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -101,18 +101,33 @@ export class ValidationError extends OCXError {
 	}
 }
 
+export interface ValidationFailureSummary {
+	valid: false
+	totalErrors: number
+	schemaErrors: number
+	sourceFileErrors: number
+	circularDependencyErrors: number
+	duplicateTargetErrors: number
+	pluginLoadabilityErrors: number
+	otherErrors: number
+}
+
+export interface StructuredValidationIssue {
+	kind: string
+	code: string
+	severity: "error" | "warning"
+	message: string
+	rendered: string
+	affectedComponents: string[]
+	affectedEntrypoints: string[]
+}
+
 export interface ValidationFailureDetails {
 	valid: false
 	errors: string[]
-	summary: {
-		valid: false
-		totalErrors: number
-		schemaErrors: number
-		sourceFileErrors: number
-		circularDependencyErrors: number
-		duplicateTargetErrors: number
-		otherErrors: number
-	}
+	warnings?: string[]
+	issues?: StructuredValidationIssue[]
+	summary: ValidationFailureSummary
 }
 
 export class ValidationFailedError extends OCXError {

--- a/packages/cli/src/utils/npm-dependencies.ts
+++ b/packages/cli/src/utils/npm-dependencies.ts
@@ -1,0 +1,78 @@
+import { ConflictError, ValidationError } from "./errors"
+
+export interface NpmDependency {
+	name: string
+	version: string
+}
+
+export interface MergedNpmDependencies {
+	dependencies: Map<string, string>
+	devDependencies: Map<string, string>
+}
+
+/**
+ * Parses an npm dependency spec into name and version.
+ * Handles: "lodash", "lodash@4.0.0", "@types/node", "@types/node@1.0.0"
+ */
+export function parseNpmDependencySpecifier(spec: string): NpmDependency {
+	if (!spec?.trim()) {
+		throw new ValidationError(`Invalid npm dependency: expected non-empty string, got "${spec}"`)
+	}
+
+	const trimmed = spec.trim()
+	const lastAt = trimmed.lastIndexOf("@")
+
+	if (lastAt > 0) {
+		const name = trimmed.slice(0, lastAt)
+		const version = trimmed.slice(lastAt + 1)
+		if (!version) {
+			throw new ValidationError(`Invalid npm dependency: missing version after @ in "${spec}"`)
+		}
+		return { name, version }
+	}
+
+	return { name: trimmed, version: "*" }
+}
+
+/**
+ * Merges npm dependency specs using the same behavior as add/install flow:
+ * - parse all specs with parseNpmDependencySpecifier
+ * - fail loud when the same package appears in both dependencies and devDependencies
+ * - last declaration wins inside each field
+ */
+export function mergeNpmDependencySpecifiers(
+	npmDependencies: string[],
+	npmDevDependencies: string[],
+): MergedNpmDependencies {
+	const dependencies = new Map<string, string>()
+	const devDependencies = new Map<string, string>()
+
+	for (const spec of npmDependencies) {
+		const parsedDependency = parseNpmDependencySpecifier(spec)
+		dependencies.set(parsedDependency.name, parsedDependency.version)
+	}
+
+	for (const spec of npmDevDependencies) {
+		const parsedDependency = parseNpmDependencySpecifier(spec)
+		devDependencies.set(parsedDependency.name, parsedDependency.version)
+	}
+
+	const conflicts: string[] = []
+	for (const dependencyName of dependencies.keys()) {
+		if (devDependencies.has(dependencyName)) {
+			conflicts.push(dependencyName)
+		}
+	}
+
+	if (conflicts.length > 0) {
+		throw new ConflictError(
+			`Package(s) appear in both dependencies and devDependencies: ${conflicts.join(", ")}.\n` +
+				"A package cannot be in both fields. Remove from one list manually before adding.",
+		)
+	}
+
+	return {
+		dependencies,
+		devDependencies,
+	}
+}

--- a/packages/cli/src/utils/validation-errors.ts
+++ b/packages/cli/src/utils/validation-errors.ts
@@ -4,10 +4,18 @@
  * Shared utilities for categorizing and displaying validation errors.
  */
 
+export interface StructuredValidationIssueLike {
+	kind?: string
+	code?: string
+	severity?: "error" | "warning"
+	rendered?: string
+}
+
 export interface CategorizedErrors {
 	file: string[]
 	circular: string[]
 	duplicate: string[]
+	pluginLoadability: string[]
 }
 
 export interface ValidationErrorSummary {
@@ -17,33 +25,31 @@ export interface ValidationErrorSummary {
 	sourceFileErrors: number
 	circularDependencyErrors: number
 	duplicateTargetErrors: number
+	pluginLoadabilityErrors: number
 	otherErrors: number
 }
 
 /**
  * Categorize validation errors by type.
- *
- * @param errors - Array of validation error messages
- * @returns Object with categorized errors
  */
 export function categorizeValidationErrors(errors: string[]): CategorizedErrors {
 	return {
-		file: errors.filter((e) => e.includes("Source file not found")),
-		circular: errors.filter((e) => e.includes("Circular dependency")),
-		duplicate: errors.filter((e) => e.includes("Duplicate target")),
+		file: errors.filter((error) => error.includes("Source file not found")),
+		circular: errors.filter((error) => error.includes("Circular dependency")),
+		duplicate: errors.filter((error) => error.includes("Duplicate target")),
+		pluginLoadability: errors.filter((error) => error.includes("Plugin loadability")),
 	}
 }
 
 /**
  * Display categorized validation errors with headings.
- *
- * @param categorized - Categorized errors object
- * @param logFn - Function to output messages (defaults to console.log)
  */
 export function displayCategorizedErrors(
 	categorized: CategorizedErrors,
 	logFn: (msg: string) => void = console.log,
 ): void {
+	const pluginErrors = categorized.pluginLoadability ?? []
+
 	if (categorized.file.length > 0) {
 		logFn("✗ Source files")
 		for (const error of categorized.file) {
@@ -64,20 +70,32 @@ export function displayCategorizedErrors(
 			logFn(`  ${error}`)
 		}
 	}
+
+	if (pluginErrors.length > 0) {
+		logFn("✗ Plugin loadability")
+		for (const error of pluginErrors) {
+			logFn(`  ${error}`)
+		}
+	}
 }
 
 /**
  * Build a stable summary object for validation results.
- *
- * @param errors - Validation error messages
- * @param options - Optional overrides for explicit schema errors
  */
 export function summarizeValidationErrors(
 	errors: string[],
-	options: { schemaErrors?: number } = {},
+	options: {
+		schemaErrors?: number
+		issues?: StructuredValidationIssueLike[]
+	} = {},
 ): ValidationErrorSummary {
 	const categorized = categorizeValidationErrors(errors)
 	const schemaErrors = options.schemaErrors ?? 0
+	const pluginLoadabilityErrors =
+		options.issues
+			?.filter((issue) => issue.severity !== "warning")
+			.filter((issue) => issue.kind === "plugin_loadability" || issue.code?.startsWith("plugin_"))
+			.length ?? categorized.pluginLoadability.length
 	const totalErrors = errors.length
 	const otherErrors = Math.max(
 		0,
@@ -85,7 +103,8 @@ export function summarizeValidationErrors(
 			schemaErrors -
 			categorized.file.length -
 			categorized.circular.length -
-			categorized.duplicate.length,
+			categorized.duplicate.length -
+			pluginLoadabilityErrors,
 	)
 
 	return {
@@ -95,6 +114,7 @@ export function summarizeValidationErrors(
 		sourceFileErrors: categorized.file.length,
 		circularDependencyErrors: categorized.circular.length,
 		duplicateTargetErrors: categorized.duplicate.length,
+		pluginLoadabilityErrors,
 		otherErrors,
 	}
 }

--- a/packages/cli/tests/build-registry.test.ts
+++ b/packages/cli/tests/build-registry.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync } from "node:fs"
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { BuildRegistryError, buildRegistry } from "../src/lib/build-registry"
+import { ValidationFailedError } from "../src/utils/errors"
+import { cleanupTempDir, createTempDir } from "./helpers"
+
+const REGISTRY_SCHEMA_V2_URL = "https://ocx.kdco.dev/schemas/v2/registry.json"
+
+describe("buildRegistry (programmatic)", () => {
+	let testDir: string
+
+	beforeEach(async () => {
+		testDir = await createTempDir("build-registry")
+	})
+
+	afterEach(async () => {
+		await cleanupTempDir(testDir)
+	})
+
+	it("throws BuildRegistryError when registry file is missing", async () => {
+		const sourceDir = join(testDir, "missing-source")
+		await mkdir(sourceDir, { recursive: true })
+
+		await expect(
+			buildRegistry({
+				source: sourceDir,
+				out: join(testDir, "dist"),
+			}),
+		).rejects.toBeInstanceOf(BuildRegistryError)
+	})
+
+	it("throws BuildRegistryError for schema parse/validation failures", async () => {
+		const sourceDir = join(testDir, "schema-source")
+		await mkdir(sourceDir, { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Invalid Registry",
+				author: "Test",
+				components: [],
+			}),
+		)
+
+		await expect(
+			buildRegistry({
+				source: sourceDir,
+				out: join(testDir, "dist"),
+			}),
+		).rejects.toBeInstanceOf(BuildRegistryError)
+	})
+
+	it("throws ValidationFailedError for post-load plugin validation failures", async () => {
+		const sourceDir = join(testDir, "plugin-invalid")
+		await mkdir(join(sourceDir, "files", "plugins"), { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Plugin Invalid",
+				version: "1.0.0",
+				author: "Test",
+				components: [
+					{
+						name: "plugin-invalid",
+						type: "plugin",
+						description: "invalid plugin",
+						files: [{ path: "plugins/main.ts", target: "plugins/main.ts" }],
+						dependencies: [],
+					},
+				],
+			}),
+		)
+
+		await writeFile(
+			join(sourceDir, "files", "plugins", "main.ts"),
+			'import x from "left-pad"\nexport default x\n',
+		)
+
+		await expect(
+			buildRegistry({
+				source: sourceDir,
+				out: join(testDir, "dist"),
+			}),
+		).rejects.toBeInstanceOf(ValidationFailedError)
+	})
+
+	it("returns dry-run structured validation and no writes on fatal validation", async () => {
+		const sourceDir = join(testDir, "dry-run-invalid")
+		const outDir = join(testDir, "dry-run-dist")
+		await mkdir(join(sourceDir, "files", "plugins"), { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Dry Run Invalid",
+				version: "1.0.0",
+				author: "Test",
+				components: [
+					{
+						name: "plugin-invalid",
+						type: "plugin",
+						description: "invalid plugin",
+						files: [{ path: "plugins/main.ts", target: "plugins/main.ts" }],
+						dependencies: [],
+					},
+				],
+			}),
+		)
+
+		await writeFile(
+			join(sourceDir, "files", "plugins", "main.ts"),
+			'import missing from "missing-package"\nexport default missing\n',
+		)
+
+		const result = await buildRegistry({ source: sourceDir, out: outDir, dryRun: true })
+		expect("dryRun" in result && result.dryRun).toBe(true)
+		if (!("dryRun" in result) || !result.dryRun) {
+			throw new Error("Expected dry-run result")
+		}
+
+		expect(result.validation.passed).toBe(false)
+		expect(result.validation.errors?.some((error) => error.includes("Plugin loadability"))).toBe(
+			true,
+		)
+		expect(result.validation.issues?.length).toBeGreaterThan(0)
+		expect(existsSync(join(outDir, "index.json"))).toBe(false)
+	})
+
+	it("keeps warnings-only plugin outcomes successful in dry-run", async () => {
+		const sourceDir = join(testDir, "dry-run-warning")
+		const outDir = join(testDir, "dry-run-warning-dist")
+		await mkdir(sourceDir, { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Dry Run Warning",
+				version: "1.0.0",
+				author: "Test",
+				components: [
+					{
+						name: "warning-component",
+						type: "skill",
+						description: "warning component",
+						files: [],
+						dependencies: [],
+						opencode: {
+							plugin: ["example-plugin"],
+						},
+					},
+				],
+			}),
+		)
+
+		const result = await buildRegistry({ source: sourceDir, out: outDir, dryRun: true })
+		expect("dryRun" in result && result.dryRun).toBe(true)
+		if (!("dryRun" in result) || !result.dryRun) {
+			throw new Error("Expected dry-run result")
+		}
+
+		expect(result.validation.passed).toBe(true)
+		expect(
+			result.validation.warnings?.some((warning) => warning.includes("non-deterministic")),
+		).toBe(true)
+	})
+})

--- a/packages/cli/tests/build-registry.test.ts
+++ b/packages/cli/tests/build-registry.test.ts
@@ -170,4 +170,108 @@ describe("buildRegistry (programmatic)", () => {
 			result.validation.warnings?.some((warning) => warning.includes("non-deterministic")),
 		).toBe(true)
 	})
+
+	it("fails duplicate targets during build by default", async () => {
+		const sourceDir = join(testDir, "duplicate-targets-default")
+		const outDir = join(testDir, "duplicate-targets-default-dist")
+		await mkdir(sourceDir, { recursive: true })
+		await mkdir(join(sourceDir, "files"), { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Duplicate Targets Default",
+				version: "1.0.0",
+				author: "Test",
+				components: [
+					{
+						name: "component-a",
+						type: "plugin",
+						description: "A",
+						files: [{ path: "a.ts", target: "plugins/shared.ts" }],
+						dependencies: [],
+					},
+					{
+						name: "component-b",
+						type: "plugin",
+						description: "B",
+						files: [{ path: "b.ts", target: "plugins/shared.ts" }],
+						dependencies: [],
+					},
+				],
+			}),
+		)
+
+		await writeFile(join(sourceDir, "files", "a.ts"), "export default { name: 'a' }\n")
+		await writeFile(join(sourceDir, "files", "b.ts"), "export default { name: 'b' }\n")
+
+		const thrown = await buildRegistry({ source: sourceDir, out: outDir }).then(
+			() => null,
+			(error: unknown) => error,
+		)
+
+		expect(thrown).toBeInstanceOf(ValidationFailedError)
+		if (!(thrown instanceof ValidationFailedError)) {
+			throw new Error("Expected ValidationFailedError for duplicate target validation")
+		}
+
+		expect(
+			thrown.details.errors.some((error) => error.includes('Duplicate target "plugins/shared.ts"')),
+		).toBe(true)
+		expect(thrown.details.summary.duplicateTargetErrors).toBe(1)
+		expect(thrown.details.issues?.some((issue) => issue.code === "duplicate_target_detected")).toBe(
+			true,
+		)
+	})
+
+	it("allows duplicate targets when explicitly opted out", async () => {
+		const sourceDir = join(testDir, "duplicate-targets-opt-out")
+		const outDir = join(testDir, "duplicate-targets-opt-out-dist")
+		await mkdir(sourceDir, { recursive: true })
+		await mkdir(join(sourceDir, "files"), { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Duplicate Targets Opt Out",
+				version: "1.0.0",
+				author: "Test",
+				components: [
+					{
+						name: "component-a",
+						type: "plugin",
+						description: "A",
+						files: [{ path: "a.ts", target: "plugins/shared.ts" }],
+						dependencies: [],
+					},
+					{
+						name: "component-b",
+						type: "plugin",
+						description: "B",
+						files: [{ path: "b.ts", target: "plugins/shared.ts" }],
+						dependencies: [],
+					},
+				],
+			}),
+		)
+
+		await writeFile(join(sourceDir, "files", "a.ts"), "export default { name: 'a' }\n")
+		await writeFile(join(sourceDir, "files", "b.ts"), "export default { name: 'b' }\n")
+
+		const result = await buildRegistry({
+			source: sourceDir,
+			out: outDir,
+			skipDuplicateTargets: true,
+		})
+
+		expect("dryRun" in result).toBe(false)
+		if ("dryRun" in result) {
+			throw new Error("Expected non-dry-run build result")
+		}
+
+		expect(result.componentsCount).toBe(2)
+		expect(existsSync(join(outDir, "index.json"))).toBe(true)
+	})
 })

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -181,6 +181,51 @@ describe("ocx build", () => {
 		expect(output).toContain("Built 1 component")
 	})
 
+	it("fails duplicate-target registries even without --show-validation", async () => {
+		const sourceDir = join(testDir, "registry-no-show-validation-duplicate-targets")
+		await mkdir(sourceDir, { recursive: true })
+		await mkdir(join(sourceDir, "files"), { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "No Show Validation Duplicate Targets",
+				namespace: "kdco",
+				version: "1.0.0",
+				author: "Test Author",
+				components: [
+					{
+						name: "component-a",
+						type: "plugin",
+						description: "A",
+						files: [{ path: "a.ts", target: "plugins/shared.ts" }],
+						dependencies: [],
+					},
+					{
+						name: "component-b",
+						type: "plugin",
+						description: "B",
+						files: [{ path: "b.ts", target: "plugins/shared.ts" }],
+						dependencies: [],
+					},
+				],
+			}),
+		)
+
+		await writeFile(join(sourceDir, "files", "a.ts"), "export default { name: 'a' }\n")
+		await writeFile(join(sourceDir, "files", "b.ts"), "export default { name: 'b' }\n")
+
+		const { exitCode, output } = await runCLI(
+			["build", "registry-no-show-validation-duplicate-targets", "--out", "dist"],
+			testDir,
+		)
+
+		expect(exitCode).toBe(EXIT_CODES.CONFIG)
+		expect(output).toContain('Duplicate target "plugins/shared.ts"')
+		expect(output).not.toContain("Built")
+	})
+
 	it("should run --show-validation checks even in JSON mode", async () => {
 		const sourceDir = join(testDir, "registry-json-show-validation")
 		await mkdir(sourceDir, { recursive: true })

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -550,4 +550,103 @@ describe("ocx build", () => {
 		expect(output).toContain("invalid-schema-url")
 		expect(output).toContain(REGISTRY_SCHEMA_V2_URL)
 	})
+
+	it("should return non-zero dry-run for fatal plugin loadability failures", async () => {
+		const sourceDir = join(testDir, "registry-dry-run-plugin-fail")
+		await mkdir(join(sourceDir, "files", "plugins"), { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Dry Run Plugin Fail",
+				version: "1.0.0",
+				author: "Test Author",
+				components: [
+					{
+						name: "plugin-fail",
+						type: "plugin",
+						description: "Plugin fail",
+						files: [{ path: "plugins/main.ts", target: "plugins/main.ts" }],
+						dependencies: [],
+					},
+				],
+			}),
+		)
+		await writeFile(
+			join(sourceDir, "files", "plugins", "main.ts"),
+			'import missing from "missing-package"\nexport default missing\n',
+		)
+
+		const { exitCode, stdout, stderr } = await runCLI(
+			["build", "registry-dry-run-plugin-fail", "--out", "dist", "--dry-run", "--json"],
+			testDir,
+		)
+
+		expect(exitCode).toBe(EXIT_CODES.CONFIG)
+		expect(stderr).toBe("")
+
+		const payload = JSON.parse(stdout) as {
+			dryRun: boolean
+			validation: {
+				passed: boolean
+				errors?: string[]
+				issues?: Array<{ kind: string; code: string }>
+			}
+		}
+
+		expect(payload.dryRun).toBe(true)
+		expect(payload.validation.passed).toBe(false)
+		expect(payload.validation.errors?.some((error) => error.includes("Plugin loadability"))).toBe(
+			true,
+		)
+		expect(payload.validation.issues?.some((issue) => issue.kind === "plugin_loadability")).toBe(
+			true,
+		)
+	})
+
+	it("keeps warnings-only plugin dry-runs successful", async () => {
+		const sourceDir = join(testDir, "registry-dry-run-plugin-warning")
+		await mkdir(sourceDir, { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Dry Run Plugin Warning",
+				version: "1.0.0",
+				author: "Test Author",
+				components: [
+					{
+						name: "warn-component",
+						type: "skill",
+						description: "warning only",
+						files: [],
+						dependencies: [],
+						opencode: { plugin: ["example-plugin"] },
+					},
+				],
+			}),
+		)
+
+		const { exitCode, stdout } = await runCLI(
+			["build", "registry-dry-run-plugin-warning", "--out", "dist", "--dry-run", "--json"],
+			testDir,
+		)
+
+		expect(exitCode).toBe(0)
+		const payload = JSON.parse(stdout) as {
+			dryRun: boolean
+			validation: {
+				passed: boolean
+				warnings?: string[]
+			}
+		}
+
+		expect(payload.dryRun).toBe(true)
+		expect(payload.validation.passed).toBe(true)
+		expect(
+			payload.validation.warnings?.some((warning) => warning.includes("non-deterministic")),
+		).toBe(true)
+	})
 })

--- a/packages/cli/tests/error-cases.test.ts
+++ b/packages/cli/tests/error-cases.test.ts
@@ -303,7 +303,7 @@ describe("Error Cases", () => {
 			await Bun.write(join(testDir, "registry.jsonc"), JSON.stringify(registryConfig))
 
 			const result = await runCLI(["build", "--cwd", testDir], testDir)
-			expect(result.exitCode).toBe(1)
+			expect(result.exitCode).toBe(78)
 			// Build errors are logged via console.log (details) and logger.error (summary)
 			// Check combined output for the error details
 			expect(result.output).toMatch(/not found|Source file not found/i)

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type Mock, spyOn } from "bun:test"
-import { mkdir, rm } from "node:fs/promises"
+import { mkdir, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { parse } from "jsonc-parser"
 
@@ -445,4 +446,50 @@ export async function runCLIIsolated(
 			...env,
 		},
 	})
+}
+
+export interface LocalPackageFixtureOptions {
+	name: string
+	version?: string
+	entrypointCode?: string
+}
+
+export async function createLocalPackageFixture(
+	rootDir: string,
+	options: LocalPackageFixtureOptions,
+): Promise<{ packageDir: string; specifier: string }> {
+	const packageDir = join(rootDir, "fixtures", "npm", options.name.replace(/[/]/g, "-"))
+	const version = options.version ?? "1.0.0"
+
+	await mkdir(packageDir, { recursive: true })
+	await Bun.write(
+		join(packageDir, "package.json"),
+		JSON.stringify(
+			{
+				name: options.name,
+				version,
+				type: "module",
+				exports: {
+					".": "./index.js",
+				},
+			},
+			null,
+			2,
+		),
+	)
+	await Bun.write(join(packageDir, "index.js"), options.entrypointCode ?? "export default {}\n")
+
+	return {
+		packageDir,
+		specifier: `${options.name}@file:${packageDir}`,
+	}
+}
+
+export async function listPluginValidationTempDirs(): Promise<string[]> {
+	const entries = await readdir(tmpdir(), { withFileTypes: true })
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((entry) => entry.startsWith("ocx-plugin-validation-"))
+		.sort()
 }

--- a/packages/cli/tests/utils/dry-run.test.ts
+++ b/packages/cli/tests/utils/dry-run.test.ts
@@ -99,6 +99,34 @@ describe("dry-run utilities", () => {
 			expect(output).toContain("Component not found")
 		})
 
+		it("preserves structured validation issues in JSON output", () => {
+			const result: DryRunResult = {
+				dryRun: true,
+				command: "build",
+				wouldPerform: [],
+				validation: {
+					passed: false,
+					errors: ["Plugin loadability: unresolved import"],
+					issues: [
+						{
+							kind: "plugin_loadability",
+							code: "plugin_static_local_import_unresolved",
+							severity: "error",
+							message: "unresolved import",
+							rendered: "Plugin loadability: unresolved import",
+							affectedComponents: ["plugin-component"],
+							affectedEntrypoints: [".opencode/plugins/main.ts"],
+						},
+					],
+				},
+			}
+
+			outputDryRun(result, { json: true })
+
+			const parsed = JSON.parse(consoleOutput[0]) as DryRunResult
+			expect(parsed.validation.issues?.[0]?.code).toBe("plugin_static_local_import_unresolved")
+		})
+
 		it("includes hints in footer", () => {
 			const result: DryRunResult = {
 				dryRun: true,

--- a/packages/cli/tests/utils/handle-error.test.ts
+++ b/packages/cli/tests/utils/handle-error.test.ts
@@ -668,6 +668,18 @@ describe("handleError JSON output", () => {
 			const error = new ValidationFailedError({
 				valid: false,
 				errors: ["comp-a: Source file not found at missing.ts"],
+				warnings: ["Plugin loadability: non-deterministic package spec"],
+				issues: [
+					{
+						kind: "plugin_loadability",
+						code: "plugin_package_spec_nondeterministic",
+						severity: "warning",
+						message: "non-deterministic package spec",
+						rendered: "Plugin loadability: non-deterministic package spec",
+						affectedComponents: ["comp-a"],
+						affectedEntrypoints: ["package:example-plugin"],
+					},
+				],
 				summary: {
 					valid: false,
 					totalErrors: 1,
@@ -675,6 +687,7 @@ describe("handleError JSON output", () => {
 					sourceFileErrors: 1,
 					circularDependencyErrors: 0,
 					duplicateTargetErrors: 0,
+					pluginLoadabilityErrors: 0,
 					otherErrors: 0,
 				},
 			})
@@ -691,6 +704,18 @@ describe("handleError JSON output", () => {
 			expect(output.error.details).toEqual({
 				valid: false,
 				errors: ["comp-a: Source file not found at missing.ts"],
+				warnings: ["Plugin loadability: non-deterministic package spec"],
+				issues: [
+					{
+						kind: "plugin_loadability",
+						code: "plugin_package_spec_nondeterministic",
+						severity: "warning",
+						message: "non-deterministic package spec",
+						rendered: "Plugin loadability: non-deterministic package spec",
+						affectedComponents: ["comp-a"],
+						affectedEntrypoints: ["package:example-plugin"],
+					},
+				],
 				summary: {
 					valid: false,
 					totalErrors: 1,
@@ -698,6 +723,7 @@ describe("handleError JSON output", () => {
 					sourceFileErrors: 1,
 					circularDependencyErrors: 0,
 					duplicateTargetErrors: 0,
+					pluginLoadabilityErrors: 0,
 					otherErrors: 0,
 				},
 			})

--- a/packages/cli/tests/validate.test.ts
+++ b/packages/cli/tests/validate.test.ts
@@ -98,6 +98,7 @@ describe("ocx validate", () => {
 					sourceFileErrors: number
 					circularDependencyErrors: number
 					duplicateTargetErrors: number
+					pluginLoadabilityErrors: number
 					otherErrors: number
 				}
 			}
@@ -113,8 +114,58 @@ describe("ocx validate", () => {
 			sourceFileErrors: 0,
 			circularDependencyErrors: 0,
 			duplicateTargetErrors: 0,
+			pluginLoadabilityErrors: 0,
 			otherErrors: 0,
 		})
+	})
+
+	it("should keep warnings-only plugin validation as success", async () => {
+		const sourceDir = join(testDir, "registry-warning-only")
+		await mkdir(sourceDir, { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Warning Registry",
+				version: "1.0.0",
+				author: "Test Author",
+				components: [
+					{
+						name: "warning-component",
+						type: "skill",
+						description: "warning component",
+						files: [],
+						dependencies: [],
+						opencode: { plugin: ["example-plugin"] },
+					},
+				],
+			}),
+		)
+
+		const { exitCode, stdout, stderr } = await runCLI(
+			["validate", "registry-warning-only", "--json"],
+			testDir,
+		)
+
+		expect(exitCode).toBe(0)
+		expect(stderr).toBe("")
+
+		const result = JSON.parse(stdout) as {
+			success: boolean
+			data: {
+				valid: boolean
+				warnings: string[]
+				summary: {
+					pluginLoadabilityErrors: number
+				}
+			}
+		}
+
+		expect(result.success).toBe(true)
+		expect(result.data.valid).toBe(true)
+		expect(result.data.summary.pluginLoadabilityErrors).toBe(0)
+		expect(result.data.warnings.some((warning) => warning.includes("non-deterministic"))).toBe(true)
 	})
 
 	it("should report validation errors for missing source files", async () => {

--- a/packages/cli/tests/validate.test.ts
+++ b/packages/cli/tests/validate.test.ts
@@ -168,6 +168,39 @@ describe("ocx validate", () => {
 		expect(result.data.warnings.some((warning) => warning.includes("non-deterministic"))).toBe(true)
 	})
 
+	it("shows all operational validation failure details in non-JSON mode", async () => {
+		const sourceDir = join(testDir, "registry-operational-failure")
+		await mkdir(sourceDir, { recursive: true })
+
+		await writeFile(
+			join(sourceDir, "registry.json"),
+			JSON.stringify({
+				$schema: REGISTRY_SCHEMA_V2_URL,
+				name: "Operational Failure Registry",
+				version: "1.0.0",
+				author: "Test Author",
+				components: [
+					{
+						name: "ops-failure",
+						type: "skill",
+						description: "Forcing install failure",
+						files: [],
+						dependencies: [],
+						opencode: {
+							plugin: ["broken-plugin@file:/definitely/not/a/real/package"],
+						},
+					},
+				],
+			}),
+		)
+
+		const { exitCode, output } = await runCLI(["validate", "registry-operational-failure"], testDir)
+
+		expect(exitCode).toBe(EXIT_CODES.GENERAL)
+		expect(output).toContain("Failed to hydrate plugin validation dependencies")
+		expect(output).toContain("exitCode=")
+	})
+
 	it("should report validation errors for missing source files", async () => {
 		const sourceDir = join(testDir, "registry")
 		await mkdir(sourceDir, { recursive: true })

--- a/packages/cli/tests/validation-errors.test.ts
+++ b/packages/cli/tests/validation-errors.test.ts
@@ -17,6 +17,7 @@ describe("categorizeValidationErrors", () => {
 		expect(result.file).toEqual(errors)
 		expect(result.circular).toEqual([])
 		expect(result.duplicate).toEqual([])
+		expect(result.pluginLoadability).toEqual([])
 	})
 
 	it("should categorize circular dependency errors", () => {
@@ -27,6 +28,7 @@ describe("categorizeValidationErrors", () => {
 		expect(result.file).toEqual([])
 		expect(result.circular).toEqual(errors)
 		expect(result.duplicate).toEqual([])
+		expect(result.pluginLoadability).toEqual([])
 	})
 
 	it("should categorize duplicate target errors", () => {
@@ -37,6 +39,18 @@ describe("categorizeValidationErrors", () => {
 		expect(result.file).toEqual([])
 		expect(result.circular).toEqual([])
 		expect(result.duplicate).toEqual(errors)
+		expect(result.pluginLoadability).toEqual([])
+	})
+
+	it("should categorize plugin loadability errors", () => {
+		const errors = ['Plugin loadability: package plugin "foo" failed runtime import']
+
+		const result = categorizeValidationErrors(errors)
+
+		expect(result.file).toEqual([])
+		expect(result.circular).toEqual([])
+		expect(result.duplicate).toEqual([])
+		expect(result.pluginLoadability).toEqual(errors)
 	})
 
 	it("should categorize mixed errors", () => {
@@ -57,6 +71,7 @@ describe("categorizeValidationErrors", () => {
 		expect(result.duplicate).toEqual([
 			'Duplicate target "plugins/test.ts" in components "comp-a" and "comp-b"',
 		])
+		expect(result.pluginLoadability).toEqual([])
 	})
 
 	it("should return empty arrays for empty input", () => {
@@ -65,6 +80,7 @@ describe("categorizeValidationErrors", () => {
 		expect(result.file).toEqual([])
 		expect(result.circular).toEqual([])
 		expect(result.duplicate).toEqual([])
+		expect(result.pluginLoadability).toEqual([])
 	})
 })
 
@@ -74,6 +90,7 @@ describe("displayCategorizedErrors", () => {
 			file: ["comp-a: Source file not found at file.ts"],
 			circular: [],
 			duplicate: [],
+			pluginLoadability: [],
 		}
 
 		const output: string[] = []
@@ -90,6 +107,7 @@ describe("displayCategorizedErrors", () => {
 			file: [],
 			circular: ["Circular dependency detected: comp-a -> comp-b -> comp-a"],
 			duplicate: [],
+			pluginLoadability: [],
 		}
 
 		const output: string[] = []
@@ -106,6 +124,7 @@ describe("displayCategorizedErrors", () => {
 			file: [],
 			circular: [],
 			duplicate: ['Duplicate target "plugins/test.ts" in components "comp-a" and "comp-b"'],
+			pluginLoadability: [],
 		}
 
 		const output: string[] = []
@@ -124,6 +143,7 @@ describe("displayCategorizedErrors", () => {
 			file: ["comp-a: Source file not found at file.ts"],
 			circular: ["Circular dependency detected: comp-a -> comp-b -> comp-a"],
 			duplicate: ['Duplicate target "plugins/test.ts" in components "comp-a" and "comp-b"'],
+			pluginLoadability: ['Plugin loadability: package plugin "foo" failed runtime import'],
 		}
 
 		const output: string[] = []
@@ -134,6 +154,7 @@ describe("displayCategorizedErrors", () => {
 		expect(output).toContain("✗ Source files")
 		expect(output).toContain("✗ Circular dependencies")
 		expect(output).toContain("✗ Duplicate targets")
+		expect(output).toContain("✗ Plugin loadability")
 	})
 
 	it("should not display categories with no errors", () => {
@@ -141,6 +162,7 @@ describe("displayCategorizedErrors", () => {
 			file: ["comp-a: Source file not found at file.ts"],
 			circular: [],
 			duplicate: [],
+			pluginLoadability: [],
 		}
 
 		const output: string[] = []
@@ -171,6 +193,7 @@ describe("summarizeValidationErrors", () => {
 			sourceFileErrors: 1,
 			circularDependencyErrors: 1,
 			duplicateTargetErrors: 1,
+			pluginLoadabilityErrors: 0,
 			otherErrors: 0,
 		})
 	})
@@ -187,6 +210,7 @@ describe("summarizeValidationErrors", () => {
 			sourceFileErrors: 0,
 			circularDependencyErrors: 0,
 			duplicateTargetErrors: 0,
+			pluginLoadabilityErrors: 0,
 			otherErrors: 0,
 		})
 	})
@@ -201,7 +225,16 @@ describe("summarizeValidationErrors", () => {
 			sourceFileErrors: 0,
 			circularDependencyErrors: 0,
 			duplicateTargetErrors: 0,
+			pluginLoadabilityErrors: 0,
 			otherErrors: 0,
 		})
+	})
+
+	it("should summarize plugin loadability errors", () => {
+		const errors = ['Plugin loadability: package plugin "foo" failed runtime import']
+		const summary = summarizeValidationErrors(errors)
+
+		expect(summary.pluginLoadabilityErrors).toBe(1)
+		expect(summary.otherErrors).toBe(0)
 	})
 })

--- a/packages/cli/tests/validation-runner.test.ts
+++ b/packages/cli/tests/validation-runner.test.ts
@@ -72,4 +72,66 @@ describe("runCompleteValidation", () => {
 		expect(result.errors[0]).toContain("version")
 		expect(result.registry).toBeUndefined()
 	})
+
+	it("returns warnings-only success for non-deterministic package plugin specs", async () => {
+		const registryContent = {
+			$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+			name: "Warning Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "warning-component",
+					type: "skill",
+					description: "Warn-only component",
+					files: [],
+					dependencies: [],
+					opencode: {
+						plugin: ["example-plugin"],
+					},
+				},
+			],
+		}
+
+		await writeFile(join(testDir, "registry.json"), JSON.stringify(registryContent, null, 2))
+
+		const result = await runCompleteValidation(testDir, {
+			skipDuplicateTargets: false,
+		})
+
+		expect(result.success).toBe(true)
+		expect(result.errors).toEqual([])
+		expect(result.warnings.some((warning) => warning.includes("non-deterministic"))).toBe(true)
+	})
+
+	it("classifies dependency hydration failures as operational", async () => {
+		const registryContent = {
+			$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+			name: "Operational Failure Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "ops-failure",
+					type: "skill",
+					description: "Forcing install failure",
+					files: [],
+					dependencies: [],
+					opencode: {
+						plugin: ["broken-plugin@file:/definitely/not/a/real/package"],
+					},
+				},
+			],
+		}
+
+		await writeFile(join(testDir, "registry.json"), JSON.stringify(registryContent, null, 2))
+
+		const result = await runCompleteValidation(testDir, {
+			skipDuplicateTargets: false,
+		})
+
+		expect(result.success).toBe(false)
+		expect(result.failureType).toBe("operational")
+		expect(result.errors[0]).toContain("Failed to hydrate plugin validation dependencies")
+	})
 })

--- a/packages/cli/tests/validators.test.ts
+++ b/packages/cli/tests/validators.test.ts
@@ -3,12 +3,18 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import {
 	loadRegistrySource,
+	validatePluginLoadability,
 	validateRegistrySchema,
 	validateRegistrySource,
 	validateRegistryWithOptions,
 	validateSourceFiles,
 } from "../src/lib/validators"
-import { cleanupTempDir, createTempDir } from "./helpers"
+import {
+	cleanupTempDir,
+	createLocalPackageFixture,
+	createTempDir,
+	listPluginValidationTempDirs,
+} from "./helpers"
 
 describe("validateRegistrySource", () => {
 	describe("schema validation", () => {
@@ -464,5 +470,411 @@ describe("validateRegistrySchema", () => {
 		expect(result.data).toBeDefined()
 		expect(result.data?.name).toBe("Test Registry")
 		expect(result.data?.components.length).toBe(1)
+	})
+})
+
+describe("validatePluginLoadability", () => {
+	let testDir: string
+
+	beforeEach(async () => {
+		testDir = await createTempDir("plugin-loadability-test")
+		await mkdir(join(testDir, "files"), { recursive: true })
+	})
+
+	afterEach(async () => {
+		await cleanupTempDir(testDir)
+	})
+
+	function createRegistry(
+		files: Array<{ path: string; target: string }>,
+		extras?: Record<string, unknown>,
+	) {
+		return {
+			$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+			name: "Plugin Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "plugin-component",
+					type: "plugin" as const,
+					description: "Plugin component",
+					files,
+					dependencies: [],
+					...extras,
+				},
+			],
+		}
+	}
+
+	it("validates helper imports outside plugins via staged install tree", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await mkdir(join(testDir, "files", "shared"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "foo.ts"),
+			'import { value } from "../shared/bar"\nexport default value\n',
+		)
+		await writeFile(join(testDir, "files", "shared", "bar.ts"), "export const value = 42\n")
+
+		const registry = createRegistry([
+			{ path: "plugins/foo.ts", target: "plugins/foo.ts" },
+			{ path: "shared/bar.ts", target: "shared/bar.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+	})
+
+	it("discovers and validates nested plugin entrypoints recursively", async () => {
+		await mkdir(join(testDir, "files", "plugins", "nested"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "nested", "deep.ts"),
+			'import leftPad from "left-pad"\nexport default leftPad\n',
+		)
+
+		const registry = createRegistry([
+			{ path: "plugins/nested/deep.ts", target: "plugins/nested/deep.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(result.errors.some((error) => error.includes("not declared in npmDependencies"))).toBe(
+			true,
+		)
+		expect(
+			result.issues.some(
+				(issue) =>
+					issue.code === "plugin_external_dependency_undeclared" &&
+					issue.affectedEntrypoints.includes(".opencode/plugins/nested/deep.ts"),
+			),
+		).toBe(true)
+	})
+
+	it("keeps runtime smoke parsing stable when plugin entrypoints log to stdout", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "logged.ts"),
+			'console.log("plugin initialized")\nexport default { ok: true }\n',
+		)
+
+		const registry = createRegistry([{ path: "plugins/logged.ts", target: "plugins/logged.ts" }])
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+	})
+
+	it("fails on missing transitive helper files", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "missing-helper.ts"),
+			'import "../shared/does-not-exist"\nexport default {}\n',
+		)
+
+		const registry = createRegistry([
+			{ path: "plugins/missing-helper.ts", target: "plugins/missing-helper.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(result.errors.some((error) => error.includes("Cannot resolve static import"))).toBe(true)
+	})
+
+	it("fails on invalid syntax in reachable helper files", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await mkdir(join(testDir, "files", "shared"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "syntax.ts"),
+			'export * from "../shared/bad"\n',
+		)
+		await writeFile(join(testDir, "files", "shared", "bad.ts"), "export const = broken\n")
+
+		const registry = createRegistry([
+			{ path: "plugins/syntax.ts", target: "plugins/syntax.ts" },
+			{ path: "shared/bad.ts", target: "shared/bad.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(result.errors.some((error) => error.includes("Invalid syntax"))).toBe(true)
+	})
+
+	it("supports Bun-style extensionless local resolution with re-export reachability", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await mkdir(join(testDir, "files", "shared"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "entry.ts"),
+			'export * from "../shared/reexport"\n',
+		)
+		await writeFile(join(testDir, "files", "shared", "reexport.ts"), 'export * from "./leaf"\n')
+		await writeFile(join(testDir, "files", "shared", "leaf.ts"), "export const leaf = true\n")
+
+		const registry = createRegistry([
+			{ path: "plugins/entry.ts", target: "plugins/entry.ts" },
+			{ path: "shared/reexport.ts", target: "shared/reexport.ts" },
+			{ path: "shared/leaf.ts", target: "shared/leaf.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+	})
+
+	it("fails unresolved external packages when not declared", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "external.ts"),
+			'import leftPad from "left-pad"\nexport default leftPad\n',
+		)
+
+		const registry = createRegistry([
+			{ path: "plugins/external.ts", target: "plugins/external.ts" },
+		])
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(result.errors.some((error) => error.includes("not declared in npmDependencies"))).toBe(
+			true,
+		)
+	})
+
+	it("ignores type-only imports and exports for dependency checks", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await mkdir(join(testDir, "files", "shared"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "types-only.ts"),
+			'import type { Foo } from "left-pad"\nexport type { TypeA } from "../shared/types"\nexport default {}\n',
+		)
+		await writeFile(join(testDir, "files", "shared", "types.ts"), "export type TypeA = string\n")
+
+		const registry = createRegistry([
+			{ path: "plugins/types-only.ts", target: "plugins/types-only.ts" },
+			{ path: "shared/types.ts", target: "shared/types.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+	})
+
+	it("fails eager dynamic imports but ignores lazy unreachable dynamic imports in precheck", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "eager.ts"),
+			'await import("../shared/missing-dynamic")\nexport default {}\n',
+		)
+		await writeFile(
+			join(testDir, "files", "plugins", "lazy.ts"),
+			'export function lazy() { return import("../shared/missing-dynamic") }\nexport default {}\n',
+		)
+
+		const registry = createRegistry([
+			{ path: "plugins/eager.ts", target: "plugins/eager.ts" },
+			{ path: "plugins/lazy.ts", target: "plugins/lazy.ts" },
+		])
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(result.errors.some((error) => error.includes("Runtime import failed"))).toBe(true)
+		expect(result.errors.some((error) => error.includes("Cannot resolve static import"))).toBe(
+			false,
+		)
+	})
+
+	it("accepts host-provided runtime packages without manifest declarations", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "host.ts"),
+			'import { tool } from "@opencode-ai/plugin"\nexport default tool\n',
+		)
+
+		const registry = createRegistry([{ path: "plugins/host.ts", target: "plugins/host.ts" }])
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+	})
+
+	it("validates opencode.plugin package imports from deterministic local fixtures", async () => {
+		const localPlugin = await createLocalPackageFixture(testDir, {
+			name: "fixture-plugin",
+			entrypointCode: "export default { name: 'fixture-plugin' }\n",
+		})
+
+		const registry = createRegistry([], {
+			opencode: {
+				plugin: [localPlugin.specifier],
+			},
+		})
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+	})
+
+	it("reports runtime failure for broken opencode.plugin package imports", async () => {
+		const brokenPlugin = await createLocalPackageFixture(testDir, {
+			name: "broken-plugin",
+			entrypointCode: 'import "./missing.js"\nexport default {}\n',
+		})
+
+		const registry = createRegistry([], {
+			opencode: {
+				plugin: [brokenPlugin.specifier],
+			},
+		})
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(result.errors.some((error) => error.includes("Package plugin"))).toBe(true)
+	})
+
+	it("warns for non-deterministic opencode.plugin specs without failing", async () => {
+		const registry = createRegistry([], {
+			opencode: {
+				plugin: ["example-plugin"],
+			},
+		})
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+		expect(result.warnings.some((warning) => warning.includes("non-deterministic"))).toBe(true)
+	})
+
+	it("preserves all owning components for shared opencode.plugin diagnostics", async () => {
+		const registry = {
+			$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+			name: "Multi-owner Plugin Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "component-a",
+					type: "skill" as const,
+					description: "component a",
+					files: [],
+					dependencies: [],
+					opencode: {
+						plugin: ["example-plugin"],
+					},
+				},
+				{
+					name: "component-b",
+					type: "skill" as const,
+					description: "component b",
+					files: [],
+					dependencies: [],
+					opencode: {
+						plugin: ["example-plugin"],
+					},
+				},
+			],
+		}
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		const warningIssue = result.issues.find(
+			(issue) => issue.code === "plugin_package_spec_nondeterministic",
+		)
+		expect(warningIssue).toBeDefined()
+		expect(warningIssue?.affectedComponents).toEqual(["component-a", "component-b"])
+	})
+
+	it("reports unsupported qualified cross-registry plugin dependencies", async () => {
+		const registry = createRegistry([], {
+			opencode: {
+				plugin: ["kdco/another-plugin"],
+			},
+		})
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(
+			result.errors.some((error) => error.includes("Unsupported qualified cross-registry")),
+		).toBe(true)
+	})
+
+	it("fails loud on dependency merge conflicts between npmDependencies and npmDevDependencies", async () => {
+		const localDep = await createLocalPackageFixture(testDir, {
+			name: "shared-dep",
+			entrypointCode: "export const value = 1\n",
+		})
+
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "conflict.ts"),
+			'import { value } from "shared-dep"\nexport default value\n',
+		)
+
+		const registry = {
+			$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+			name: "Conflict Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "plugin-a",
+					type: "plugin" as const,
+					description: "A",
+					files: [{ path: "plugins/conflict.ts", target: "plugins/conflict.ts" }],
+					dependencies: [],
+					npmDependencies: [localDep.specifier],
+				},
+				{
+					name: "plugin-b",
+					type: "plugin" as const,
+					description: "B",
+					files: [],
+					dependencies: [],
+					npmDevDependencies: [localDep.specifier],
+				},
+			],
+		}
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(false)
+		expect(
+			result.errors.some((error) => error.includes("both dependencies and devDependencies")),
+		).toBe(true)
+	})
+
+	it("supports .js plugin entrypoints", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(join(testDir, "files", "plugins", "plain.js"), "export default { ok: true }\n")
+
+		const registry = createRegistry([{ path: "plugins/plain.js", target: "plugins/plain.js" }])
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+	})
+
+	it("cleans up ocx-plugin-validation-* workspaces on failure", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "cleanup.ts"),
+			'import "../shared/missing"\nexport default {}\n',
+		)
+
+		const registry = createRegistry([{ path: "plugins/cleanup.ts", target: "plugins/cleanup.ts" }])
+		const before = await listPluginValidationTempDirs()
+
+		await validatePluginLoadability(registry, testDir)
+
+		const after = await listPluginValidationTempDirs()
+		expect(after).toEqual(before)
 	})
 })

--- a/packages/cli/tests/validators.test.ts
+++ b/packages/cli/tests/validators.test.ts
@@ -643,6 +643,29 @@ describe("validatePluginLoadability", () => {
 		)
 	})
 
+	it("does not flag bare Node builtins as undeclared external dependencies", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "builtins.ts"),
+			[
+				'import path from "path"',
+				'import os from "os"',
+				'import { readFile } from "fs/promises"',
+				"export default { sep: path.sep, cwd: process.cwd, tmpdir: os.tmpdir, readFile }",
+			].join("\n"),
+		)
+
+		const registry = createRegistry([
+			{ path: "plugins/builtins.ts", target: "plugins/builtins.ts" },
+		])
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(
+			result.issues.some((issue) => issue.code === "plugin_external_dependency_undeclared"),
+		).toBe(false)
+	})
+
 	it("ignores type-only imports and exports for dependency checks", async () => {
 		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
 		await mkdir(join(testDir, "files", "shared"), { recursive: true })
@@ -702,6 +725,64 @@ describe("validatePluginLoadability", () => {
 		expect(result.errors).toEqual([])
 	})
 
+	it("does not misclassify versioned npm: imports for unscoped packages", async () => {
+		const localDependency = await createLocalPackageFixture(testDir, {
+			name: "versioned-import-dep",
+			version: "4.17.21",
+			entrypointCode: "export default { ok: true }\n",
+		})
+
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "versioned-unscoped.ts"),
+			[
+				'import dep from "npm:versioned-import-dep@4.17.21"',
+				'import "./missing-local"',
+				"export default dep",
+			].join("\n"),
+		)
+
+		const registry = createRegistry(
+			[{ path: "plugins/versioned-unscoped.ts", target: "plugins/versioned-unscoped.ts" }],
+			{
+				npmDependencies: [localDependency.specifier],
+			},
+		)
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(
+			result.issues.some((issue) => issue.code === "plugin_external_dependency_undeclared"),
+		).toBe(false)
+		expect(
+			result.issues.some((issue) => issue.code === "plugin_static_local_import_unresolved"),
+		).toBe(true)
+	})
+
+	it("does not misclassify versioned npm: imports for scoped host packages", async () => {
+		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
+		await writeFile(
+			join(testDir, "files", "plugins", "versioned-scoped.ts"),
+			[
+				'import { tool } from "npm:@opencode-ai/plugin@0.0.0"',
+				'import "./missing-local"',
+				"export default tool",
+			].join("\n"),
+		)
+
+		const registry = createRegistry([
+			{ path: "plugins/versioned-scoped.ts", target: "plugins/versioned-scoped.ts" },
+		])
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(
+			result.issues.some((issue) => issue.code === "plugin_external_dependency_undeclared"),
+		).toBe(false)
+		expect(
+			result.issues.some((issue) => issue.code === "plugin_static_local_import_unresolved"),
+		).toBe(true)
+	})
+
 	it("validates opencode.plugin package imports from deterministic local fixtures", async () => {
 		const localPlugin = await createLocalPackageFixture(testDir, {
 			name: "fixture-plugin",
@@ -750,6 +831,35 @@ describe("validatePluginLoadability", () => {
 		expect(result.valid).toBe(true)
 		expect(result.errors).toEqual([])
 		expect(result.warnings.some((warning) => warning.includes("non-deterministic"))).toBe(true)
+	})
+
+	it("warns for range and tag plugin versions instead of treating them as deterministic", async () => {
+		const nonDeterministicSpecs = [
+			"missing-range-plugin@^1.2.0",
+			"missing-wildcard-plugin@1.x",
+			"missing-tag-plugin@next",
+			"missing-beta-plugin@beta",
+		]
+
+		const registry = createRegistry([], {
+			opencode: {
+				plugin: nonDeterministicSpecs,
+			},
+		})
+
+		const result = await validatePluginLoadability(registry, testDir)
+
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+
+		const nonDeterministicIssues = result.issues.filter(
+			(issue) => issue.code === "plugin_package_spec_nondeterministic",
+		)
+		expect(nonDeterministicIssues).toHaveLength(nonDeterministicSpecs.length)
+
+		for (const spec of nonDeterministicSpecs) {
+			expect(result.warnings.some((warning) => warning.includes(`"${spec}"`))).toBe(true)
+		}
 	})
 
 	it("preserves all owning components for shared opencode.plugin diagnostics", async () => {
@@ -852,14 +962,32 @@ describe("validatePluginLoadability", () => {
 		).toBe(true)
 	})
 
-	it("supports .js plugin entrypoints", async () => {
+	it("validates all Bun-supported plugin entrypoint extensions", async () => {
+		const supportedExtensions = [".ts", ".js", ".mjs", ".cjs", ".mts", ".cts", ".tsx", ".jsx"]
+
 		await mkdir(join(testDir, "files", "plugins"), { recursive: true })
-		await writeFile(join(testDir, "files", "plugins", "plain.js"), "export default { ok: true }\n")
 
-		const registry = createRegistry([{ path: "plugins/plain.js", target: "plugins/plain.js" }])
-		const result = await validatePluginLoadability(registry, testDir)
+		for (const extension of supportedExtensions) {
+			const fileName = `entry${extension}`
+			await writeFile(
+				join(testDir, "files", "plugins", fileName),
+				'import leftPad from "left-pad"\nexport default leftPad\n',
+			)
 
-		expect(result.valid).toBe(true)
+			const registry = createRegistry([
+				{ path: `plugins/${fileName}`, target: `plugins/${fileName}` },
+			])
+			const result = await validatePluginLoadability(registry, testDir)
+
+			expect(result.valid).toBe(false)
+			expect(
+				result.issues.some(
+					(issue) =>
+						issue.code === "plugin_external_dependency_undeclared" &&
+						issue.affectedEntrypoints.includes(`.opencode/plugins/${fileName}`),
+				),
+			).toBe(true)
+		}
 	})
 
 	it("cleans up ocx-plugin-validation-* workspaces on failure", async () => {

--- a/workers/ocx-kit/scripts/build.ts
+++ b/workers/ocx-kit/scripts/build.ts
@@ -3,6 +3,7 @@ import { buildRegistry } from "ocx"
 const result = await buildRegistry({
 	source: ".",
 	out: "dist",
+	skipDuplicateTargets: true,
 })
 
 console.log(`✓ Built ${result.componentsCount} components`)


### PR DESCRIPTION
## Summary
- add plugin loadability checks to registry build and validation flows so broken plugin imports are caught before publish
- integrate host runtime package/dependency handling and improved validation error surfacing across add/build/validate commands
- expand CLI test coverage for validation runner, validators, dry-run behavior, and error handling

## Testing
- not run in this PR creation step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end plugin loadability checks to validation and build, with structured issues and warnings in CLI/JSON output. Restores duplicate-target validation by default; programmatic `buildRegistry` can explicitly opt out via `skipDuplicateTargets`.

- **New Features**
  - Plugin loadability validation: entrypoint presence, static local import resolution, package spec checks, TypeScript transpile, runtime smoke test, and normalized npm/builtin import names.
  - Integrated into `ocx validate`, `ocx build` (incl. dry-run), and programmatic `buildRegistry`; results include `errors`, `warnings`, and structured `issues`.
  - Host runtime stubs for `@opencode-ai/plugin` for deterministic, offline checks.
  - Added `parseNpmDependencySpecifier` and `mergeNpmDependencySpecifiers`; `add` now uses them.

- **Refactors**
  - Centralized via `runCompleteValidation`; `buildRegistry` validates with duplicate-target checks enabled by default (set `skipDuplicateTargets: true` to opt out) and surfaces operational failures via `ValidationFailedError`.
  - CLI and dry-run JSON include issue fields (kind, code, severity, message, affected components/entrypoints); summaries track `pluginLoadabilityErrors`.
  - Exported `BuildRegistryError` and `ValidationFailedError`; broadened tests for validators, runner, build, dry-run JSON, and error formatting.

<sup>Written for commit e3cceb56c19b97fcfaf52162b476b0343d5d6774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

