### PR TITLE
feat: Add notification parity runtime gate and bridge normalization

### DIFF
--- a/docs/MANUAL_TESTING.md
+++ b/docs/MANUAL_TESTING.md
@@ -43,6 +43,79 @@ This document provides a complete testing checklist for OCX. Use it to verify fu
 
 > **Testing Coverage**: For automated coverage details, see `packages/cli/tests/`.
 
+### Phase 2.10 Notification Contract Release Gate (Blocks Phase 3)
+
+- **OCX ownership:** `packages/cli/src/notify/contract-compat.ts`
+- **OCX blocking test:** `packages/cli/tests/notify/contract-compat.test.ts`
+
+Required release evidence:
+
+1. `bun --cwd packages/cli test tests/notify/contract-compat.test.ts` passes.
+2. Upstream opencode notification contract evidence is attached for the same release window:
+   - `packages/opencode/test/plugin/notification-contract.test.ts`
+   - `packages/opencode/test/bus/bus-event-visibility.test.ts`
+   - `packages/opencode/test/server/event-visibility.test.ts`
+
+Scope clarification for Phase 2.10 closure evidence:
+
+- The 2.10 closure gate validates that public generated artifacts remain correct and exclude internal-only channels.
+- It does **not** require those artifacts to be newly regenerated in the 2.10 slice itself.
+- Phase 2 closure still relies on `packages/sdk/openapi.json` and `packages/sdk/js/src/v2/gen/types.gen.ts` being already synced from earlier Phase 2 generation work.
+
+Do not mark the notification contract gate complete (or begin Phase 3-dependent release steps) without this evidence set.
+
+Current closure-window evidence (2026-04-01, blocker audit refresh):
+
+- [x] `bun --cwd packages/cli test tests/notify/contract-compat.test.ts`
+  - PASS — `18 pass`, `0 fail` (bun test v1.3.5, 150ms)
+- [x] (run in `/Users/kenny/workspace/kdcokenny/opencode`) `bun --cwd packages/opencode test test/plugin/notification-contract.test.ts test/bus/bus-event-visibility.test.ts test/server/event-visibility.test.ts`
+  - PASS — `20 pass`, `0 fail` across the three required upstream gate tests (bun test v1.3.11, 5.26s)
+
+### Notification Parity Closure Snapshot (Host Phase 2 closed; OCX Phase 3.1–3.5 complete)
+
+This checklist captures the current reviewer-approved status for notification parity.
+
+**Normative source-of-truth (do not redefine in OCX docs):**
+
+- `opencode/packages/plugin/src/notification.ts`
+- `opencode/packages/opencode/specs/notification-contract-slice-2-host-task-system-mcp.md`
+
+**Derived per-channel status (auditable):**
+
+`Capability visibility` below is the negotiated contract metadata from `opencode/packages/plugin/src/notification.ts` (not the same field as host `notification.*` event-stream visibility).
+
+| Channel | Negotiated state | Capability visibility (matrix metadata) | Support | Fallback / slice note |
+| --- | --- | --- | --- | --- |
+| `ui.toast` | `supported` | `public` | `supported` | `none` |
+| `task.system` | `supported` | `public` | `supported` | `none` |
+| `sdk.system` | `unsupported` | `public` | `unsupported` | `drop`; host `notification.sdk.system` event is internal and not emitted in this slice |
+| `desktop.terminal` | `unsupported` | `public` | `unsupported` | `fail_closed` |
+| `mcp.channel` | `internal_only` | `internal` | `unsupported` | `fail_closed`; host `notification.mcp.channel` event is internal |
+
+**Verification evidence (exact test files):**
+
+- [x] **OCX mixed-version seam verification**
+  - `packages/cli/tests/notify/contract-compat.test.ts`
+  - Covers: unsupported major fail-closed, newer minor/patch warn-and-continue, canonical-channel/state enforcement.
+- [x] **Host 5-channel parity smoke**
+  - `opencode/packages/opencode/test/plugin/notification-contract.test.ts`
+  - Includes `capability matrix parity smoke stays auditable across all five channels`.
+- [x] **MCP fail-closed verification across host/app surfaces**
+  - `opencode/packages/opencode/test/mcp/notification-guard.test.ts`
+  - `opencode/packages/opencode/test/mcp/notification-flow.test.ts`
+  - `opencode/packages/app/src/utils/host-notification.test.ts`
+  - `opencode/packages/app/src/context/notification.consumer.test.ts`
+- [x] **Public/internal visibility enforcement**
+  - `opencode/packages/opencode/test/bus/bus-event-visibility.test.ts`
+  - `opencode/packages/opencode/test/server/event-visibility.test.ts`
+
+**Known non-blocking limitations (recorded, not blockers):**
+
+- `sdk.system` remains negotiated `unsupported` in the capability matrix; host `notification.sdk.system` remains internal and unemitted in this slice.
+- `desktop.terminal` remains unsupported (no delivery implementation yet).
+- `mcp.channel` remains internal-only and not rendered in app/TUI until a trust/source-aware UI surface exists.
+- Reviewer notes include minor coverage follow-ups only; no critical/major blockers remain.
+
 ### Out of Scope
 
 - **Performance benchmarking** - Not covered by manual testing

--- a/packages/cli/src/notify/contract-compat.ts
+++ b/packages/cli/src/notify/contract-compat.ts
@@ -1,0 +1,538 @@
+import { isPlainObject } from "../utils/type-guards"
+
+export const NotificationContractID = "opencode.host.notification" as const
+export const NotificationContractSchemaVersion = "1.1.0" as const
+
+export const NotificationChannel = {
+	UIToast: "ui.toast",
+	TaskSystem: "task.system",
+	SDKSystem: "sdk.system",
+	DesktopTerminal: "desktop.terminal",
+	MCPChannel: "mcp.channel",
+} as const
+
+export type NotificationChannel = (typeof NotificationChannel)[keyof typeof NotificationChannel]
+
+export const NotificationNegotiatedState = {
+	Supported: "supported",
+	FallbackApproved: "fallback_approved",
+	Unsupported: "unsupported",
+	InternalOnly: "internal_only",
+} as const
+
+export type NotificationNegotiatedState =
+	(typeof NotificationNegotiatedState)[keyof typeof NotificationNegotiatedState]
+
+export const NotificationFallbackMode = {
+	None: "none",
+	Drop: "drop",
+	FailClosed: "fail_closed",
+} as const
+
+export type NotificationFallbackMode =
+	(typeof NotificationFallbackMode)[keyof typeof NotificationFallbackMode]
+
+export const NotificationCanonicalChannels = Object.values(
+	NotificationChannel,
+) as readonly NotificationChannel[]
+
+export type NotificationNegotiatedStateByChannel = {
+	[channel in NotificationChannel]: NotificationNegotiatedState
+}
+
+export type NotificationFallbackModeByChannel = {
+	[channel in NotificationChannel]: NotificationFallbackMode
+}
+
+type SemverParts = {
+	major: number
+	minor: number
+	patch: number
+}
+
+const STRICT_SEMVER_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+const NotificationCanonicalChannelSet = new Set<string>(NotificationCanonicalChannels)
+const NotificationNegotiatedStateSet = new Set<string>(Object.values(NotificationNegotiatedState))
+
+const SupportedSchemaVersionParts = (() => {
+	const parsed = parseStrictSemver(NotificationContractSchemaVersion)
+	if (!parsed) {
+		throw new Error(
+			`Invalid NotificationContractSchemaVersion constant: ${NotificationContractSchemaVersion}`,
+		)
+	}
+
+	return parsed
+})()
+
+export type NotificationContractCompatErrorIssue =
+	| {
+			severity: "error"
+			code: "invalid-contract-format"
+			path: string
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "invalid-contract-id"
+			expectedContractID: typeof NotificationContractID
+			receivedContractID: string | null
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "missing-schema-version"
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "invalid-schema-version"
+			schemaVersion: string
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "unsupported-schema-major"
+			supportedMajor: number
+			detectedMajor: number
+			schemaVersion: string
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "missing-required-channel"
+			channel: NotificationChannel
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "unknown-negotiated-state"
+			channel: NotificationChannel
+			state: string
+			message: string
+	  }
+
+export type NotificationContractCompatWarningIssue =
+	| {
+			severity: "warning"
+			code: "newer-schema-minor-or-patch"
+			supportedSchemaVersion: typeof NotificationContractSchemaVersion
+			receivedSchemaVersion: string
+			message: string
+	  }
+	| {
+			severity: "warning"
+			code: "unknown-channel-ignored"
+			channel: string
+			message: string
+	  }
+
+export type NotificationContractCompatibilityResult =
+	| {
+			compatible: true
+			contractID: typeof NotificationContractID
+			schemaVersion: string
+			negotiatedStateByChannel: NotificationNegotiatedStateByChannel
+			warnings: NotificationContractCompatWarningIssue[]
+	  }
+	| {
+			compatible: false
+			errors: NotificationContractCompatErrorIssue[]
+			warnings: NotificationContractCompatWarningIssue[]
+	  }
+
+export interface NotificationContractHandshake {
+	contract: {
+		id: string
+		schemaVersion: string
+	}
+	capabilities: Record<string, { state: string }>
+}
+
+export function classifyNotificationContractHandshake(
+	handshake: unknown,
+): NotificationContractCompatibilityResult {
+	const warnings: NotificationContractCompatWarningIssue[] = []
+
+	if (!isPlainObject(handshake)) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-format",
+					path: "$",
+					message: "Notification contract handshake must be an object.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (!isPlainObject(handshake.contract)) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-format",
+					path: "contract",
+					message: "Notification contract handshake must include a contract object.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const contract = handshake.contract
+	const contractID = contract.id
+
+	if (contractID !== NotificationContractID) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-id",
+					expectedContractID: NotificationContractID,
+					receivedContractID: typeof contractID === "string" ? contractID : null,
+					message: `Notification contract id mismatch. Expected "${NotificationContractID}".`,
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (!Object.hasOwn(contract, "schemaVersion")) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "missing-schema-version",
+					message: "Notification contract schemaVersion is required.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const schemaVersion = contract.schemaVersion
+	if (typeof schemaVersion !== "string" || schemaVersion.length === 0) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-schema-version",
+					schemaVersion: String(schemaVersion),
+					message: "Notification contract schemaVersion must be a non-empty semver string.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const parsedSchemaVersion = parseStrictSemver(schemaVersion)
+	if (!parsedSchemaVersion) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-schema-version",
+					schemaVersion,
+					message: "Notification contract schemaVersion must be strict semver (major.minor.patch).",
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (parsedSchemaVersion.major !== SupportedSchemaVersionParts.major) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "unsupported-schema-major",
+					supportedMajor: SupportedSchemaVersionParts.major,
+					detectedMajor: parsedSchemaVersion.major,
+					schemaVersion,
+					message:
+						`Unsupported notification contract schema major ${parsedSchemaVersion.major}. ` +
+						`Expected major ${SupportedSchemaVersionParts.major}.`,
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (isNewerMinorOrPatch(parsedSchemaVersion, SupportedSchemaVersionParts)) {
+		warnings.push({
+			severity: "warning",
+			code: "newer-schema-minor-or-patch",
+			supportedSchemaVersion: NotificationContractSchemaVersion,
+			receivedSchemaVersion: schemaVersion,
+			message:
+				`Notification contract schemaVersion ${schemaVersion} is newer than supported ` +
+				`${NotificationContractSchemaVersion}. Continuing with same-major compatibility mode.`,
+		})
+	}
+
+	if (!isPlainObject(handshake.capabilities)) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-format",
+					path: "capabilities",
+					message: "Notification contract handshake must include a capabilities object.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const capabilities = handshake.capabilities
+
+	for (const channel of Object.keys(capabilities)) {
+		if (NotificationCanonicalChannelSet.has(channel)) {
+			continue
+		}
+
+		warnings.push({
+			severity: "warning",
+			code: "unknown-channel-ignored",
+			channel,
+			message: `Notification channel "${channel}" is unknown to this OCX version and will be ignored.`,
+		})
+	}
+
+	const errors: NotificationContractCompatErrorIssue[] = []
+	const parsedStates: Partial<NotificationNegotiatedStateByChannel> = {}
+
+	for (const channel of NotificationCanonicalChannels) {
+		if (!Object.hasOwn(capabilities, channel)) {
+			errors.push({
+				severity: "error",
+				code: "missing-required-channel",
+				channel,
+				message: `Missing required notification channel capability "${channel}".`,
+			})
+			continue
+		}
+
+		const capability = capabilities[channel]
+		if (!isPlainObject(capability)) {
+			errors.push({
+				severity: "error",
+				code: "invalid-contract-format",
+				path: `capabilities.${channel}`,
+				message: `Capability entry for channel "${channel}" must be an object.`,
+			})
+			continue
+		}
+
+		const state = capability.state
+		if (typeof state !== "string") {
+			errors.push({
+				severity: "error",
+				code: "invalid-contract-format",
+				path: `capabilities.${channel}.state`,
+				message: `Capability state for channel "${channel}" must be a string.`,
+			})
+			continue
+		}
+
+		if (!NotificationNegotiatedStateSet.has(state)) {
+			errors.push({
+				severity: "error",
+				code: "unknown-negotiated-state",
+				channel,
+				state,
+				message: `Unknown notification negotiated state "${state}" for channel "${channel}".`,
+			})
+			continue
+		}
+
+		parsedStates[channel] = state as NotificationNegotiatedState
+	}
+
+	if (errors.length > 0) {
+		return incompatible(errors, warnings)
+	}
+
+	const negotiatedStateByChannelResult = buildNegotiatedStateByChannel(parsedStates)
+	if (!negotiatedStateByChannelResult.compatible) {
+		return incompatible(negotiatedStateByChannelResult.errors, warnings)
+	}
+
+	return {
+		compatible: true,
+		contractID: NotificationContractID,
+		schemaVersion,
+		negotiatedStateByChannel: negotiatedStateByChannelResult.negotiatedStateByChannel,
+		warnings,
+	}
+}
+
+function parseStrictSemver(version: string): SemverParts | null {
+	const match = version.match(STRICT_SEMVER_REGEX)
+	if (!match) {
+		return null
+	}
+
+	const majorToken = match[1]
+	const minorToken = match[2]
+	const patchToken = match[3]
+	if (!majorToken || !minorToken || !patchToken) {
+		return null
+	}
+
+	return {
+		major: Number.parseInt(majorToken, 10),
+		minor: Number.parseInt(minorToken, 10),
+		patch: Number.parseInt(patchToken, 10),
+	}
+}
+
+function isNewerMinorOrPatch(candidate: SemverParts, supported: SemverParts): boolean {
+	if (candidate.major !== supported.major) {
+		return false
+	}
+
+	if (candidate.minor > supported.minor) {
+		return true
+	}
+
+	if (candidate.minor < supported.minor) {
+		return false
+	}
+
+	return candidate.patch > supported.patch
+}
+
+function buildNegotiatedStateByChannel(parsedStates: Partial<NotificationNegotiatedStateByChannel>):
+	| {
+			compatible: true
+			negotiatedStateByChannel: NotificationNegotiatedStateByChannel
+	  }
+	| {
+			compatible: false
+			errors: NotificationContractCompatErrorIssue[]
+	  } {
+	const errors: NotificationContractCompatErrorIssue[] = []
+	const negotiatedStateByChannel: Partial<NotificationNegotiatedStateByChannel> = {}
+
+	for (const channel of NotificationCanonicalChannels) {
+		const state = parsedStates[channel]
+		if (state === undefined) {
+			errors.push({
+				severity: "error",
+				code: "missing-required-channel",
+				channel,
+				message: `Missing required notification channel capability "${channel}".`,
+			})
+			continue
+		}
+
+		negotiatedStateByChannel[channel] = state
+	}
+
+	if (errors.length > 0) {
+		return {
+			compatible: false,
+			errors,
+		}
+	}
+
+	return {
+		compatible: true,
+		negotiatedStateByChannel: negotiatedStateByChannel as NotificationNegotiatedStateByChannel,
+	}
+}
+
+function incompatible(
+	errors: NotificationContractCompatErrorIssue[],
+	warnings: NotificationContractCompatWarningIssue[],
+): NotificationContractCompatibilityResult {
+	return {
+		compatible: false,
+		errors,
+		warnings,
+	}
+}
+
+export const ClosedHostDefaultNotificationHandshake: NotificationContractHandshake = {
+	contract: {
+		id: NotificationContractID,
+		schemaVersion: NotificationContractSchemaVersion,
+	},
+	capabilities: {
+		[NotificationChannel.UIToast]: { state: NotificationNegotiatedState.Supported },
+		[NotificationChannel.TaskSystem]: { state: NotificationNegotiatedState.Supported },
+		[NotificationChannel.SDKSystem]: { state: NotificationNegotiatedState.Unsupported },
+		[NotificationChannel.DesktopTerminal]: { state: NotificationNegotiatedState.Unsupported },
+		[NotificationChannel.MCPChannel]: { state: NotificationNegotiatedState.InternalOnly },
+	},
+}
+
+export const ClosedHostDefaultNotificationCompatibility = (() => {
+	const compatibility = classifyNotificationContractHandshake(
+		ClosedHostDefaultNotificationHandshake,
+	)
+	if (!compatibility.compatible) {
+		const issueCodes = compatibility.errors.map((issue) => issue.code).join(", ") || "unknown"
+		throw new Error(
+			`Closed host notification contract fixture is invalid. Compatibility errors: ${issueCodes}.`,
+		)
+	}
+
+	return compatibility
+})()
+
+export const ClosedHostDefaultNotificationNegotiatedStateByChannel =
+	ClosedHostDefaultNotificationCompatibility.negotiatedStateByChannel
+
+export const ClosedHostDefaultNotificationFallbackModeByChannel: NotificationFallbackModeByChannel =
+	{
+		[NotificationChannel.UIToast]: NotificationFallbackMode.None,
+		[NotificationChannel.TaskSystem]: NotificationFallbackMode.None,
+		[NotificationChannel.SDKSystem]: NotificationFallbackMode.Drop,
+		[NotificationChannel.DesktopTerminal]: NotificationFallbackMode.FailClosed,
+		[NotificationChannel.MCPChannel]: NotificationFallbackMode.FailClosed,
+	}
+
+assertClosedHostDefaultFallbackPolicyConsistency({
+	negotiatedStateByChannel: ClosedHostDefaultNotificationNegotiatedStateByChannel,
+	fallbackModeByChannel: ClosedHostDefaultNotificationFallbackModeByChannel,
+})
+
+function assertClosedHostDefaultFallbackPolicyConsistency(input: {
+	negotiatedStateByChannel: NotificationNegotiatedStateByChannel
+	fallbackModeByChannel: NotificationFallbackModeByChannel
+}): void {
+	for (const channel of NotificationCanonicalChannels) {
+		const state = input.negotiatedStateByChannel[channel]
+		const fallbackMode = input.fallbackModeByChannel[channel]
+
+		if (fallbackMode === NotificationFallbackMode.None) {
+			if (
+				state === NotificationNegotiatedState.Supported ||
+				state === NotificationNegotiatedState.FallbackApproved
+			) {
+				continue
+			}
+
+			throw new Error(
+				`Closed host notification fallback policy mismatch: channel ${channel} uses fallback mode "${fallbackMode}" but negotiated state is "${state}".`,
+			)
+		}
+
+		if (
+			state === NotificationNegotiatedState.Unsupported ||
+			state === NotificationNegotiatedState.InternalOnly
+		) {
+			continue
+		}
+
+		throw new Error(
+			`Closed host notification fallback policy mismatch: channel ${channel} uses fallback mode "${fallbackMode}" but negotiated state is "${state}".`,
+		)
+	}
+}

--- a/packages/cli/tests/notify/contract-compat.test.ts
+++ b/packages/cli/tests/notify/contract-compat.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from "bun:test"
+import {
+	classifyNotificationContractHandshake,
+	NotificationChannel,
+	NotificationContractID,
+	NotificationContractSchemaVersion,
+	NotificationNegotiatedState,
+} from "../../src/notify/contract-compat"
+
+function createValidHandshake(): {
+	contract: { id: string; schemaVersion: string }
+	capabilities: Record<string, { state: string }>
+} {
+	return {
+		contract: {
+			id: NotificationContractID,
+			schemaVersion: NotificationContractSchemaVersion,
+		},
+		capabilities: {
+			[NotificationChannel.UIToast]: { state: NotificationNegotiatedState.Supported },
+			[NotificationChannel.TaskSystem]: { state: NotificationNegotiatedState.Supported },
+			[NotificationChannel.SDKSystem]: { state: NotificationNegotiatedState.Unsupported },
+			[NotificationChannel.DesktopTerminal]: {
+				state: NotificationNegotiatedState.Unsupported,
+			},
+			[NotificationChannel.MCPChannel]: { state: NotificationNegotiatedState.InternalOnly },
+		},
+	}
+}
+
+describe("classifyNotificationContractHandshake", () => {
+	it("fails when handshake payload is not an object", () => {
+		const result = classifyNotificationContractHandshake(null)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-contract-format",
+			path: "$",
+		})
+	})
+
+	it("fails when contract is missing", () => {
+		const result = classifyNotificationContractHandshake({
+			capabilities: {},
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-contract-format",
+			path: "contract",
+		})
+	})
+
+	it("fails when contract is not an object", () => {
+		const result = classifyNotificationContractHandshake({
+			contract: "invalid",
+			capabilities: {},
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-contract-format",
+			path: "contract",
+		})
+	})
+
+	it("accepts exact schema version 1.1.0 with no warnings", () => {
+		const result = classifyNotificationContractHandshake(createValidHandshake())
+
+		expect(result.compatible).toBe(true)
+		if (!result.compatible) {
+			expect.unreachable("Expected compatible notification handshake")
+		}
+
+		expect(result.schemaVersion).toBe("1.1.0")
+		expect(result.warnings).toEqual([])
+		expect(result.negotiatedStateByChannel).toEqual({
+			[NotificationChannel.UIToast]: NotificationNegotiatedState.Supported,
+			[NotificationChannel.TaskSystem]: NotificationNegotiatedState.Supported,
+			[NotificationChannel.SDKSystem]: NotificationNegotiatedState.Unsupported,
+			[NotificationChannel.DesktopTerminal]: NotificationNegotiatedState.Unsupported,
+			[NotificationChannel.MCPChannel]: NotificationNegotiatedState.InternalOnly,
+		})
+	})
+
+	it("fails on unsupported schema major mismatch", () => {
+		const handshake = createValidHandshake()
+		handshake.contract.schemaVersion = "2.0.0"
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]?.code).toBe("unsupported-schema-major")
+		expect(result.errors[0]).toMatchObject({
+			code: "unsupported-schema-major",
+			supportedMajor: 1,
+			detectedMajor: 2,
+			schemaVersion: "2.0.0",
+		})
+	})
+
+	it("warns and continues for newer minor/patch on same major", () => {
+		const handshake = createValidHandshake()
+		handshake.contract.schemaVersion = "1.2.0"
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(true)
+		if (!result.compatible) {
+			expect.unreachable("Expected compatible notification handshake")
+		}
+
+		expect(result.warnings).toHaveLength(1)
+		expect(result.warnings[0]).toMatchObject({
+			code: "newer-schema-minor-or-patch",
+			receivedSchemaVersion: "1.2.0",
+			supportedSchemaVersion: "1.1.0",
+		})
+	})
+
+	it("warns and ignores unknown extra channel keys", () => {
+		const handshake = createValidHandshake()
+		handshake.capabilities["future.channel"] = { state: NotificationNegotiatedState.Supported }
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(true)
+		if (!result.compatible) {
+			expect.unreachable("Expected compatible notification handshake")
+		}
+
+		expect(result.warnings).toContainEqual(
+			expect.objectContaining({
+				code: "unknown-channel-ignored",
+				channel: "future.channel",
+			}),
+		)
+		expect(Object.hasOwn(result.negotiatedStateByChannel, "future.channel")).toBe(false)
+	})
+
+	it("fails when a canonical channel is missing", () => {
+		const handshake = createValidHandshake()
+		delete handshake.capabilities[NotificationChannel.DesktopTerminal]
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: "missing-required-channel",
+				channel: NotificationChannel.DesktopTerminal,
+			}),
+		)
+	})
+
+	it("fails when a known channel has an unknown negotiated state", () => {
+		const handshake = createValidHandshake()
+		handshake.capabilities[NotificationChannel.SDKSystem] = { state: "legacy_supported" }
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: "unknown-negotiated-state",
+				channel: NotificationChannel.SDKSystem,
+				state: "legacy_supported",
+			}),
+		)
+	})
+
+	it("fails malformed contract payloads", () => {
+		const result = classifyNotificationContractHandshake({
+			contract: {
+				id: "invalid.contract.id",
+				schemaVersion: "1.1.0",
+			},
+			capabilities: {},
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]?.code).toBe("invalid-contract-id")
+	})
+
+	it("fails invalid contract id types with null receivedContractID", () => {
+		const result = classifyNotificationContractHandshake({
+			contract: {
+				id: 42,
+				schemaVersion: "1.1.0",
+			},
+			capabilities: {},
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-contract-id",
+			receivedContractID: null,
+		})
+	})
+
+	it("fails when schemaVersion is missing", () => {
+		const result = classifyNotificationContractHandshake({
+			contract: {
+				id: NotificationContractID,
+			},
+			capabilities: {},
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]?.code).toBe("missing-schema-version")
+	})
+
+	it("fails when schemaVersion is an empty string", () => {
+		const handshake = createValidHandshake()
+		handshake.contract.schemaVersion = ""
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-schema-version",
+			schemaVersion: "",
+		})
+	})
+
+	it("fails when schemaVersion format is not strict semver", () => {
+		const handshake = createValidHandshake()
+		handshake.contract.schemaVersion = "1.1"
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-schema-version",
+			schemaVersion: "1.1",
+		})
+	})
+
+	it("fails when capabilities object is missing", () => {
+		const result = classifyNotificationContractHandshake({
+			contract: {
+				id: NotificationContractID,
+				schemaVersion: NotificationContractSchemaVersion,
+			},
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-contract-format",
+			path: "capabilities",
+		})
+	})
+
+	it("fails when capabilities is not an object", () => {
+		const result = classifyNotificationContractHandshake({
+			contract: {
+				id: NotificationContractID,
+				schemaVersion: NotificationContractSchemaVersion,
+			},
+			capabilities: "invalid",
+		})
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors[0]).toMatchObject({
+			code: "invalid-contract-format",
+			path: "capabilities",
+		})
+	})
+
+	it("fails when capability entry is not an object", () => {
+		const handshake = createValidHandshake()
+		handshake.capabilities[NotificationChannel.SDKSystem] = "invalid" as never
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: "invalid-contract-format",
+				path: `capabilities.${NotificationChannel.SDKSystem}`,
+			}),
+		)
+	})
+
+	it("fails when negotiated state is not a string", () => {
+		const handshake = createValidHandshake()
+		handshake.capabilities[NotificationChannel.SDKSystem] = { state: 123 as never }
+
+		const result = classifyNotificationContractHandshake(handshake)
+
+		expect(result.compatible).toBe(false)
+		if (result.compatible) {
+			expect.unreachable("Expected incompatible notification handshake")
+		}
+
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: "invalid-contract-format",
+				path: `capabilities.${NotificationChannel.SDKSystem}.state`,
+			}),
+		)
+	})
+})

--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -17,6 +17,11 @@ import type { Event, Message, Part, TextPart } from "@opencode-ai/sdk"
 import { adjectives, animals, colors, uniqueNamesGenerator } from "unique-names-generator"
 import { getProjectId } from "./kdco-primitives/get-project-id"
 import type { OpencodeClient } from "./kdco-primitives/types"
+import {
+	type NotificationLevel,
+	NotificationLevel as NotificationLevelValue,
+} from "./notify/normalize"
+import { createNotificationTaskSystemEvent } from "./notify/task-system-event"
 
 // ==========================================
 // READABLE ID GENERATION
@@ -236,6 +241,7 @@ const DEFAULT_MAX_RUN_TIME_MS = 15 * 60 * 1000 // 15 minutes
 const TERMINAL_WAIT_GRACE_MS = 10_000
 const READ_POLL_INTERVAL_MS = 250
 const ALL_COMPLETE_QUIET_PERIOD_MS = 50
+const TASK_SYSTEM_BRIDGE_PAYLOAD_TAG = "task-system-bridge-payload"
 
 interface DelegateInput {
 	parentSessionID: string
@@ -394,6 +400,33 @@ function parsePersistedStatus(raw: string | undefined): DelegationStatus {
 	if (raw === "cancelled") return "cancelled"
 	if (raw === "timeout") return "timeout"
 	return "complete"
+}
+
+function mapDelegationStatusToTaskSystemLevel(status: DelegationStatus): NotificationLevel {
+	if (status === "complete") return NotificationLevelValue.Success
+	if (status === "error") return NotificationLevelValue.Error
+	if (status === "registered" || status === "running") return NotificationLevelValue.Info
+	return NotificationLevelValue.Warning
+}
+
+function buildTaskSystemBridgePayload(input: {
+	id: string
+	dedupeKey: string
+	title?: string
+	message: string
+	level: NotificationLevel
+	sessionID?: string
+}): string {
+	return JSON.stringify(
+		createNotificationTaskSystemEvent({
+			id: input.id,
+			dedupeKey: input.dedupeKey,
+			title: input.title,
+			message: input.message,
+			level: input.level,
+			sessionID: input.sessionID,
+		}),
+	)
 }
 
 export class DelegationManager {
@@ -840,16 +873,28 @@ export class DelegationManager {
 	}
 
 	private buildTerminalNotification(delegation: DelegationRecord, remainingCount: number): string {
+		const summary = `Background agent ${delegation.status}: ${delegation.title || delegation.id}`
+		const bridgeIdentity = `background-agent:terminal:${delegation.parentSessionID}:${delegation.id}:${delegation.status}`
+		const taskSystemBridgePayload = buildTaskSystemBridgePayload({
+			id: bridgeIdentity,
+			dedupeKey: bridgeIdentity,
+			title: delegation.title,
+			message: summary,
+			level: mapDelegationStatusToTaskSystemLevel(delegation.status),
+			sessionID: delegation.parentSessionID,
+		})
+
 		const lines = [
 			"<task-notification>",
 			`<task-id>${delegation.id}</task-id>`,
 			`<status>${delegation.status}</status>`,
-			`<summary>Background agent ${delegation.status}: ${delegation.title || delegation.id}</summary>`,
+			`<summary>${summary}</summary>`,
 			delegation.title ? `<title>${delegation.title}</title>` : "",
 			delegation.description ? `<description>${delegation.description}</description>` : "",
 			delegation.error ? `<error>${delegation.error}</error>` : "",
 			`<artifact>${delegation.artifact.filePath}</artifact>`,
 			`<retrieval>Use delegation_read("${delegation.id}") for full output.</retrieval>`,
+			`<${TASK_SYSTEM_BRIDGE_PAYLOAD_TAG}>${taskSystemBridgePayload}</${TASK_SYSTEM_BRIDGE_PAYLOAD_TAG}>`,
 			remainingCount > 0 ? `<remaining>${remainingCount}</remaining>` : "",
 			"</task-notification>",
 		]
@@ -862,6 +907,17 @@ export class DelegationManager {
 		cycle: number,
 		cycleToken: string,
 	): string {
+		const summary = "All delegations complete."
+		const bridgeIdentity = `background-agent:all-complete:${parentSessionID}:${cycleToken}`
+		const taskSystemBridgePayload = buildTaskSystemBridgePayload({
+			id: bridgeIdentity,
+			dedupeKey: bridgeIdentity,
+			title: "All delegations complete",
+			message: summary,
+			level: NotificationLevelValue.Success,
+			sessionID: parentSessionID,
+		})
+
 		// cycle-token is a boundary watermark.
 		// Receivers should ignore all-complete payloads whose token is older than
 		// the latest known registration cycle for this parent session.
@@ -869,10 +925,11 @@ export class DelegationManager {
 			"<task-notification>",
 			"<type>all-complete</type>",
 			"<status>completed</status>",
-			"<summary>All delegations complete.</summary>",
+			`<summary>${summary}</summary>`,
 			`<parent-session-id>${parentSessionID}</parent-session-id>`,
 			`<cycle>${cycle}</cycle>`,
 			`<cycle-token>${cycleToken}</cycle-token>`,
+			`<${TASK_SYSTEM_BRIDGE_PAYLOAD_TAG}>${taskSystemBridgePayload}</${TASK_SYSTEM_BRIDGE_PAYLOAD_TAG}>`,
 			"</task-notification>",
 		].join("\n")
 	}

--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -17,11 +17,41 @@ import type { Event, Message, Part, TextPart } from "@opencode-ai/sdk"
 import { adjectives, animals, colors, uniqueNamesGenerator } from "unique-names-generator"
 import { getProjectId } from "./kdco-primitives/get-project-id"
 import type { OpencodeClient } from "./kdco-primitives/types"
-import {
-	type NotificationLevel,
-	NotificationLevel as NotificationLevelValue,
-} from "./notify/normalize"
-import { createNotificationTaskSystemEvent } from "./notify/task-system-event"
+
+const NotificationLevelValue = {
+	Info: "info",
+	Success: "success",
+	Warning: "warning",
+	Error: "error",
+} as const
+
+type NotificationLevel = (typeof NotificationLevelValue)[keyof typeof NotificationLevelValue]
+
+const NotificationTaskSystemEventType = "notification.task.system" as const
+
+function createNotificationTaskSystemEvent(properties: {
+	id?: string
+	dedupeKey?: string
+	title?: string
+	message: string
+	level: NotificationLevel
+	sessionID?: string
+}): {
+	type: typeof NotificationTaskSystemEventType
+	properties: {
+		id?: string
+		dedupeKey?: string
+		title?: string
+		message: string
+		level: NotificationLevel
+		sessionID?: string
+	}
+} {
+	return {
+		type: NotificationTaskSystemEventType,
+		properties,
+	}
+}
 
 // ==========================================
 // READABLE ID GENERATION

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -306,17 +306,12 @@ export function resolveNotificationRuntimePolicyFromHostHandshake(
 	}
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		!Array.isArray(value) &&
-		Object.getPrototypeOf(value) === Object.prototype
-	)
+function isPropertyBag(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function readHostNotificationContractHandshake(ctx: unknown): unknown {
-	if (!isPlainObject(ctx)) {
+	if (!isPropertyBag(ctx)) {
 		return undefined
 	}
 

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -25,11 +25,32 @@ import type { Plugin } from "@opencode-ai/plugin"
 import type { Event } from "@opencode-ai/sdk"
 // @ts-expect-error - installed at runtime by OCX
 import detectTerminal from "detect-terminal"
-// @ts-expect-error - installed at runtime by OCX
-import notifier from "node-notifier"
+import {
+	classifyNotificationContractHandshake,
+	type NotificationContractCompatErrorIssue,
+	type NotificationContractCompatWarningIssue,
+} from "../../../../packages/cli/src/notify/contract-compat"
+import { isPlainObject } from "../../../../packages/cli/src/utils/type-guards"
 import type { OpencodeClient } from "./kdco-primitives/types"
-import { sendNotificationWithFallback } from "./notify/backend"
-import { canUseCmuxNotification, sendCmuxNotification } from "./notify/cmux"
+import {
+	type DesktopTransportPayload,
+	type NotifyBackendRuntime,
+	sendNotificationWithFallback,
+} from "./notify/backend"
+import { canUseCmuxNotification } from "./notify/cmux"
+import {
+	createNotificationCapabilityByChannelFromNegotiatedState,
+	DEFAULT_NOTIFICATION_CAPABILITY_BY_CHANNEL,
+	DesktopTerminalSemanticIntent,
+	type NormalizedNotificationIntent,
+	type NormalizedNotificationParseFailure,
+	type NormalizeNotificationBoundaryInput,
+	type NormalizeNotificationOptions,
+	NotificationChannel,
+	NotificationHandlingMode,
+	NotificationLevel,
+	normalizeNotificationBoundaryInput,
+} from "./notify/normalize"
 
 interface NotifyConfig {
 	/** Notify for child/sub-session events (default: false) */
@@ -227,27 +248,114 @@ interface NotificationOptions {
 	subtitle?: string
 	cmuxBody?: string
 	sound: string
-	terminalInfo: TerminalInfo
-}
-
-interface NotificationRuntime {
-	preferCmux: boolean
+	terminalBundleId?: string | null
 }
 
 const QUESTION_DEDUPE_WINDOW_MS = 1500
 const READY_DEDUPE_WINDOW_MS = 1500
 const PERMISSION_DEDUPE_WINDOW_MS = 1500
 
+const NORMALIZE_NOTIFICATION_POLICY: NormalizeNotificationOptions = {
+	capabilityByChannel: DEFAULT_NOTIFICATION_CAPABILITY_BY_CHANNEL,
+}
+
+export type NotifyRuntimePolicyResolution =
+	| {
+			compatible: true
+			source: "default" | "host-handshake"
+			normalizePolicy: NormalizeNotificationOptions
+			warnings: NotificationContractCompatWarningIssue[]
+	  }
+	| {
+			compatible: false
+			source: "host-handshake"
+			errors: NotificationContractCompatErrorIssue[]
+			warnings: NotificationContractCompatWarningIssue[]
+	  }
+
+export function resolveNotificationRuntimePolicyFromHostHandshake(
+	hostNotificationContractHandshake: unknown,
+): NotifyRuntimePolicyResolution {
+	if (hostNotificationContractHandshake === undefined) {
+		return {
+			compatible: true,
+			source: "default",
+			normalizePolicy: NORMALIZE_NOTIFICATION_POLICY,
+			warnings: [],
+		}
+	}
+
+	const compatibility = classifyNotificationContractHandshake(hostNotificationContractHandshake)
+	if (!compatibility.compatible) {
+		return {
+			compatible: false,
+			source: "host-handshake",
+			errors: compatibility.errors,
+			warnings: compatibility.warnings,
+		}
+	}
+
+	return {
+		compatible: true,
+		source: "host-handshake",
+		normalizePolicy: {
+			capabilityByChannel: createNotificationCapabilityByChannelFromNegotiatedState(
+				compatibility.negotiatedStateByChannel,
+			),
+		},
+		warnings: compatibility.warnings,
+	}
+}
+
+function readHostNotificationContractHandshake(ctx: unknown): unknown {
+	if (!isPlainObject(ctx)) {
+		return undefined
+	}
+
+	if (!Object.hasOwn(ctx, "notificationContractHandshake")) {
+		return undefined
+	}
+
+	return (ctx as Record<string, unknown>).notificationContractHandshake
+}
+
+function reportHostHandshakeWarnings(warnings: NotificationContractCompatWarningIssue[]): void {
+	for (const warning of warnings) {
+		console.warn(
+			`[notify] Host notification handshake warning: ${warning.code} (${warning.message})`,
+		)
+	}
+}
+
+export async function processBoundaryInput(
+	input: NormalizeNotificationBoundaryInput,
+	options: {
+		normalizePolicy?: NormalizeNotificationOptions
+		routeNormalizedIntent: (intent: NormalizedNotificationIntent) => Promise<void>
+		handleParseFailure?: (failure: NormalizedNotificationParseFailure) => void
+	},
+): Promise<void> {
+	const parsed = normalizeNotificationBoundaryInput(input, options.normalizePolicy)
+	if (!parsed.ok) {
+		const onParseFailure = options.handleParseFailure ?? handleNormalizeParseFailure
+		onParseFailure(parsed)
+		return
+	}
+
+	await options.routeNormalizedIntent(parsed.intent)
+}
+
+const SESSION_READY_TITLE = "Ready for review"
+const SESSION_ERROR_TITLE = "Something went wrong"
+const PERMISSION_TITLE = "Waiting for you"
+const QUESTION_TITLE = "Question for you"
+
 type RecentNotifications = Map<string, number>
 
-function toNonEmptyString(value: unknown): string | null {
-	if (typeof value !== "string") return null
-
-	const normalized = value.trim()
-	if (!normalized) return null
-
-	return normalized
-}
+type DesktopTerminalIntent = Extract<
+	NormalizedNotificationIntent,
+	{ channel: typeof NotificationChannel.DesktopTerminal }
+>
 
 function shouldSendDedupedNotification(
 	recentNotifications: RecentNotifications,
@@ -270,89 +378,59 @@ function shouldSendDedupedNotification(
 	return true
 }
 
-function buildQuestionToolDedupeKey(sessionID: unknown, callID: unknown): string | null {
-	const normalizedSessionID = toNonEmptyString(sessionID)
-	if (!normalizedSessionID) return null
-
-	const normalizedCallID = toNonEmptyString(callID)
-	if (!normalizedCallID) return null
-
-	return `question:${normalizedSessionID}:${normalizedCallID}`
-}
-
-function buildQuestionEventDedupeKey(properties: unknown): string | null {
-	if (!properties || typeof properties !== "object") return null
-
-	const record = properties as Record<string, unknown>
-	const normalizedSessionID = toNonEmptyString(record.sessionID)
-	if (!normalizedSessionID) return null
-
-	const toolInfo =
-		record.tool && typeof record.tool === "object"
-			? (record.tool as Record<string, unknown>)
-			: undefined
-	const normalizedCallID = toNonEmptyString(toolInfo?.callID)
-	if (normalizedCallID) {
-		return `question:${normalizedSessionID}:${normalizedCallID}`
+function handleNormalizeParseFailure(failure: NormalizedNotificationParseFailure): void {
+	if (failure.code === "unsupported-type") {
+		return
 	}
 
-	const normalizedRequestID = toNonEmptyString(record.id)
-	if (normalizedRequestID) {
-		return `question:${normalizedSessionID}:request:${normalizedRequestID}`
-	}
-
-	return null
+	const rawTypeLabel = failure.rawType ? ` type=${failure.rawType}` : ""
+	console.warn(
+		`[notify] Dropping ${failure.source} payload${rawTypeLabel}: ${failure.code} (${failure.message})`,
+	)
 }
 
-function buildSessionReadyDedupeKey(sessionID: unknown): string | null {
-	const normalizedSessionID = toNonEmptyString(sessionID)
-	if (!normalizedSessionID) return null
-
-	return `session-ready:${normalizedSessionID}`
+function resolveDesktopSound(level: NotificationLevel, config: NotifyConfig): string {
+	switch (level) {
+		case NotificationLevel.Error:
+			return config.sounds.error
+		case NotificationLevel.Warning:
+			return config.sounds.permission
+		case NotificationLevel.Info:
+		case NotificationLevel.Success:
+			return config.sounds.idle
+	}
 }
 
-function buildPermissionEventDedupeKey(properties: unknown): string | null {
-	if (!properties || typeof properties !== "object") return null
-
-	const record = properties as Record<string, unknown>
-	const normalizedRequestID = toNonEmptyString(record.id)
-	if (!normalizedRequestID) return null
-
-	return `permission:request:${normalizedRequestID}`
-}
-
-function sendNodeNotification(options: NotificationOptions): void {
-	const { title, message, sound, terminalInfo } = options
-
-	// Base notification options
-	const notifyOptions: Record<string, unknown> = {
-		title,
-		message,
-		sound,
+function resolveDesktopTitle(intent: DesktopTerminalIntent): string {
+	if (intent.payload.title) {
+		return intent.payload.title
 	}
 
-	// macOS-specific: click notification to focus terminal
-	if (process.platform === "darwin" && terminalInfo.bundleId) {
-		notifyOptions.activate = terminalInfo.bundleId
+	switch (intent.payload.level) {
+		case NotificationLevel.Error:
+			return SESSION_ERROR_TITLE
+		case NotificationLevel.Warning:
+			return "OpenCode notification"
+		case NotificationLevel.Info:
+		case NotificationLevel.Success:
+			return "OpenCode"
 	}
-
-	notifier.notify(notifyOptions)
 }
 
 async function sendNotification(
 	options: NotificationOptions,
-	runtime: NotificationRuntime,
+	runtime: NotifyBackendRuntime,
 ): Promise<void> {
-	await sendNotificationWithFallback({
-		preferCmux: runtime.preferCmux,
-		tryCmuxNotify: () =>
-			sendCmuxNotification({
-				title: options.title,
-				subtitle: options.subtitle,
-				body: options.cmuxBody ?? options.message,
-			}),
-		sendNodeNotify: () => sendNodeNotification(options),
-	})
+	const transportPayload: DesktopTransportPayload = {
+		title: options.title,
+		message: options.message,
+		sound: options.sound,
+		subtitle: options.subtitle,
+		cmuxBody: options.cmuxBody,
+		terminalBundleId: options.terminalBundleId,
+	}
+
+	await sendNotificationWithFallback(transportPayload, runtime)
 }
 
 // ==========================================
@@ -364,7 +442,7 @@ async function handleSessionIdle(
 	sessionID: string,
 	config: NotifyConfig,
 	terminalInfo: TerminalInfo,
-	notificationRuntime: NotificationRuntime,
+	notificationRuntime: NotifyBackendRuntime,
 ): Promise<void> {
 	// Check if we should notify for this session
 	if (!config.notifyChildSessions) {
@@ -391,12 +469,12 @@ async function handleSessionIdle(
 
 	await sendNotification(
 		{
-			title: "Ready for review",
+			title: SESSION_READY_TITLE,
 			message: sessionTitle,
 			subtitle: sessionTitle,
 			cmuxBody: "OpenCode task is ready for review",
 			sound: config.sounds.idle,
-			terminalInfo,
+			terminalBundleId: terminalInfo.bundleId,
 		},
 		notificationRuntime,
 	)
@@ -408,7 +486,7 @@ async function handleSessionError(
 	error: string | undefined,
 	config: NotifyConfig,
 	terminalInfo: TerminalInfo,
-	notificationRuntime: NotificationRuntime,
+	notificationRuntime: NotifyBackendRuntime,
 ): Promise<void> {
 	// Check if we should notify for this session
 	if (!config.notifyChildSessions) {
@@ -426,10 +504,10 @@ async function handleSessionError(
 
 	await sendNotification(
 		{
-			title: "Something went wrong",
+			title: SESSION_ERROR_TITLE,
 			message: errorMessage,
 			sound: config.sounds.error,
-			terminalInfo,
+			terminalBundleId: terminalInfo.bundleId,
 		},
 		notificationRuntime,
 	)
@@ -438,7 +516,7 @@ async function handleSessionError(
 async function handlePermissionUpdated(
 	config: NotifyConfig,
 	terminalInfo: TerminalInfo,
-	notificationRuntime: NotificationRuntime,
+	notificationRuntime: NotifyBackendRuntime,
 ): Promise<void> {
 	// Always notify for permission events - AI is blocked waiting for human
 	// No parent check needed: permissions always need human attention
@@ -451,10 +529,10 @@ async function handlePermissionUpdated(
 
 	await sendNotification(
 		{
-			title: "Waiting for you",
+			title: PERMISSION_TITLE,
 			message: "OpenCode needs your input",
 			sound: config.sounds.permission,
-			terminalInfo,
+			terminalBundleId: terminalInfo.bundleId,
 		},
 		notificationRuntime,
 	)
@@ -463,7 +541,7 @@ async function handlePermissionUpdated(
 async function handleQuestionAsked(
 	config: NotifyConfig,
 	terminalInfo: TerminalInfo,
-	notificationRuntime: NotificationRuntime,
+	notificationRuntime: NotifyBackendRuntime,
 ): Promise<void> {
 	// Guard: quiet hours only (no focus check for questions - tmux workflow)
 	if (isQuietHours(config)) return
@@ -472,10 +550,31 @@ async function handleQuestionAsked(
 
 	await sendNotification(
 		{
-			title: "Question for you",
+			title: QUESTION_TITLE,
 			message: "OpenCode needs your input",
 			sound,
-			terminalInfo,
+			terminalBundleId: terminalInfo.bundleId,
+		},
+		notificationRuntime,
+	)
+}
+
+async function handleDesktopTerminalNotification(
+	intent: DesktopTerminalIntent,
+	config: NotifyConfig,
+	terminalInfo: TerminalInfo,
+	notificationRuntime: NotifyBackendRuntime,
+): Promise<void> {
+	if (isQuietHours(config)) return
+
+	if (await isTerminalFocused(terminalInfo)) return
+
+	await sendNotification(
+		{
+			title: resolveDesktopTitle(intent),
+			message: intent.payload.message,
+			sound: resolveDesktopSound(intent.payload.level, config),
+			terminalBundleId: terminalInfo.bundleId,
 		},
 		notificationRuntime,
 	)
@@ -487,20 +586,35 @@ async function handleQuestionAsked(
 
 export const NotifyPlugin: Plugin = async (ctx) => {
 	const { client } = ctx
+	const policyResolution = resolveNotificationRuntimePolicyFromHostHandshake(
+		readHostNotificationContractHandshake(ctx),
+	)
+
+	if (!policyResolution.compatible) {
+		const issueCodes = policyResolution.errors.map((issue) => issue.code).join(", ") || "unknown"
+		throw new Error(`Incompatible notification contract handshake: ${issueCodes}`)
+	}
+
+	if (policyResolution.warnings.length > 0) {
+		reportHostHandshakeWarnings(policyResolution.warnings)
+	}
+
+	const normalizePolicy = policyResolution.normalizePolicy
+	const shouldEnforceHostFailClosedRuntime = policyResolution.source === "host-handshake"
 
 	// Load config once at startup
 	const config = await loadConfig()
 
 	// Detect terminal once at startup (cached for performance)
 	const terminalInfo = await detectTerminalInfo(config)
-	const notificationRuntime: NotificationRuntime = {
+	const notificationRuntime: NotifyBackendRuntime = {
 		preferCmux: canUseCmuxNotification(),
 	}
 	const recentQuestionNotifications: RecentNotifications = new Map()
 	const recentReadyNotifications: RecentNotifications = new Map()
 	const recentPermissionNotifications: RecentNotifications = new Map()
 
-	const notifyQuestionIfNeeded = async (dedupeKey: string | null): Promise<void> => {
+	const notifyQuestionIfNeeded = async (dedupeKey: string | undefined): Promise<void> => {
 		if (
 			dedupeKey &&
 			!shouldSendDedupedNotification(
@@ -515,14 +629,14 @@ export const NotifyPlugin: Plugin = async (ctx) => {
 		await handleQuestionAsked(config, terminalInfo, notificationRuntime)
 	}
 
-	const notifySessionReadyIfNeeded = async (sessionID: unknown): Promise<void> => {
-		const normalizedSessionID = toNonEmptyString(sessionID)
-		if (!normalizedSessionID) return
-
-		const dedupeKey = buildSessionReadyDedupeKey(normalizedSessionID)
-		if (!dedupeKey) return
+	const notifySessionReadyIfNeeded = async (
+		sessionID: string | undefined,
+		dedupeKey: string | undefined,
+	): Promise<void> => {
+		if (!sessionID) return
 
 		if (
+			dedupeKey &&
 			!shouldSendDedupedNotification(recentReadyNotifications, dedupeKey, READY_DEDUPE_WINDOW_MS)
 		) {
 			return
@@ -530,16 +644,14 @@ export const NotifyPlugin: Plugin = async (ctx) => {
 
 		await handleSessionIdle(
 			client as OpencodeClient,
-			normalizedSessionID,
+			sessionID,
 			config,
 			terminalInfo,
 			notificationRuntime,
 		)
 	}
 
-	const notifyPermissionIfNeeded = async (properties: unknown): Promise<void> => {
-		const dedupeKey = buildPermissionEventDedupeKey(properties)
-
+	const notifyPermissionIfNeeded = async (dedupeKey: string | undefined): Promise<void> => {
 		if (
 			dedupeKey &&
 			!shouldSendDedupedNotification(
@@ -554,60 +666,84 @@ export const NotifyPlugin: Plugin = async (ctx) => {
 		await handlePermissionUpdated(config, terminalInfo, notificationRuntime)
 	}
 
-	return {
-		"tool.execute.before": async (input: { tool: string; sessionID: string; callID: string }) => {
-			if (input.tool === "question") {
-				await notifyQuestionIfNeeded(buildQuestionToolDedupeKey(input.sessionID, input.callID))
+	const routeNormalizedIntent = async (intent: NormalizedNotificationIntent): Promise<void> => {
+		if (intent.channel !== NotificationChannel.DesktopTerminal) {
+			return
+		}
+
+		switch (intent.handlingMode) {
+			case NotificationHandlingMode.Drop:
+				return
+			case NotificationHandlingMode.FailClosed:
+				if (shouldEnforceHostFailClosedRuntime) {
+					console.warn(
+						`[notify] Dropping ${intent.origin.rawType} notification due host fail_closed policy on ${intent.channel} (state=${intent.capabilityState}).`,
+					)
+					return
+				}
+				break
+			case NotificationHandlingMode.Deliver:
+				break
+		}
+
+		switch (intent.semanticIntent) {
+			case DesktopTerminalSemanticIntent.SessionReady: {
+				await notifySessionReadyIfNeeded(intent.payload.sessionID, intent.dedupeKey)
+				return
 			}
+			case DesktopTerminalSemanticIntent.SessionError: {
+				if (!intent.payload.sessionID) return
+				await handleSessionError(
+					client as OpencodeClient,
+					intent.payload.sessionID,
+					intent.payload.message,
+					config,
+					terminalInfo,
+					notificationRuntime,
+				)
+				return
+			}
+			case DesktopTerminalSemanticIntent.Permission: {
+				await notifyPermissionIfNeeded(intent.dedupeKey)
+				return
+			}
+			case DesktopTerminalSemanticIntent.Question: {
+				await notifyQuestionIfNeeded(intent.dedupeKey)
+				return
+			}
+			case DesktopTerminalSemanticIntent.Generic: {
+				await handleDesktopTerminalNotification(intent, config, terminalInfo, notificationRuntime)
+				return
+			}
+		}
+	}
+
+	return {
+		"tool.execute.before": async (input: unknown) => {
+			await processBoundaryInput(
+				{
+					source: "tool.execute.before",
+					value: input,
+				},
+				{
+					normalizePolicy,
+					routeNormalizedIntent,
+					handleParseFailure: handleNormalizeParseFailure,
+				},
+			)
 		},
 		event: async ({ event }: { event: Event }): Promise<void> => {
-			const runtimeEvent = event as { type: string; properties: Record<string, unknown> }
-
-			switch (runtimeEvent.type) {
-				case "session.status": {
-					const sessionID = runtimeEvent.properties.sessionID
-					const statusType =
-						runtimeEvent.properties.status && typeof runtimeEvent.properties.status === "object"
-							? ((runtimeEvent.properties.status as { type?: string }).type ?? undefined)
-							: undefined
-
-					if (sessionID && statusType === "idle") {
-						await notifySessionReadyIfNeeded(sessionID)
-					}
-					break
-				}
-				case "session.idle": {
-					await notifySessionReadyIfNeeded(runtimeEvent.properties.sessionID)
-					break
-				}
-				case "session.error": {
-					const sessionID = toNonEmptyString(runtimeEvent.properties.sessionID)
-					const error = runtimeEvent.properties.error
-					const errorMessage = typeof error === "string" ? error : error ? String(error) : undefined
-					if (sessionID) {
-						await handleSessionError(
-							client as OpencodeClient,
-							sessionID,
-							errorMessage,
-							config,
-							terminalInfo,
-							notificationRuntime,
-						)
-					}
-					break
-				}
-
-				case "permission.updated":
-				case "permission.asked": {
-					await notifyPermissionIfNeeded(runtimeEvent.properties)
-					break
-				}
-				case "question.asked": {
-					const dedupeKey = buildQuestionEventDedupeKey(runtimeEvent.properties)
-					await notifyQuestionIfNeeded(dedupeKey)
-					break
-				}
-			}
+			await processBoundaryInput(
+				{
+					source: "event",
+					value: event,
+				},
+				{
+					normalizePolicy,
+					routeNormalizedIntent,
+					handleParseFailure: handleNormalizeParseFailure,
+				},
+			)
 		},
 	}
 }

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -306,13 +306,13 @@ export function resolveNotificationRuntimePolicyFromHostHandshake(
 	}
 }
 
-function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
-	if (value === null || typeof value !== "object") {
-		return false
-	}
-
-	const prototype = Object.getPrototypeOf(value)
-	return prototype === Object.prototype || prototype === null
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	)
 }
 
 function readHostNotificationContractHandshake(ctx: unknown): unknown {

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -25,12 +25,6 @@ import type { Plugin } from "@opencode-ai/plugin"
 import type { Event } from "@opencode-ai/sdk"
 // @ts-expect-error - installed at runtime by OCX
 import detectTerminal from "detect-terminal"
-import {
-	classifyNotificationContractHandshake,
-	type NotificationContractCompatErrorIssue,
-	type NotificationContractCompatWarningIssue,
-} from "../../../../packages/cli/src/notify/contract-compat"
-import { isPlainObject } from "../../../../packages/cli/src/utils/type-guards"
 import type { OpencodeClient } from "./kdco-primitives/types"
 import {
 	type DesktopTransportPayload,
@@ -38,6 +32,11 @@ import {
 	sendNotificationWithFallback,
 } from "./notify/backend"
 import { canUseCmuxNotification } from "./notify/cmux"
+import {
+	classifyNotificationContractHandshake,
+	type NotificationContractCompatErrorIssue,
+	type NotificationContractCompatWarningIssue,
+} from "./notify/contract-compat"
 import {
 	createNotificationCapabilityByChannelFromNegotiatedState,
 	DEFAULT_NOTIFICATION_CAPABILITY_BY_CHANNEL,
@@ -305,6 +304,15 @@ export function resolveNotificationRuntimePolicyFromHostHandshake(
 		},
 		warnings: compatibility.warnings,
 	}
+}
+
+function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
+	if (value === null || typeof value !== "object") {
+		return false
+	}
+
+	const prototype = Object.getPrototypeOf(value)
+	return prototype === Object.prototype || prototype === null
 }
 
 function readHostNotificationContractHandshake(ctx: unknown): unknown {

--- a/workers/kdco-registry/files/plugins/notify/backend.ts
+++ b/workers/kdco-registry/files/plugins/notify/backend.ts
@@ -1,21 +1,72 @@
-interface NotifyBackendOptions {
+// @ts-expect-error - installed at runtime by OCX
+import notifier from "node-notifier"
+import { type CmuxNotificationPayload, sendCmuxNotification } from "./cmux"
+
+export interface NotifyBackendRuntime {
 	preferCmux: boolean
-	tryCmuxNotify: () => Promise<boolean>
-	sendNodeNotify: () => void
 }
 
-export async function sendNotificationWithFallback(options: NotifyBackendOptions): Promise<void> {
-	if (!options.preferCmux) {
-		options.sendNodeNotify()
+export interface DesktopTransportPayload {
+	title: string
+	message: string
+	sound: string
+	subtitle?: string
+	cmuxBody?: string
+	terminalBundleId?: string | null
+}
+
+interface NotifyBackendDependencies {
+	sendCmuxNotification?: (payload: CmuxNotificationPayload) => Promise<boolean>
+	sendNodeNotification?: (payload: Record<string, unknown>) => void
+}
+
+function toCmuxNotificationPayload(payload: DesktopTransportPayload): CmuxNotificationPayload {
+	return {
+		title: payload.title,
+		subtitle: payload.subtitle,
+		body: payload.cmuxBody ?? payload.message,
+	}
+}
+
+function toNodeNotificationPayload(payload: DesktopTransportPayload): Record<string, unknown> {
+	const nodePayload: Record<string, unknown> = {
+		title: payload.title,
+		message: payload.message,
+		sound: payload.sound,
+	}
+
+	if (process.platform === "darwin" && payload.terminalBundleId) {
+		nodePayload.activate = payload.terminalBundleId
+	}
+
+	return nodePayload
+}
+
+export async function sendNotificationWithFallback(
+	payload: DesktopTransportPayload,
+	runtime: NotifyBackendRuntime,
+	dependencies: NotifyBackendDependencies = {},
+): Promise<void> {
+	const cmuxSender = dependencies.sendCmuxNotification ?? sendCmuxNotification
+	const nodeSender =
+		dependencies.sendNodeNotification ??
+		((nodePayload: Record<string, unknown>) => {
+			notifier.notify(nodePayload)
+		})
+
+	if (!runtime.preferCmux) {
+		nodeSender(toNodeNotificationPayload(payload))
 		return
 	}
 
 	try {
-		const sentViaCmux = await options.tryCmuxNotify()
-		if (sentViaCmux) return
+		const sentViaCmux = await cmuxSender(toCmuxNotificationPayload(payload))
+		if (sentViaCmux) {
+			return
+		}
 	} catch {
 		// Fall through to node-notifier fallback
 	}
 
-	options.sendNodeNotify()
+	nodeSender(toNodeNotificationPayload(payload))
 }

--- a/workers/kdco-registry/files/plugins/notify/cmux.ts
+++ b/workers/kdco-registry/files/plugins/notify/cmux.ts
@@ -1,6 +1,6 @@
 import { TimeoutError, withTimeout } from "../kdco-primitives/with-timeout"
 
-interface CmuxNotificationPayload {
+export interface CmuxNotificationPayload {
 	title: string
 	body: string
 	subtitle?: string

--- a/workers/kdco-registry/files/plugins/notify/contract-compat.ts
+++ b/workers/kdco-registry/files/plugins/notify/contract-compat.ts
@@ -3,13 +3,13 @@
  *
  * Keep this in sync with packages/cli/src/notify/contract-compat.ts.
  */
-function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
-	if (value === null || typeof value !== "object") {
-		return false
-	}
-
-	const prototype = Object.getPrototypeOf(value)
-	return prototype === Object.prototype || prototype === null
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	)
 }
 
 export const NotificationContractID = "opencode.host.notification" as const

--- a/workers/kdco-registry/files/plugins/notify/contract-compat.ts
+++ b/workers/kdco-registry/files/plugins/notify/contract-compat.ts
@@ -1,0 +1,550 @@
+/**
+ * Standalone notify contract compatibility logic for shipped plugins.
+ *
+ * Keep this in sync with packages/cli/src/notify/contract-compat.ts.
+ */
+function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
+	if (value === null || typeof value !== "object") {
+		return false
+	}
+
+	const prototype = Object.getPrototypeOf(value)
+	return prototype === Object.prototype || prototype === null
+}
+
+export const NotificationContractID = "opencode.host.notification" as const
+export const NotificationContractSchemaVersion = "1.1.0" as const
+
+export const NotificationChannel = {
+	UIToast: "ui.toast",
+	TaskSystem: "task.system",
+	SDKSystem: "sdk.system",
+	DesktopTerminal: "desktop.terminal",
+	MCPChannel: "mcp.channel",
+} as const
+
+export type NotificationChannel = (typeof NotificationChannel)[keyof typeof NotificationChannel]
+
+export const NotificationNegotiatedState = {
+	Supported: "supported",
+	FallbackApproved: "fallback_approved",
+	Unsupported: "unsupported",
+	InternalOnly: "internal_only",
+} as const
+
+export type NotificationNegotiatedState =
+	(typeof NotificationNegotiatedState)[keyof typeof NotificationNegotiatedState]
+
+export const NotificationFallbackMode = {
+	None: "none",
+	Drop: "drop",
+	FailClosed: "fail_closed",
+} as const
+
+export type NotificationFallbackMode =
+	(typeof NotificationFallbackMode)[keyof typeof NotificationFallbackMode]
+
+export const NotificationCanonicalChannels = Object.values(
+	NotificationChannel,
+) as readonly NotificationChannel[]
+
+export type NotificationNegotiatedStateByChannel = {
+	[channel in NotificationChannel]: NotificationNegotiatedState
+}
+
+export type NotificationFallbackModeByChannel = {
+	[channel in NotificationChannel]: NotificationFallbackMode
+}
+
+type SemverParts = {
+	major: number
+	minor: number
+	patch: number
+}
+
+const STRICT_SEMVER_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+const NotificationCanonicalChannelSet = new Set<string>(NotificationCanonicalChannels)
+const NotificationNegotiatedStateSet = new Set<string>(Object.values(NotificationNegotiatedState))
+
+const SupportedSchemaVersionParts = (() => {
+	const parsed = parseStrictSemver(NotificationContractSchemaVersion)
+	if (!parsed) {
+		throw new Error(
+			`Invalid NotificationContractSchemaVersion constant: ${NotificationContractSchemaVersion}`,
+		)
+	}
+
+	return parsed
+})()
+
+export type NotificationContractCompatErrorIssue =
+	| {
+			severity: "error"
+			code: "invalid-contract-format"
+			path: string
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "invalid-contract-id"
+			expectedContractID: typeof NotificationContractID
+			receivedContractID: string | null
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "missing-schema-version"
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "invalid-schema-version"
+			schemaVersion: string
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "unsupported-schema-major"
+			supportedMajor: number
+			detectedMajor: number
+			schemaVersion: string
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "missing-required-channel"
+			channel: NotificationChannel
+			message: string
+	  }
+	| {
+			severity: "error"
+			code: "unknown-negotiated-state"
+			channel: NotificationChannel
+			state: string
+			message: string
+	  }
+
+export type NotificationContractCompatWarningIssue =
+	| {
+			severity: "warning"
+			code: "newer-schema-minor-or-patch"
+			supportedSchemaVersion: typeof NotificationContractSchemaVersion
+			receivedSchemaVersion: string
+			message: string
+	  }
+	| {
+			severity: "warning"
+			code: "unknown-channel-ignored"
+			channel: string
+			message: string
+	  }
+
+export type NotificationContractCompatibilityResult =
+	| {
+			compatible: true
+			contractID: typeof NotificationContractID
+			schemaVersion: string
+			negotiatedStateByChannel: NotificationNegotiatedStateByChannel
+			warnings: NotificationContractCompatWarningIssue[]
+	  }
+	| {
+			compatible: false
+			errors: NotificationContractCompatErrorIssue[]
+			warnings: NotificationContractCompatWarningIssue[]
+	  }
+
+export interface NotificationContractHandshake {
+	contract: {
+		id: string
+		schemaVersion: string
+	}
+	capabilities: Record<string, { state: string }>
+}
+
+export function classifyNotificationContractHandshake(
+	handshake: unknown,
+): NotificationContractCompatibilityResult {
+	const warnings: NotificationContractCompatWarningIssue[] = []
+
+	if (!isPlainObject(handshake)) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-format",
+					path: "$",
+					message: "Notification contract handshake must be an object.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (!isPlainObject(handshake.contract)) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-format",
+					path: "contract",
+					message: "Notification contract handshake must include a contract object.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const contract = handshake.contract
+	const contractID = contract.id
+
+	if (contractID !== NotificationContractID) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-id",
+					expectedContractID: NotificationContractID,
+					receivedContractID: typeof contractID === "string" ? contractID : null,
+					message: `Notification contract id mismatch. Expected "${NotificationContractID}".`,
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (!Object.hasOwn(contract, "schemaVersion")) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "missing-schema-version",
+					message: "Notification contract schemaVersion is required.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const schemaVersion = contract.schemaVersion
+	if (typeof schemaVersion !== "string" || schemaVersion.length === 0) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-schema-version",
+					schemaVersion: String(schemaVersion),
+					message: "Notification contract schemaVersion must be a non-empty semver string.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const parsedSchemaVersion = parseStrictSemver(schemaVersion)
+	if (!parsedSchemaVersion) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-schema-version",
+					schemaVersion,
+					message: "Notification contract schemaVersion must be strict semver (major.minor.patch).",
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (parsedSchemaVersion.major !== SupportedSchemaVersionParts.major) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "unsupported-schema-major",
+					supportedMajor: SupportedSchemaVersionParts.major,
+					detectedMajor: parsedSchemaVersion.major,
+					schemaVersion,
+					message:
+						`Unsupported notification contract schema major ${parsedSchemaVersion.major}. ` +
+						`Expected major ${SupportedSchemaVersionParts.major}.`,
+				},
+			],
+			warnings,
+		)
+	}
+
+	if (isNewerMinorOrPatch(parsedSchemaVersion, SupportedSchemaVersionParts)) {
+		warnings.push({
+			severity: "warning",
+			code: "newer-schema-minor-or-patch",
+			supportedSchemaVersion: NotificationContractSchemaVersion,
+			receivedSchemaVersion: schemaVersion,
+			message:
+				`Notification contract schemaVersion ${schemaVersion} is newer than supported ` +
+				`${NotificationContractSchemaVersion}. Continuing with same-major compatibility mode.`,
+		})
+	}
+
+	if (!isPlainObject(handshake.capabilities)) {
+		return incompatible(
+			[
+				{
+					severity: "error",
+					code: "invalid-contract-format",
+					path: "capabilities",
+					message: "Notification contract handshake must include a capabilities object.",
+				},
+			],
+			warnings,
+		)
+	}
+
+	const capabilities = handshake.capabilities
+
+	for (const channel of Object.keys(capabilities)) {
+		if (NotificationCanonicalChannelSet.has(channel)) {
+			continue
+		}
+
+		warnings.push({
+			severity: "warning",
+			code: "unknown-channel-ignored",
+			channel,
+			message: `Notification channel "${channel}" is unknown to this OCX version and will be ignored.`,
+		})
+	}
+
+	const errors: NotificationContractCompatErrorIssue[] = []
+	const parsedStates: Partial<NotificationNegotiatedStateByChannel> = {}
+
+	for (const channel of NotificationCanonicalChannels) {
+		if (!Object.hasOwn(capabilities, channel)) {
+			errors.push({
+				severity: "error",
+				code: "missing-required-channel",
+				channel,
+				message: `Missing required notification channel capability "${channel}".`,
+			})
+			continue
+		}
+
+		const capability = capabilities[channel]
+		if (!isPlainObject(capability)) {
+			errors.push({
+				severity: "error",
+				code: "invalid-contract-format",
+				path: `capabilities.${channel}`,
+				message: `Capability entry for channel "${channel}" must be an object.`,
+			})
+			continue
+		}
+
+		const state = capability.state
+		if (typeof state !== "string") {
+			errors.push({
+				severity: "error",
+				code: "invalid-contract-format",
+				path: `capabilities.${channel}.state`,
+				message: `Capability state for channel "${channel}" must be a string.`,
+			})
+			continue
+		}
+
+		if (!NotificationNegotiatedStateSet.has(state)) {
+			errors.push({
+				severity: "error",
+				code: "unknown-negotiated-state",
+				channel,
+				state,
+				message: `Unknown notification negotiated state "${state}" for channel "${channel}".`,
+			})
+			continue
+		}
+
+		parsedStates[channel] = state as NotificationNegotiatedState
+	}
+
+	if (errors.length > 0) {
+		return incompatible(errors, warnings)
+	}
+
+	const negotiatedStateByChannelResult = buildNegotiatedStateByChannel(parsedStates)
+	if (!negotiatedStateByChannelResult.compatible) {
+		return incompatible(negotiatedStateByChannelResult.errors, warnings)
+	}
+
+	return {
+		compatible: true,
+		contractID: NotificationContractID,
+		schemaVersion,
+		negotiatedStateByChannel: negotiatedStateByChannelResult.negotiatedStateByChannel,
+		warnings,
+	}
+}
+
+function parseStrictSemver(version: string): SemverParts | null {
+	const match = version.match(STRICT_SEMVER_REGEX)
+	if (!match) {
+		return null
+	}
+
+	const majorToken = match[1]
+	const minorToken = match[2]
+	const patchToken = match[3]
+	if (!majorToken || !minorToken || !patchToken) {
+		return null
+	}
+
+	return {
+		major: Number.parseInt(majorToken, 10),
+		minor: Number.parseInt(minorToken, 10),
+		patch: Number.parseInt(patchToken, 10),
+	}
+}
+
+function isNewerMinorOrPatch(candidate: SemverParts, supported: SemverParts): boolean {
+	if (candidate.major !== supported.major) {
+		return false
+	}
+
+	if (candidate.minor > supported.minor) {
+		return true
+	}
+
+	if (candidate.minor < supported.minor) {
+		return false
+	}
+
+	return candidate.patch > supported.patch
+}
+
+function buildNegotiatedStateByChannel(parsedStates: Partial<NotificationNegotiatedStateByChannel>):
+	| {
+			compatible: true
+			negotiatedStateByChannel: NotificationNegotiatedStateByChannel
+	  }
+	| {
+			compatible: false
+			errors: NotificationContractCompatErrorIssue[]
+	  } {
+	const errors: NotificationContractCompatErrorIssue[] = []
+	const negotiatedStateByChannel: Partial<NotificationNegotiatedStateByChannel> = {}
+
+	for (const channel of NotificationCanonicalChannels) {
+		const state = parsedStates[channel]
+		if (state === undefined) {
+			errors.push({
+				severity: "error",
+				code: "missing-required-channel",
+				channel,
+				message: `Missing required notification channel capability "${channel}".`,
+			})
+			continue
+		}
+
+		negotiatedStateByChannel[channel] = state
+	}
+
+	if (errors.length > 0) {
+		return {
+			compatible: false,
+			errors,
+		}
+	}
+
+	return {
+		compatible: true,
+		negotiatedStateByChannel: negotiatedStateByChannel as NotificationNegotiatedStateByChannel,
+	}
+}
+
+function incompatible(
+	errors: NotificationContractCompatErrorIssue[],
+	warnings: NotificationContractCompatWarningIssue[],
+): NotificationContractCompatibilityResult {
+	return {
+		compatible: false,
+		errors,
+		warnings,
+	}
+}
+
+export const ClosedHostDefaultNotificationHandshake: NotificationContractHandshake = {
+	contract: {
+		id: NotificationContractID,
+		schemaVersion: NotificationContractSchemaVersion,
+	},
+	capabilities: {
+		[NotificationChannel.UIToast]: { state: NotificationNegotiatedState.Supported },
+		[NotificationChannel.TaskSystem]: { state: NotificationNegotiatedState.Supported },
+		[NotificationChannel.SDKSystem]: { state: NotificationNegotiatedState.Unsupported },
+		[NotificationChannel.DesktopTerminal]: { state: NotificationNegotiatedState.Unsupported },
+		[NotificationChannel.MCPChannel]: { state: NotificationNegotiatedState.InternalOnly },
+	},
+}
+
+export const ClosedHostDefaultNotificationCompatibility = (() => {
+	const compatibility = classifyNotificationContractHandshake(
+		ClosedHostDefaultNotificationHandshake,
+	)
+	if (!compatibility.compatible) {
+		const issueCodes = compatibility.errors.map((issue) => issue.code).join(", ") || "unknown"
+		throw new Error(
+			`Closed host notification contract fixture is invalid. Compatibility errors: ${issueCodes}.`,
+		)
+	}
+
+	return compatibility
+})()
+
+export const ClosedHostDefaultNotificationNegotiatedStateByChannel =
+	ClosedHostDefaultNotificationCompatibility.negotiatedStateByChannel
+
+export const ClosedHostDefaultNotificationFallbackModeByChannel: NotificationFallbackModeByChannel =
+	{
+		[NotificationChannel.UIToast]: NotificationFallbackMode.None,
+		[NotificationChannel.TaskSystem]: NotificationFallbackMode.None,
+		[NotificationChannel.SDKSystem]: NotificationFallbackMode.Drop,
+		[NotificationChannel.DesktopTerminal]: NotificationFallbackMode.FailClosed,
+		[NotificationChannel.MCPChannel]: NotificationFallbackMode.FailClosed,
+	}
+
+assertClosedHostDefaultFallbackPolicyConsistency({
+	negotiatedStateByChannel: ClosedHostDefaultNotificationNegotiatedStateByChannel,
+	fallbackModeByChannel: ClosedHostDefaultNotificationFallbackModeByChannel,
+})
+
+function assertClosedHostDefaultFallbackPolicyConsistency(input: {
+	negotiatedStateByChannel: NotificationNegotiatedStateByChannel
+	fallbackModeByChannel: NotificationFallbackModeByChannel
+}): void {
+	for (const channel of NotificationCanonicalChannels) {
+		const state = input.negotiatedStateByChannel[channel]
+		const fallbackMode = input.fallbackModeByChannel[channel]
+
+		if (fallbackMode === NotificationFallbackMode.None) {
+			if (
+				state === NotificationNegotiatedState.Supported ||
+				state === NotificationNegotiatedState.FallbackApproved
+			) {
+				continue
+			}
+
+			throw new Error(
+				`Closed host notification fallback policy mismatch: channel ${channel} uses fallback mode "${fallbackMode}" but negotiated state is "${state}".`,
+			)
+		}
+
+		if (
+			state === NotificationNegotiatedState.Unsupported ||
+			state === NotificationNegotiatedState.InternalOnly
+		) {
+			continue
+		}
+
+		throw new Error(
+			`Closed host notification fallback policy mismatch: channel ${channel} uses fallback mode "${fallbackMode}" but negotiated state is "${state}".`,
+		)
+	}
+}

--- a/workers/kdco-registry/files/plugins/notify/normalize.ts
+++ b/workers/kdco-registry/files/plugins/notify/normalize.ts
@@ -1,0 +1,1228 @@
+import {
+	ClosedHostDefaultNotificationFallbackModeByChannel as CanonicalClosedHostFallbackModeByChannel,
+	ClosedHostDefaultNotificationNegotiatedStateByChannel as CanonicalClosedHostNegotiatedStateByChannel,
+	type NotificationFallbackModeByChannel as CanonicalNotificationFallbackModeByChannel,
+	type NotificationNegotiatedStateByChannel as CanonicalNotificationNegotiatedStateByChannel,
+} from "../../../../../packages/cli/src/notify/contract-compat"
+import { NotificationTaskSystemEventType } from "./task-system-event"
+
+export const NotificationChannel = {
+	UIToast: "ui.toast",
+	TaskSystem: "task.system",
+	SDKSystem: "sdk.system",
+	DesktopTerminal: "desktop.terminal",
+	MCPChannel: "mcp.channel",
+} as const
+
+export type NotificationChannel = (typeof NotificationChannel)[keyof typeof NotificationChannel]
+
+export const NotificationCapabilityState = {
+	Supported: "supported",
+	FallbackApproved: "fallback_approved",
+	Unsupported: "unsupported",
+	InternalOnly: "internal_only",
+} as const
+
+export type NotificationCapabilityState =
+	(typeof NotificationCapabilityState)[keyof typeof NotificationCapabilityState]
+
+export const NotificationFallbackMode = {
+	None: "none",
+	Drop: "drop",
+	FailClosed: "fail_closed",
+} as const
+
+export type NotificationFallbackMode =
+	(typeof NotificationFallbackMode)[keyof typeof NotificationFallbackMode]
+
+export const NotificationTrustLevel = {
+	Trusted: "trusted",
+	Untrusted: "untrusted",
+} as const
+
+export type NotificationTrustLevel =
+	(typeof NotificationTrustLevel)[keyof typeof NotificationTrustLevel]
+
+export const NotificationLevel = {
+	Info: "info",
+	Success: "success",
+	Warning: "warning",
+	Error: "error",
+} as const
+
+export type NotificationLevel = (typeof NotificationLevel)[keyof typeof NotificationLevel]
+
+export const DesktopTerminalSemanticIntent = {
+	Generic: "generic",
+	SessionReady: "session-ready",
+	SessionError: "session-error",
+	Permission: "permission",
+	Question: "question",
+} as const
+
+export type DesktopTerminalSemanticIntent =
+	(typeof DesktopTerminalSemanticIntent)[keyof typeof DesktopTerminalSemanticIntent]
+
+export const NotificationHandlingMode = {
+	Deliver: "deliver",
+	Drop: "drop",
+	FailClosed: "fail_closed",
+} as const
+
+export type NotificationHandlingMode =
+	(typeof NotificationHandlingMode)[keyof typeof NotificationHandlingMode]
+
+export interface NotificationCapabilityProfile {
+	state: NotificationCapabilityState
+	fallbackMode: NotificationFallbackMode
+}
+
+export type NotificationCapabilityByChannel = {
+	[channel in NotificationChannel]: NotificationCapabilityProfile
+}
+
+export type NotificationNegotiatedStateByChannel = {
+	[channel in NotificationChannel]: NotificationCapabilityState
+}
+
+const NOTIFICATION_CAPABILITY_STATE_SET = new Set<string>(
+	Object.values(NotificationCapabilityState),
+)
+
+const NOTIFICATION_FALLBACK_MODE_SET = new Set<string>(Object.values(NotificationFallbackMode))
+
+function parseCapabilityStateFromCanonicalContract(input: {
+	channel: NotificationChannel
+	state: string
+}): NotificationCapabilityState {
+	if (!NOTIFICATION_CAPABILITY_STATE_SET.has(input.state)) {
+		throw new Error(
+			`Authoritative notification negotiated-state mismatch: channel ${input.channel} has unsupported state "${input.state}".`,
+		)
+	}
+
+	return input.state as NotificationCapabilityState
+}
+
+function parseFallbackModeFromCanonicalContract(input: {
+	channel: NotificationChannel
+	fallbackMode: string
+}): NotificationFallbackMode {
+	if (!NOTIFICATION_FALLBACK_MODE_SET.has(input.fallbackMode)) {
+		throw new Error(
+			`Authoritative notification fallback-mode mismatch: channel ${input.channel} has unsupported fallback mode "${input.fallbackMode}".`,
+		)
+	}
+
+	return input.fallbackMode as NotificationFallbackMode
+}
+
+function parseNegotiatedStateFromCanonicalContract(
+	negotiatedStateByChannel: CanonicalNotificationNegotiatedStateByChannel,
+): NotificationNegotiatedStateByChannel {
+	return {
+		[NotificationChannel.UIToast]: parseCapabilityStateFromCanonicalContract({
+			channel: NotificationChannel.UIToast,
+			state: negotiatedStateByChannel[NotificationChannel.UIToast],
+		}),
+		[NotificationChannel.TaskSystem]: parseCapabilityStateFromCanonicalContract({
+			channel: NotificationChannel.TaskSystem,
+			state: negotiatedStateByChannel[NotificationChannel.TaskSystem],
+		}),
+		[NotificationChannel.SDKSystem]: parseCapabilityStateFromCanonicalContract({
+			channel: NotificationChannel.SDKSystem,
+			state: negotiatedStateByChannel[NotificationChannel.SDKSystem],
+		}),
+		[NotificationChannel.DesktopTerminal]: parseCapabilityStateFromCanonicalContract({
+			channel: NotificationChannel.DesktopTerminal,
+			state: negotiatedStateByChannel[NotificationChannel.DesktopTerminal],
+		}),
+		[NotificationChannel.MCPChannel]: parseCapabilityStateFromCanonicalContract({
+			channel: NotificationChannel.MCPChannel,
+			state: negotiatedStateByChannel[NotificationChannel.MCPChannel],
+		}),
+	}
+}
+
+function parseFallbackModeByChannelFromCanonicalContract(
+	fallbackModeByChannel: CanonicalNotificationFallbackModeByChannel,
+): {
+	[channel in NotificationChannel]: NotificationFallbackMode
+} {
+	return {
+		[NotificationChannel.UIToast]: parseFallbackModeFromCanonicalContract({
+			channel: NotificationChannel.UIToast,
+			fallbackMode: fallbackModeByChannel[NotificationChannel.UIToast],
+		}),
+		[NotificationChannel.TaskSystem]: parseFallbackModeFromCanonicalContract({
+			channel: NotificationChannel.TaskSystem,
+			fallbackMode: fallbackModeByChannel[NotificationChannel.TaskSystem],
+		}),
+		[NotificationChannel.SDKSystem]: parseFallbackModeFromCanonicalContract({
+			channel: NotificationChannel.SDKSystem,
+			fallbackMode: fallbackModeByChannel[NotificationChannel.SDKSystem],
+		}),
+		[NotificationChannel.DesktopTerminal]: parseFallbackModeFromCanonicalContract({
+			channel: NotificationChannel.DesktopTerminal,
+			fallbackMode: fallbackModeByChannel[NotificationChannel.DesktopTerminal],
+		}),
+		[NotificationChannel.MCPChannel]: parseFallbackModeFromCanonicalContract({
+			channel: NotificationChannel.MCPChannel,
+			fallbackMode: fallbackModeByChannel[NotificationChannel.MCPChannel],
+		}),
+	}
+}
+
+export const CLOSED_HOST_DEFAULT_NOTIFICATION_NEGOTIATED_STATE_BY_CHANNEL =
+	parseNegotiatedStateFromCanonicalContract(CanonicalClosedHostNegotiatedStateByChannel)
+
+export const CLOSED_HOST_NOTIFICATION_FALLBACK_MODE_BY_CHANNEL =
+	parseFallbackModeByChannelFromCanonicalContract(CanonicalClosedHostFallbackModeByChannel)
+
+function createClosedHostCapabilityProfile(input: {
+	channel: NotificationChannel
+	state: NotificationCapabilityState
+}): NotificationCapabilityProfile {
+	const fallbackMode = CLOSED_HOST_NOTIFICATION_FALLBACK_MODE_BY_CHANNEL[input.channel]
+
+	if (fallbackMode === NotificationFallbackMode.None) {
+		if (
+			input.state !== NotificationCapabilityState.Supported &&
+			input.state !== NotificationCapabilityState.FallbackApproved
+		) {
+			throw new Error(
+				`Closed host notification policy mismatch: channel ${input.channel} requires supported/fallback_approved when fallback mode is none (received ${input.state}).`,
+			)
+		}
+
+		return {
+			state: input.state,
+			fallbackMode,
+		}
+	}
+
+	if (
+		input.state === NotificationCapabilityState.Supported ||
+		input.state === NotificationCapabilityState.FallbackApproved
+	) {
+		throw new Error(
+			`Closed host notification policy mismatch: channel ${input.channel} cannot be supported/fallback_approved when fallback mode is ${fallbackMode}.`,
+		)
+	}
+
+	return {
+		state: input.state,
+		fallbackMode,
+	}
+}
+
+export function createNotificationCapabilityByChannelFromNegotiatedState(
+	negotiatedStateByChannel: NotificationNegotiatedStateByChannel,
+): NotificationCapabilityByChannel {
+	return {
+		[NotificationChannel.UIToast]: createClosedHostCapabilityProfile({
+			channel: NotificationChannel.UIToast,
+			state: negotiatedStateByChannel[NotificationChannel.UIToast],
+		}),
+		[NotificationChannel.TaskSystem]: createClosedHostCapabilityProfile({
+			channel: NotificationChannel.TaskSystem,
+			state: negotiatedStateByChannel[NotificationChannel.TaskSystem],
+		}),
+		[NotificationChannel.SDKSystem]: createClosedHostCapabilityProfile({
+			channel: NotificationChannel.SDKSystem,
+			state: negotiatedStateByChannel[NotificationChannel.SDKSystem],
+		}),
+		[NotificationChannel.DesktopTerminal]: createClosedHostCapabilityProfile({
+			channel: NotificationChannel.DesktopTerminal,
+			state: negotiatedStateByChannel[NotificationChannel.DesktopTerminal],
+		}),
+		[NotificationChannel.MCPChannel]: createClosedHostCapabilityProfile({
+			channel: NotificationChannel.MCPChannel,
+			state: negotiatedStateByChannel[NotificationChannel.MCPChannel],
+		}),
+	}
+}
+
+export const DEFAULT_NOTIFICATION_CAPABILITY_BY_CHANNEL =
+	createNotificationCapabilityByChannelFromNegotiatedState(
+		CLOSED_HOST_DEFAULT_NOTIFICATION_NEGOTIATED_STATE_BY_CHANNEL,
+	)
+
+export type NotificationTimeoutByChannel = {
+	[channel in NotificationChannel]: number
+}
+
+export const DEFAULT_NOTIFICATION_TIMEOUT_MS_BY_CHANNEL: NotificationTimeoutByChannel = {
+	[NotificationChannel.UIToast]: 5000,
+	[NotificationChannel.TaskSystem]: 5000,
+	[NotificationChannel.SDKSystem]: 5000,
+	[NotificationChannel.DesktopTerminal]: 5000,
+	[NotificationChannel.MCPChannel]: 5000,
+}
+
+export interface NormalizeNotificationOptions {
+	capabilityByChannel?: NotificationCapabilityByChannel
+	timeoutMsByChannel?: Partial<NotificationTimeoutByChannel>
+}
+
+export interface NormalizedNotificationOrigin {
+	source: "event" | "tool.execute.before"
+	rawType: string
+}
+
+export interface NormalizedNotificationIntentBase<Channel extends NotificationChannel> {
+	channel: Channel
+	capabilityState: NotificationCapabilityState
+	fallbackMode: NotificationFallbackMode
+	handlingMode: NotificationHandlingMode
+	origin: NormalizedNotificationOrigin
+	notificationId: string
+	dedupeKey?: string
+	trustLevel: NotificationTrustLevel
+	timeoutMs: number
+	invalidates: readonly string[]
+}
+
+export interface NormalizedUIToastIntent
+	extends NormalizedNotificationIntentBase<typeof NotificationChannel.UIToast> {
+	payload: {
+		title?: string
+		message: string
+		variant: NotificationLevel
+		durationMs: number
+	}
+}
+
+export interface NormalizedTaskSystemIntent
+	extends NormalizedNotificationIntentBase<typeof NotificationChannel.TaskSystem> {
+	payload: {
+		title?: string
+		message: string
+		level: NotificationLevel
+		sessionID?: string
+	}
+}
+
+export interface NormalizedSDKSystemIntent
+	extends NormalizedNotificationIntentBase<typeof NotificationChannel.SDKSystem> {
+	payload: {
+		code: string
+		message: string
+		level: NotificationLevel
+		sourceEvent: string
+	}
+}
+
+export interface NormalizedDesktopTerminalIntent
+	extends NormalizedNotificationIntentBase<typeof NotificationChannel.DesktopTerminal> {
+	semanticIntent: DesktopTerminalSemanticIntent
+	payload: {
+		title?: string
+		message: string
+		level: NotificationLevel
+		sessionID?: string
+	}
+}
+
+export interface NormalizedMCPChannelIntent
+	extends NormalizedNotificationIntentBase<typeof NotificationChannel.MCPChannel> {
+	payload: {
+		server: string
+		message: string
+		level: NotificationLevel
+		source: "mcp.server" | "host.bridge"
+		trust: NotificationTrustLevel
+	}
+}
+
+export type NormalizedNotificationIntent =
+	| NormalizedUIToastIntent
+	| NormalizedTaskSystemIntent
+	| NormalizedSDKSystemIntent
+	| NormalizedDesktopTerminalIntent
+	| NormalizedMCPChannelIntent
+
+export type NormalizedNotificationParseFailureCode =
+	| "invalid-envelope"
+	| "invalid-properties"
+	| "unsupported-type"
+	| "invalid-tool-input"
+
+export interface NormalizedNotificationParseFailure {
+	ok: false
+	kind: "parse_failure"
+	code: NormalizedNotificationParseFailureCode
+	message: string
+	source: "event" | "tool.execute.before"
+	rawType?: string
+	raw: unknown
+	details?: Record<string, unknown>
+}
+
+export interface NormalizedNotificationParseSuccess {
+	ok: true
+	kind: "normalized_intent"
+	intent: NormalizedNotificationIntent
+}
+
+export type NormalizedNotificationParseResult =
+	| NormalizedNotificationParseSuccess
+	| NormalizedNotificationParseFailure
+
+export type NormalizeNotificationBoundaryInput =
+	| { source: "event"; value: unknown }
+	| { source: "tool.execute.before"; value: unknown }
+
+const NOTIFICATION_LEVEL_SET = new Set<string>(Object.values(NotificationLevel))
+
+function normalizeNotificationCapabilities(
+	capabilityByChannel: NormalizeNotificationOptions["capabilityByChannel"],
+): NotificationCapabilityByChannel {
+	return capabilityByChannel ?? DEFAULT_NOTIFICATION_CAPABILITY_BY_CHANNEL
+}
+
+function normalizeNotificationTimeouts(
+	overrides: NormalizeNotificationOptions["timeoutMsByChannel"],
+): NotificationTimeoutByChannel {
+	return {
+		[NotificationChannel.UIToast]:
+			overrides?.[NotificationChannel.UIToast] ??
+			DEFAULT_NOTIFICATION_TIMEOUT_MS_BY_CHANNEL[NotificationChannel.UIToast],
+		[NotificationChannel.TaskSystem]:
+			overrides?.[NotificationChannel.TaskSystem] ??
+			DEFAULT_NOTIFICATION_TIMEOUT_MS_BY_CHANNEL[NotificationChannel.TaskSystem],
+		[NotificationChannel.SDKSystem]:
+			overrides?.[NotificationChannel.SDKSystem] ??
+			DEFAULT_NOTIFICATION_TIMEOUT_MS_BY_CHANNEL[NotificationChannel.SDKSystem],
+		[NotificationChannel.DesktopTerminal]:
+			overrides?.[NotificationChannel.DesktopTerminal] ??
+			DEFAULT_NOTIFICATION_TIMEOUT_MS_BY_CHANNEL[NotificationChannel.DesktopTerminal],
+		[NotificationChannel.MCPChannel]:
+			overrides?.[NotificationChannel.MCPChannel] ??
+			DEFAULT_NOTIFICATION_TIMEOUT_MS_BY_CHANNEL[NotificationChannel.MCPChannel],
+	}
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined
+	}
+
+	return value as Record<string, unknown>
+}
+
+function toNonEmptyString(value: unknown): string | undefined {
+	if (typeof value !== "string") {
+		return undefined
+	}
+
+	const normalized = value.trim()
+	return normalized.length > 0 ? normalized : undefined
+}
+
+function toNotificationLevel(value: unknown): NotificationLevel | undefined {
+	const normalized = toNonEmptyString(value)
+	if (!normalized || !NOTIFICATION_LEVEL_SET.has(normalized)) {
+		return undefined
+	}
+
+	return normalized as NotificationLevel
+}
+
+function toDurationMs(value: unknown, fallback: number): number | undefined {
+	if (value === undefined) {
+		return fallback
+	}
+
+	if (typeof value !== "number" || !Number.isInteger(value)) {
+		return undefined
+	}
+
+	if (value <= 0 || value > 60_000) {
+		return undefined
+	}
+
+	return value
+}
+
+function toLegacySessionErrorMessage(errorValue: unknown): string {
+	const directMessage = toNonEmptyString(errorValue)
+	if (directMessage) {
+		return directMessage
+	}
+
+	if (!errorValue) {
+		return "Something went wrong"
+	}
+
+	const stringified = toNonEmptyString(String(errorValue))
+	return stringified ?? "Something went wrong"
+}
+
+function failure(input: {
+	code: NormalizedNotificationParseFailureCode
+	message: string
+	source: "event" | "tool.execute.before"
+	rawType?: string
+	raw: unknown
+	details?: Record<string, unknown>
+}): NormalizedNotificationParseFailure {
+	return {
+		ok: false,
+		kind: "parse_failure",
+		code: input.code,
+		message: input.message,
+		source: input.source,
+		rawType: input.rawType,
+		raw: input.raw,
+		details: input.details,
+	}
+}
+
+function success(intent: NormalizedNotificationIntent): NormalizedNotificationParseSuccess {
+	return {
+		ok: true,
+		kind: "normalized_intent",
+		intent,
+	}
+}
+
+function resolveHandlingMode(
+	capabilityState: NotificationCapabilityState,
+	fallbackMode: NotificationFallbackMode,
+): NotificationHandlingMode {
+	if (
+		capabilityState === NotificationCapabilityState.Supported ||
+		capabilityState === NotificationCapabilityState.FallbackApproved
+	) {
+		return NotificationHandlingMode.Deliver
+	}
+
+	if (fallbackMode === NotificationFallbackMode.Drop) {
+		return NotificationHandlingMode.Drop
+	}
+
+	if (fallbackMode === NotificationFallbackMode.FailClosed) {
+		return NotificationHandlingMode.FailClosed
+	}
+
+	throw new Error(
+		`Invalid notification capability combination: state=${capabilityState}, fallback=${fallbackMode}`,
+	)
+}
+
+function createIdentity(input: {
+	explicitID?: string
+	explicitDedupeKey?: string
+	fallbackNotificationID: string
+	fallbackDedupeKey?: string
+}): {
+	notificationId: string
+	dedupeKey?: string
+} {
+	const fallbackNotificationID = input.fallbackNotificationID.trim()
+	const notificationId = input.explicitID ?? fallbackNotificationID
+	const dedupeKey = input.explicitDedupeKey ?? input.fallbackDedupeKey
+
+	return {
+		notificationId,
+		dedupeKey,
+	}
+}
+
+function createIntentBase<Channel extends NotificationChannel>(input: {
+	channel: Channel
+	origin: NormalizedNotificationOrigin
+	trustLevel: NotificationTrustLevel
+	notificationId: string
+	dedupeKey?: string
+	invalidates?: readonly string[]
+	capabilityByChannel: NotificationCapabilityByChannel
+	timeoutMsByChannel: NotificationTimeoutByChannel
+}): NormalizedNotificationIntentBase<Channel> {
+	const capability = input.capabilityByChannel[input.channel]
+
+	return {
+		channel: input.channel,
+		capabilityState: capability.state,
+		fallbackMode: capability.fallbackMode,
+		handlingMode: resolveHandlingMode(capability.state, capability.fallbackMode),
+		origin: input.origin,
+		notificationId: input.notificationId,
+		dedupeKey: input.dedupeKey,
+		trustLevel: input.trustLevel,
+		timeoutMs: input.timeoutMsByChannel[input.channel],
+		invalidates: input.invalidates ?? [],
+	}
+}
+
+function normalizeTaskSystemEvent(
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const message = toNonEmptyString(properties.message)
+	const level = toNotificationLevel(properties.level)
+
+	if (!message || !level) {
+		return failure({
+			code: "invalid-properties",
+			message: `${NotificationTaskSystemEventType} requires non-empty message and valid level.`,
+			source: "event",
+			rawType: NotificationTaskSystemEventType,
+			raw: properties,
+		})
+	}
+
+	const title = toNonEmptyString(properties.title)
+	const sessionID = toNonEmptyString(properties.sessionID)
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: `task-system:${sessionID ?? "global"}:${level}:${message}`,
+		fallbackDedupeKey: `task-system:${sessionID ?? "global"}:${level}:${message}`,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.TaskSystem,
+		origin: {
+			source: "event",
+			rawType: NotificationTaskSystemEventType,
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		payload: {
+			title,
+			message,
+			level,
+			sessionID,
+		},
+	})
+}
+
+function normalizeSDKSystemEvent(
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const code = toNonEmptyString(properties.code)
+	const message = toNonEmptyString(properties.message)
+	const level = toNotificationLevel(properties.level)
+	const sourceEvent = toNonEmptyString(properties.sourceEvent)
+
+	if (!code || !message || !level || !sourceEvent) {
+		return failure({
+			code: "invalid-properties",
+			message:
+				"notification.sdk.system requires code, message, level, and sourceEvent as non-empty values.",
+			source: "event",
+			rawType: "notification.sdk.system",
+			raw: properties,
+		})
+	}
+
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: `sdk-system:${code}:${sourceEvent}`,
+		fallbackDedupeKey: `sdk-system:${code}:${sourceEvent}`,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.SDKSystem,
+		origin: {
+			source: "event",
+			rawType: "notification.sdk.system",
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		payload: {
+			code,
+			message,
+			level,
+			sourceEvent,
+		},
+	})
+}
+
+function normalizeUIToastEvent(
+	rawType: string,
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const message = toNonEmptyString(properties.message)
+	const variant = toNotificationLevel(properties.variant)
+	const durationMs = toDurationMs(properties.duration, 5000)
+
+	if (!message || !variant || durationMs === undefined) {
+		return failure({
+			code: "invalid-properties",
+			message: "ui.toast requires message, variant, and optional duration within 1..60000.",
+			source: "event",
+			rawType,
+			raw: properties,
+		})
+	}
+
+	const title = toNonEmptyString(properties.title)
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: `ui-toast:${variant}:${message}`,
+		fallbackDedupeKey: `ui-toast:${variant}:${message}`,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.UIToast,
+		origin: {
+			source: "event",
+			rawType,
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel: {
+			...timeoutMsByChannel,
+			[NotificationChannel.UIToast]: durationMs,
+		},
+	})
+
+	return success({
+		...base,
+		payload: {
+			title,
+			message,
+			variant,
+			durationMs,
+		},
+	})
+}
+
+function normalizeDesktopTerminalEvent(
+	rawType: string,
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const message = toNonEmptyString(properties.message)
+	const level = toNotificationLevel(properties.level)
+
+	if (!message || !level) {
+		return failure({
+			code: "invalid-properties",
+			message: "desktop.terminal requires non-empty message and valid level.",
+			source: "event",
+			rawType,
+			raw: properties,
+		})
+	}
+
+	const title = toNonEmptyString(properties.title)
+	const sessionID = toNonEmptyString(properties.sessionID)
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: `desktop-terminal:${sessionID ?? "global"}:${level}:${message}`,
+		fallbackDedupeKey: `desktop-terminal:${sessionID ?? "global"}:${level}:${message}`,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.DesktopTerminal,
+		origin: {
+			source: "event",
+			rawType,
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		semanticIntent: DesktopTerminalSemanticIntent.Generic,
+		payload: {
+			title,
+			message,
+			level,
+			sessionID,
+		},
+	})
+}
+
+function normalizeMCPChannelEvent(
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const server = toNonEmptyString(properties.server)
+	const message = toNonEmptyString(properties.message)
+	const level = toNotificationLevel(properties.level)
+	const source = toNonEmptyString(properties.source)
+	const trust = toNonEmptyString(properties.trust)
+
+	if (!server || !message || !level || !source || !trust) {
+		return failure({
+			code: "invalid-properties",
+			message:
+				"notification.mcp.channel requires server, message, level, source, and trust fields.",
+			source: "event",
+			rawType: "notification.mcp.channel",
+			raw: properties,
+		})
+	}
+
+	if (source !== "mcp.server" && source !== "host.bridge") {
+		return failure({
+			code: "invalid-properties",
+			message: `notification.mcp.channel source must be "mcp.server" or "host.bridge", received "${source}".`,
+			source: "event",
+			rawType: "notification.mcp.channel",
+			raw: properties,
+		})
+	}
+
+	if (trust !== NotificationTrustLevel.Trusted && trust !== NotificationTrustLevel.Untrusted) {
+		return failure({
+			code: "invalid-properties",
+			message: `notification.mcp.channel trust must be "${NotificationTrustLevel.Trusted}" or "${NotificationTrustLevel.Untrusted}".`,
+			source: "event",
+			rawType: "notification.mcp.channel",
+			raw: properties,
+		})
+	}
+
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: `mcp-channel:${source}:${server}:${level}`,
+		fallbackDedupeKey: `mcp-channel:${source}:${server}:${level}`,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.MCPChannel,
+		origin: {
+			source: "event",
+			rawType: "notification.mcp.channel",
+		},
+		trustLevel: trust,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		payload: {
+			server,
+			message,
+			level,
+			source,
+			trust,
+		},
+	})
+}
+
+function normalizeLegacySessionReadyEvent(
+	rawType: "session.status" | "session.idle",
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const sessionID = toNonEmptyString(properties.sessionID)
+	if (!sessionID) {
+		return failure({
+			code: "invalid-properties",
+			message: `${rawType} requires a non-empty sessionID.`,
+			source: "event",
+			rawType,
+			raw: properties,
+		})
+	}
+
+	if (rawType === "session.status") {
+		const status = toRecord(properties.status)
+		const statusType = toNonEmptyString(status?.type)
+		if (statusType !== "idle") {
+			return failure({
+				code: "unsupported-type",
+				message: "session.status is only normalized when status.type is idle.",
+				source: "event",
+				rawType,
+				raw: properties,
+			})
+		}
+	}
+
+	const dedupeKey = `session-ready:${sessionID}`
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: dedupeKey,
+		fallbackDedupeKey: dedupeKey,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.DesktopTerminal,
+		origin: {
+			source: "event",
+			rawType,
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		semanticIntent: DesktopTerminalSemanticIntent.SessionReady,
+		payload: {
+			title: "Ready for review",
+			message: "OpenCode task is ready for review",
+			level: NotificationLevel.Info,
+			sessionID,
+		},
+	})
+}
+
+function normalizeLegacySessionErrorEvent(
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const sessionID = toNonEmptyString(properties.sessionID)
+	if (!sessionID) {
+		return failure({
+			code: "invalid-properties",
+			message: "session.error requires a non-empty sessionID.",
+			source: "event",
+			rawType: "session.error",
+			raw: properties,
+		})
+	}
+
+	const errorMessage = toLegacySessionErrorMessage(properties.error)
+
+	const dedupeKey = `session-error:${sessionID}`
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(properties.id),
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: dedupeKey,
+		fallbackDedupeKey: dedupeKey,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.DesktopTerminal,
+		origin: {
+			source: "event",
+			rawType: "session.error",
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		semanticIntent: DesktopTerminalSemanticIntent.SessionError,
+		payload: {
+			title: "Something went wrong",
+			message: errorMessage,
+			level: NotificationLevel.Error,
+			sessionID,
+		},
+	})
+}
+
+function normalizeLegacyPermissionEvent(
+	rawType: "permission.updated" | "permission.asked",
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const requestID = toNonEmptyString(properties.id)
+	const dedupeKey = requestID ? `permission:request:${requestID}` : undefined
+	const identity = createIdentity({
+		explicitID: requestID,
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: requestID ? `permission:request:${requestID}` : `permission:${rawType}`,
+		fallbackDedupeKey: dedupeKey,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.DesktopTerminal,
+		origin: {
+			source: "event",
+			rawType,
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		semanticIntent: DesktopTerminalSemanticIntent.Permission,
+		payload: {
+			title: "Waiting for you",
+			message: "OpenCode needs your input",
+			level: NotificationLevel.Warning,
+			sessionID: toNonEmptyString(properties.sessionID),
+		},
+	})
+}
+
+function buildLegacyQuestionDedupeKey(properties: Record<string, unknown>): string | undefined {
+	const sessionID = toNonEmptyString(properties.sessionID)
+	const requestID = toNonEmptyString(properties.id)
+	const tool = toRecord(properties.tool)
+	const toolCallID = toNonEmptyString(tool?.callID)
+
+	if (sessionID && toolCallID) {
+		return `question:${sessionID}:${toolCallID}`
+	}
+
+	if (sessionID && requestID) {
+		return `question:${sessionID}:request:${requestID}`
+	}
+
+	return undefined
+}
+
+function normalizeLegacyQuestionAskedEvent(
+	properties: Record<string, unknown>,
+	capabilityByChannel: NotificationCapabilityByChannel,
+	timeoutMsByChannel: NotificationTimeoutByChannel,
+): NormalizedNotificationParseResult {
+	const sessionID = toNonEmptyString(properties.sessionID)
+	const requestID = toNonEmptyString(properties.id)
+	const dedupeKey = buildLegacyQuestionDedupeKey(properties)
+	const identity = createIdentity({
+		explicitID: requestID,
+		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
+		fallbackNotificationID: dedupeKey ?? `question:${sessionID ?? "unknown"}:legacy-event`,
+		fallbackDedupeKey: dedupeKey,
+	})
+
+	const base = createIntentBase({
+		channel: NotificationChannel.DesktopTerminal,
+		origin: {
+			source: "event",
+			rawType: "question.asked",
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		semanticIntent: DesktopTerminalSemanticIntent.Question,
+		payload: {
+			title: "Question for you",
+			message: "OpenCode needs your input",
+			level: NotificationLevel.Warning,
+			sessionID,
+		},
+	})
+}
+
+export function normalizeNotificationEvent(
+	rawEvent: unknown,
+	options: NormalizeNotificationOptions = {},
+): NormalizedNotificationParseResult {
+	const event = toRecord(rawEvent)
+	if (!event) {
+		return failure({
+			code: "invalid-envelope",
+			message: "Notification event must be an object.",
+			source: "event",
+			raw: rawEvent,
+		})
+	}
+
+	const rawType = toNonEmptyString(event.type)
+	if (!rawType) {
+		return failure({
+			code: "invalid-envelope",
+			message: "Notification event requires a non-empty type.",
+			source: "event",
+			raw: rawEvent,
+		})
+	}
+
+	const properties = toRecord(event.properties)
+	if (!properties) {
+		return failure({
+			code: "invalid-properties",
+			message: `Notification event "${rawType}" requires an object properties payload.`,
+			source: "event",
+			rawType,
+			raw: rawEvent,
+		})
+	}
+
+	const capabilityByChannel = normalizeNotificationCapabilities(options.capabilityByChannel)
+	const timeoutMsByChannel = normalizeNotificationTimeouts(options.timeoutMsByChannel)
+
+	switch (rawType) {
+		case NotificationTaskSystemEventType:
+			return normalizeTaskSystemEvent(properties, capabilityByChannel, timeoutMsByChannel)
+		case "notification.sdk.system":
+			return normalizeSDKSystemEvent(properties, capabilityByChannel, timeoutMsByChannel)
+		case "notification.mcp.channel":
+			return normalizeMCPChannelEvent(properties, capabilityByChannel, timeoutMsByChannel)
+		case "notification.desktop.terminal":
+			return normalizeDesktopTerminalEvent(
+				rawType,
+				properties,
+				capabilityByChannel,
+				timeoutMsByChannel,
+			)
+		case "notification.ui.toast":
+		case "tui.toast.show":
+			return normalizeUIToastEvent(rawType, properties, capabilityByChannel, timeoutMsByChannel)
+		case "session.status":
+			return normalizeLegacySessionReadyEvent(
+				"session.status",
+				properties,
+				capabilityByChannel,
+				timeoutMsByChannel,
+			)
+		case "session.idle":
+			return normalizeLegacySessionReadyEvent(
+				"session.idle",
+				properties,
+				capabilityByChannel,
+				timeoutMsByChannel,
+			)
+		case "session.error":
+			return normalizeLegacySessionErrorEvent(properties, capabilityByChannel, timeoutMsByChannel)
+		case "permission.updated":
+			return normalizeLegacyPermissionEvent(
+				"permission.updated",
+				properties,
+				capabilityByChannel,
+				timeoutMsByChannel,
+			)
+		case "permission.asked":
+			return normalizeLegacyPermissionEvent(
+				"permission.asked",
+				properties,
+				capabilityByChannel,
+				timeoutMsByChannel,
+			)
+		case "question.asked":
+			return normalizeLegacyQuestionAskedEvent(properties, capabilityByChannel, timeoutMsByChannel)
+		default:
+			return failure({
+				code: "unsupported-type",
+				message: `Unsupported notification event type: "${rawType}".`,
+				source: "event",
+				rawType,
+				raw: rawEvent,
+			})
+	}
+}
+
+export function normalizeNotificationToolExecuteBefore(
+	rawInput: unknown,
+	options: NormalizeNotificationOptions = {},
+): NormalizedNotificationParseResult {
+	const input = toRecord(rawInput)
+	if (!input) {
+		return failure({
+			code: "invalid-tool-input",
+			message: "tool.execute.before payload must be an object.",
+			source: "tool.execute.before",
+			raw: rawInput,
+		})
+	}
+
+	const tool = toNonEmptyString(input.tool)
+	if (tool !== "question") {
+		return failure({
+			code: "unsupported-type",
+			message: `Unsupported tool.execute.before notification source: "${tool ?? "<missing>"}".`,
+			source: "tool.execute.before",
+			rawType: tool,
+			raw: rawInput,
+		})
+	}
+
+	const sessionID = toNonEmptyString(input.sessionID)
+	const callID = toNonEmptyString(input.callID)
+	const dedupeKey = sessionID && callID ? `question:${sessionID}:${callID}` : undefined
+	const fallbackNotificationID = dedupeKey ?? `question:${sessionID ?? "unknown"}:legacy-tool`
+
+	const identity = createIdentity({
+		explicitID: toNonEmptyString(input.id),
+		explicitDedupeKey: toNonEmptyString(input.dedupeKey),
+		fallbackNotificationID,
+		fallbackDedupeKey: dedupeKey,
+	})
+
+	const capabilityByChannel = normalizeNotificationCapabilities(options.capabilityByChannel)
+	const timeoutMsByChannel = normalizeNotificationTimeouts(options.timeoutMsByChannel)
+
+	const base = createIntentBase({
+		channel: NotificationChannel.DesktopTerminal,
+		origin: {
+			source: "tool.execute.before",
+			rawType: "tool.execute.before:question",
+		},
+		trustLevel: NotificationTrustLevel.Trusted,
+		notificationId: identity.notificationId,
+		dedupeKey: identity.dedupeKey,
+		capabilityByChannel,
+		timeoutMsByChannel,
+	})
+
+	return success({
+		...base,
+		semanticIntent: DesktopTerminalSemanticIntent.Question,
+		payload: {
+			title: "Question for you",
+			message: "OpenCode needs your input",
+			level: NotificationLevel.Warning,
+			sessionID,
+		},
+	})
+}
+
+export function normalizeNotificationBoundaryInput(
+	input: NormalizeNotificationBoundaryInput,
+	options?: NormalizeNotificationOptions,
+): NormalizedNotificationParseResult {
+	if (input.source === "event") {
+		return normalizeNotificationEvent(input.value, options)
+	}
+
+	return normalizeNotificationToolExecuteBefore(input.value, options)
+}

--- a/workers/kdco-registry/files/plugins/notify/normalize.ts
+++ b/workers/kdco-registry/files/plugins/notify/normalize.ts
@@ -3,7 +3,7 @@ import {
 	ClosedHostDefaultNotificationNegotiatedStateByChannel as CanonicalClosedHostNegotiatedStateByChannel,
 	type NotificationFallbackModeByChannel as CanonicalNotificationFallbackModeByChannel,
 	type NotificationNegotiatedStateByChannel as CanonicalNotificationNegotiatedStateByChannel,
-} from "../../../../../packages/cli/src/notify/contract-compat"
+} from "./contract-compat"
 import { NotificationTaskSystemEventType } from "./task-system-event"
 
 export const NotificationChannel = {
@@ -812,8 +812,8 @@ function normalizeMCPChannelEvent(
 	const identity = createIdentity({
 		explicitID: toNonEmptyString(properties.id),
 		explicitDedupeKey: toNonEmptyString(properties.dedupeKey),
-		fallbackNotificationID: `mcp-channel:${source}:${server}:${level}`,
-		fallbackDedupeKey: `mcp-channel:${source}:${server}:${level}`,
+		fallbackNotificationID: `mcp-channel:${source}:${server}:${level}:${message}`,
+		fallbackDedupeKey: `mcp-channel:${source}:${server}:${level}:${message}`,
 	})
 
 	const base = createIntentBase({

--- a/workers/kdco-registry/files/plugins/notify/task-system-event.ts
+++ b/workers/kdco-registry/files/plugins/notify/task-system-event.ts
@@ -1,0 +1,24 @@
+import type { NotificationLevel } from "./normalize"
+
+export const NotificationTaskSystemEventType = "notification.task.system" as const
+
+export interface NotificationTaskSystemEvent {
+	type: typeof NotificationTaskSystemEventType
+	properties: {
+		id?: string
+		dedupeKey?: string
+		title?: string
+		message: string
+		level: NotificationLevel
+		sessionID?: string
+	}
+}
+
+export function createNotificationTaskSystemEvent(
+	properties: NotificationTaskSystemEvent["properties"],
+): NotificationTaskSystemEvent {
+	return {
+		type: NotificationTaskSystemEventType,
+		properties,
+	}
+}

--- a/workers/kdco-registry/registry.jsonc
+++ b/workers/kdco-registry/registry.jsonc
@@ -58,7 +58,14 @@
 			"name": "notify",
 			"type": "plugin",
 			"description": "Native OS notifications - get notified when tasks complete",
-			"files": ["plugins/notify.ts", "plugins/notify/backend.ts", "plugins/notify/cmux.ts"],
+			"files": [
+				"plugins/notify.ts",
+				"plugins/notify/backend.ts",
+				"plugins/notify/cmux.ts",
+				"plugins/notify/normalize.ts",
+				"plugins/notify/task-system-event.ts",
+				"plugins/notify/contract-compat.ts"
+			],
 			"dependencies": ["kdco-primitives"],
 			"npmDevDependencies": ["node-notifier@10.0.1", "detect-terminal@2.0.0"]
 		},

--- a/workers/kdco-registry/tests/background-agents.test.ts
+++ b/workers/kdco-registry/tests/background-agents.test.ts
@@ -3,6 +3,11 @@ import * as fs from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
 import { BackgroundAgentsPlugin, DelegationManager } from "../files/plugins/background-agents"
+import {
+	NotificationChannel,
+	NotificationLevel,
+	normalizeNotificationEvent,
+} from "../files/plugins/notify/normalize"
 
 type PromptCall = {
 	sessionID: string
@@ -161,6 +166,16 @@ function sleep(ms: number): Promise<void> {
 
 function getPromptText(call: PromptCall): string {
 	return call.body.parts?.[0]?.text || ""
+}
+
+function extractTaskSystemBridgeEvent(text: string): Record<string, unknown> {
+	const match = text.match(/<task-system-bridge-payload>([\s\S]*?)<\/task-system-bridge-payload>/)
+
+	if (!match?.[1]) {
+		throw new Error("Missing task-system bridge payload in notification text")
+	}
+
+	return JSON.parse(match[1]) as Record<string, unknown>
 }
 
 let originalHome: string | undefined
@@ -396,6 +411,89 @@ describe("background-agents lifecycle refactor", () => {
 			getPromptText(call).includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompletePromptIndex).toBeGreaterThan(Math.max(...terminalPromptIndices))
+	})
+
+	it("emits task/system bridge payloads that normalize for terminal and all-complete notifications", async () => {
+		const rootSessionID = "root-session"
+		const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "background-agents-bridge-"))
+		testDirs.push(baseDir)
+		const allCompleteQuietPeriodMs = 20
+
+		const { client, state } = createMockClient({
+			rootSessionID,
+			childPromptMode: "pending",
+		})
+
+		const manager = new DelegationManager(client as never, baseDir, createNoopLogger(), {
+			idGenerator: () => "bridge-id",
+			metadataGenerator: async () => ({
+				title: "Bridge Result",
+				description: "Bridge payload check.",
+			}),
+			allCompleteQuietPeriodMs,
+		})
+
+		const delegation = await manager.delegate({
+			parentSessionID: rootSessionID,
+			parentMessageID: "msg-1",
+			parentAgent: "plan",
+			prompt: "Verify task/system bridge payload",
+			agent: "researcher",
+		})
+
+		state.messagesBySession.set(delegation.sessionID, "Bridge payload body")
+		await manager.handleSessionIdle(delegation.sessionID)
+		await sleep(allCompleteQuietPeriodMs + 30)
+
+		const terminalNotification = state.notificationTexts.find((text) =>
+			text.includes("<task-id>bridge-id</task-id>"),
+		)
+		expect(terminalNotification).toBeTruthy()
+		if (!terminalNotification) {
+			throw new Error("Missing terminal notification")
+		}
+
+		const terminalBridgeEvent = extractTaskSystemBridgeEvent(terminalNotification)
+		expect(terminalBridgeEvent.type).toBe("notification.task.system")
+
+		const normalizedTerminalBridge = normalizeNotificationEvent(terminalBridgeEvent)
+		expect(normalizedTerminalBridge.ok).toBe(true)
+		if (!normalizedTerminalBridge.ok) {
+			expect.unreachable("Expected normalized terminal bridge event")
+		}
+
+		expect(normalizedTerminalBridge.intent.channel).toBe(NotificationChannel.TaskSystem)
+		expect(normalizedTerminalBridge.intent.payload).toEqual({
+			title: "Bridge Result",
+			message: "Background agent complete: Bridge Result",
+			level: NotificationLevel.Success,
+			sessionID: rootSessionID,
+		})
+
+		const allCompleteNotification = state.notificationTexts.find((text) =>
+			text.includes("<type>all-complete</type>"),
+		)
+		expect(allCompleteNotification).toBeTruthy()
+		if (!allCompleteNotification) {
+			throw new Error("Missing all-complete notification")
+		}
+
+		const allCompleteBridgeEvent = extractTaskSystemBridgeEvent(allCompleteNotification)
+		expect(allCompleteBridgeEvent.type).toBe("notification.task.system")
+
+		const normalizedAllCompleteBridge = normalizeNotificationEvent(allCompleteBridgeEvent)
+		expect(normalizedAllCompleteBridge.ok).toBe(true)
+		if (!normalizedAllCompleteBridge.ok) {
+			expect.unreachable("Expected normalized all-complete bridge event")
+		}
+
+		expect(normalizedAllCompleteBridge.intent.channel).toBe(NotificationChannel.TaskSystem)
+		expect(normalizedAllCompleteBridge.intent.payload).toEqual({
+			title: "All delegations complete",
+			message: "All delegations complete.",
+			level: NotificationLevel.Success,
+			sessionID: rootSessionID,
+		})
 	})
 
 	it("allows batch B registration while cycle A all-complete is pending and suppresses stale cycle A before dispatch", async () => {

--- a/workers/kdco-registry/tests/notify-backend.test.ts
+++ b/workers/kdco-registry/tests/notify-backend.test.ts
@@ -2,111 +2,165 @@ import { describe, expect, it, mock } from "bun:test"
 import { sendNotificationWithFallback } from "../files/plugins/notify/backend"
 import { sendCmuxNotification } from "../files/plugins/notify/cmux"
 
+const baseTransportPayload = {
+	title: "Ready for review",
+	message: "Agent needs your attention",
+	sound: "Glass",
+	subtitle: "Session A",
+	cmuxBody: "OpenCode task is ready for review",
+	terminalBundleId: "com.mitchellh.ghostty",
+} as const
+
 describe("notify backend fallback behavior", () => {
 	it("uses node notifier directly when cmux is not preferred", async () => {
-		const tryCmuxNotify = mock(async () => true)
-		const sendNodeNotify = mock(() => {})
+		const cmuxSender = mock(async () => true)
+		const nodeSender = mock(() => {})
 
-		await sendNotificationWithFallback({
-			preferCmux: false,
-			tryCmuxNotify,
-			sendNodeNotify,
-		})
+		await sendNotificationWithFallback(
+			baseTransportPayload,
+			{
+				preferCmux: false,
+			},
+			{
+				sendCmuxNotification: cmuxSender,
+				sendNodeNotification: nodeSender,
+			},
+		)
 
-		expect(tryCmuxNotify).not.toHaveBeenCalled()
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(cmuxSender).not.toHaveBeenCalled()
+		expect(nodeSender).toHaveBeenCalledTimes(1)
+		const expectedNodePayload: Record<string, unknown> = {
+			title: "Ready for review",
+			message: "Agent needs your attention",
+			sound: "Glass",
+		}
+		if (process.platform === "darwin") {
+			expectedNodePayload.activate = "com.mitchellh.ghostty"
+		}
+		expect(nodeSender).toHaveBeenCalledWith(expectedNodePayload)
 	})
 
 	it("prefers cmux when cmux delivery succeeds", async () => {
-		const tryCmuxNotify = mock(async () => true)
-		const sendNodeNotify = mock(() => {})
+		const cmuxSender = mock(async () => true)
+		const nodeSender = mock(() => {})
 
-		await sendNotificationWithFallback({
-			preferCmux: true,
-			tryCmuxNotify,
-			sendNodeNotify,
+		await sendNotificationWithFallback(
+			baseTransportPayload,
+			{ preferCmux: true },
+			{
+				sendCmuxNotification: cmuxSender,
+				sendNodeNotification: nodeSender,
+			},
+		)
+
+		expect(cmuxSender).toHaveBeenCalledTimes(1)
+		expect(cmuxSender).toHaveBeenCalledWith({
+			title: "Ready for review",
+			subtitle: "Session A",
+			body: "OpenCode task is ready for review",
 		})
-
-		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
-		expect(sendNodeNotify).not.toHaveBeenCalled()
+		expect(nodeSender).not.toHaveBeenCalled()
 	})
 
 	it("falls back to node notifier when cmux returns false", async () => {
-		const tryCmuxNotify = mock(async () => false)
-		const sendNodeNotify = mock(() => {})
+		const cmuxSender = mock(async () => false)
+		const nodeSender = mock(() => {})
 
-		await sendNotificationWithFallback({
-			preferCmux: true,
-			tryCmuxNotify,
-			sendNodeNotify,
-		})
+		await sendNotificationWithFallback(
+			baseTransportPayload,
+			{ preferCmux: true },
+			{
+				sendCmuxNotification: cmuxSender,
+				sendNodeNotification: nodeSender,
+			},
+		)
 
-		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(cmuxSender).toHaveBeenCalledTimes(1)
+		expect(nodeSender).toHaveBeenCalledTimes(1)
 	})
 
 	it("falls back to node notifier when cmux throws", async () => {
-		const tryCmuxNotify = mock(async () => {
+		const cmuxSender = mock(async () => {
 			throw new Error("cmux unavailable")
 		})
-		const sendNodeNotify = mock(() => {})
+		const nodeSender = mock(() => {})
 
-		await sendNotificationWithFallback({
-			preferCmux: true,
-			tryCmuxNotify,
-			sendNodeNotify,
-		})
+		await sendNotificationWithFallback(
+			baseTransportPayload,
+			{ preferCmux: true },
+			{
+				sendCmuxNotification: cmuxSender,
+				sendNodeNotification: nodeSender,
+			},
+		)
 
-		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(cmuxSender).toHaveBeenCalledTimes(1)
+		expect(nodeSender).toHaveBeenCalledTimes(1)
 	})
 
 	it("falls back to node notifier when cmux exits non-zero", async () => {
-		const sendNodeNotify = mock(() => {})
+		const nodeSender = mock(() => {})
 
-		await sendNotificationWithFallback({
-			preferCmux: true,
-			tryCmuxNotify: () =>
-				sendCmuxNotification(
-					{
-						title: "Something went wrong",
-						body: "Task failed",
-					},
-					{
+		await sendNotificationWithFallback(
+			baseTransportPayload,
+			{ preferCmux: true },
+			{
+				sendCmuxNotification: (payload) =>
+					sendCmuxNotification(payload, {
 						spawnProcess: () => ({
 							exited: Promise.resolve(1),
 						}),
-					},
-				),
-			sendNodeNotify,
-		})
+					}),
+				sendNodeNotification: nodeSender,
+			},
+		)
 
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(nodeSender).toHaveBeenCalledTimes(1)
 	})
 
 	it("falls back to node notifier when cmux times out", async () => {
-		const sendNodeNotify = mock(() => {})
+		const nodeSender = mock(() => {})
 
-		await sendNotificationWithFallback({
-			preferCmux: true,
-			tryCmuxNotify: () =>
-				sendCmuxNotification(
-					{
-						title: "Ready",
-						body: "Task complete",
-					},
-					{
+		await sendNotificationWithFallback(
+			baseTransportPayload,
+			{ preferCmux: true },
+			{
+				sendCmuxNotification: (payload) =>
+					sendCmuxNotification(payload, {
 						timeoutMs: 10,
 						spawnProcess: () => ({
 							exited: new Promise<number>(() => {
 								// Simulate hung cmux process
 							}),
 						}),
-					},
-				),
-			sendNodeNotify,
-		})
+					}),
+				sendNodeNotification: nodeSender,
+			},
+		)
 
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(nodeSender).toHaveBeenCalledTimes(1)
+	})
+
+	it("uses message as cmux body when cmuxBody is omitted", async () => {
+		const cmuxSender = mock(async () => true)
+
+		await sendNotificationWithFallback(
+			{
+				title: "Fallback body",
+				message: "Message body",
+				sound: "Glass",
+			},
+			{ preferCmux: true },
+			{
+				sendCmuxNotification: cmuxSender,
+				sendNodeNotification: mock(() => {}),
+			},
+		)
+
+		expect(cmuxSender).toHaveBeenCalledWith({
+			title: "Fallback body",
+			subtitle: undefined,
+			body: "Message body",
+		})
 	})
 })

--- a/workers/kdco-registry/tests/notify-contract-compat-parity.test.ts
+++ b/workers/kdco-registry/tests/notify-contract-compat-parity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test"
+import {
+	ClosedHostDefaultNotificationFallbackModeByChannel as canonicalClosedHostDefaultFallbackModeByChannel,
+	ClosedHostDefaultNotificationHandshake as canonicalClosedHostDefaultHandshake,
+	ClosedHostDefaultNotificationNegotiatedStateByChannel as canonicalClosedHostNegotiatedStateByChannel,
+	NotificationContractID as canonicalNotificationContractID,
+	NotificationContractSchemaVersion as canonicalNotificationContractSchemaVersion,
+	classifyNotificationContractHandshake as classifyCanonicalNotificationContractHandshake,
+} from "../../../packages/cli/src/notify/contract-compat"
+import {
+	classifyNotificationContractHandshake as classifyShippedNotificationContractHandshake,
+	ClosedHostDefaultNotificationFallbackModeByChannel as shippedClosedHostDefaultFallbackModeByChannel,
+	ClosedHostDefaultNotificationNegotiatedStateByChannel as shippedClosedHostNegotiatedStateByChannel,
+	NotificationContractID as shippedNotificationContractID,
+	NotificationContractSchemaVersion as shippedNotificationContractSchemaVersion,
+} from "../files/plugins/notify/contract-compat"
+
+describe("notify contract-compat parity", () => {
+	it("keeps shipped notification contract constants aligned with canonical CLI definitions", () => {
+		expect(shippedNotificationContractID).toBe(canonicalNotificationContractID)
+		expect(shippedNotificationContractSchemaVersion).toBe(
+			canonicalNotificationContractSchemaVersion,
+		)
+		expect(shippedClosedHostNegotiatedStateByChannel).toEqual(
+			canonicalClosedHostNegotiatedStateByChannel,
+		)
+		expect(shippedClosedHostDefaultFallbackModeByChannel).toEqual(
+			canonicalClosedHostDefaultFallbackModeByChannel,
+		)
+	})
+
+	it("classifies canonical closed-host handshake the same way as canonical implementation", () => {
+		const canonicalResult = classifyCanonicalNotificationContractHandshake(
+			canonicalClosedHostDefaultHandshake,
+		)
+		const shippedResult = classifyShippedNotificationContractHandshake(
+			canonicalClosedHostDefaultHandshake,
+		)
+
+		expect(shippedResult).toEqual(canonicalResult)
+	})
+})

--- a/workers/kdco-registry/tests/notify-contract-compat-parity.test.ts
+++ b/workers/kdco-registry/tests/notify-contract-compat-parity.test.ts
@@ -15,6 +15,10 @@ import {
 	NotificationContractSchemaVersion as shippedNotificationContractSchemaVersion,
 } from "../files/plugins/notify/contract-compat"
 
+function withNullPrototype<T extends object>(value: T): T {
+	return Object.assign(Object.create(null), value) as T
+}
+
 describe("notify contract-compat parity", () => {
 	it("keeps shipped notification contract constants aligned with canonical CLI definitions", () => {
 		expect(shippedNotificationContractID).toBe(canonicalNotificationContractID)
@@ -38,5 +42,54 @@ describe("notify contract-compat parity", () => {
 		)
 
 		expect(shippedResult).toEqual(canonicalResult)
+	})
+
+	it("matches canonical classification for invalid object-shape handshakes", () => {
+		const channel = Object.keys(canonicalClosedHostDefaultHandshake.capabilities)[0]
+		expect(channel).toBeTruthy()
+		if (!channel) {
+			expect.unreachable("Expected closed-host handshake fixture to include at least one channel")
+		}
+
+		const invalidShapeCases = [
+			{
+				label: "null-prototype handshake root",
+				handshake: withNullPrototype(canonicalClosedHostDefaultHandshake),
+			},
+			{
+				label: "null-prototype contract",
+				handshake: {
+					...canonicalClosedHostDefaultHandshake,
+					contract: withNullPrototype(canonicalClosedHostDefaultHandshake.contract),
+				},
+			},
+			{
+				label: "null-prototype capabilities",
+				handshake: {
+					...canonicalClosedHostDefaultHandshake,
+					capabilities: withNullPrototype(canonicalClosedHostDefaultHandshake.capabilities),
+				},
+			},
+			{
+				label: "null-prototype capability entry",
+				handshake: {
+					...canonicalClosedHostDefaultHandshake,
+					capabilities: {
+						...canonicalClosedHostDefaultHandshake.capabilities,
+						[channel]: withNullPrototype(
+							canonicalClosedHostDefaultHandshake.capabilities[channel] as { state: string },
+						),
+					},
+				},
+			},
+		] as const
+
+		for (const testCase of invalidShapeCases) {
+			const canonicalResult = classifyCanonicalNotificationContractHandshake(testCase.handshake)
+			const shippedResult = classifyShippedNotificationContractHandshake(testCase.handshake)
+
+			expect(canonicalResult.compatible, testCase.label).toBe(false)
+			expect(shippedResult, testCase.label).toEqual(canonicalResult)
+		}
 	})
 })

--- a/workers/kdco-registry/tests/notify-normalize.test.ts
+++ b/workers/kdco-registry/tests/notify-normalize.test.ts
@@ -1,0 +1,521 @@
+import { describe, expect, it } from "bun:test"
+import {
+	CLOSED_HOST_DEFAULT_NOTIFICATION_NEGOTIATED_STATE_BY_CHANNEL,
+	createNotificationCapabilityByChannelFromNegotiatedState,
+	DesktopTerminalSemanticIntent,
+	type NormalizeNotificationOptions,
+	type NotificationCapabilityByChannel,
+	NotificationCapabilityState,
+	NotificationChannel,
+	NotificationFallbackMode,
+	NotificationHandlingMode,
+	NotificationLevel,
+	normalizeNotificationBoundaryInput,
+	normalizeNotificationEvent,
+	normalizeNotificationToolExecuteBefore,
+} from "../files/plugins/notify/normalize"
+import { createNotificationTaskSystemEvent } from "../files/plugins/notify/task-system-event"
+
+function createBehaviorallyDistinctPolicy(): NormalizeNotificationOptions {
+	const defaultCapabilityByChannel = createNotificationCapabilityByChannelFromNegotiatedState(
+		CLOSED_HOST_DEFAULT_NOTIFICATION_NEGOTIATED_STATE_BY_CHANNEL,
+	)
+
+	const capabilityByChannel: NotificationCapabilityByChannel = {
+		...defaultCapabilityByChannel,
+		[NotificationChannel.TaskSystem]: {
+			state: NotificationCapabilityState.Unsupported,
+			fallbackMode: NotificationFallbackMode.Drop,
+		},
+		[NotificationChannel.SDKSystem]: {
+			state: NotificationCapabilityState.Supported,
+			fallbackMode: NotificationFallbackMode.None,
+		},
+		[NotificationChannel.DesktopTerminal]: {
+			state: NotificationCapabilityState.Supported,
+			fallbackMode: NotificationFallbackMode.None,
+		},
+	}
+
+	return { capabilityByChannel }
+}
+
+describe("notify normalization boundary", () => {
+	it("normalizes valid notification.task.system events", () => {
+		const result = normalizeNotificationEvent({
+			type: "notification.task.system",
+			properties: {
+				title: "Task started",
+				message: 'Started task "audit" with @coder.',
+				level: "info",
+				sessionID: "session-1",
+			},
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized task.system intent")
+		}
+
+		expect(result.intent.channel).toBe(NotificationChannel.TaskSystem)
+		expect(result.intent.capabilityState).toBe(NotificationCapabilityState.Supported)
+		expect(result.intent.fallbackMode).toBe(NotificationFallbackMode.None)
+		expect(result.intent.handlingMode).toBe(NotificationHandlingMode.Deliver)
+		expect(result.intent.payload).toEqual({
+			title: "Task started",
+			message: 'Started task "audit" with @coder.',
+			level: "info",
+			sessionID: "session-1",
+		})
+	})
+
+	it("normalizes helper-built task/system bridge payloads", () => {
+		const event = createNotificationTaskSystemEvent({
+			id: "background-agent:terminal:session-42:task-1:complete",
+			dedupeKey: "background-agent:terminal:session-42:task-1:complete",
+			title: "Bridge Result",
+			message: "Background agent complete: Bridge Result",
+			level: NotificationLevel.Success,
+			sessionID: "session-42",
+		})
+
+		const result = normalizeNotificationEvent(event)
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized helper-built task.system intent")
+		}
+
+		expect(result.intent.channel).toBe(NotificationChannel.TaskSystem)
+		expect(result.intent.payload).toEqual({
+			title: "Bridge Result",
+			message: "Background agent complete: Bridge Result",
+			level: "success",
+			sessionID: "session-42",
+		})
+	})
+
+	it("normalizes legacy desktop/native-ready events to desktop.terminal intent", () => {
+		const result = normalizeNotificationEvent({
+			type: "session.idle",
+			properties: {
+				sessionID: "session-ready-42",
+			},
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized desktop intent")
+		}
+
+		expect(result.intent.channel).toBe(NotificationChannel.DesktopTerminal)
+		if (result.intent.channel !== NotificationChannel.DesktopTerminal) {
+			expect.unreachable("Expected desktop terminal intent")
+		}
+
+		expect(result.intent.semanticIntent).toBe(DesktopTerminalSemanticIntent.SessionReady)
+		expect(result.intent.origin.rawType).toBe("session.idle")
+		expect(result.intent.notificationId).toBe("session-ready:session-ready-42")
+		expect(result.intent.dedupeKey).toBe("session-ready:session-ready-42")
+		expect(result.intent.payload).toEqual({
+			title: "Ready for review",
+			message: "OpenCode task is ready for review",
+			level: "info",
+			sessionID: "session-ready-42",
+		})
+	})
+
+	it("encodes internal_only and unsupported handling in normalized result", () => {
+		const sdkResult = normalizeNotificationEvent({
+			type: "notification.sdk.system",
+			properties: {
+				code: "SESSION_RETRYING",
+				message: "Session retry scheduled",
+				level: "warning",
+				sourceEvent: "notification.task.system",
+			},
+		})
+
+		expect(sdkResult.ok).toBe(true)
+		if (!sdkResult.ok) {
+			expect.unreachable("Expected normalized sdk.system intent")
+		}
+
+		expect(sdkResult.intent.channel).toBe(NotificationChannel.SDKSystem)
+		expect(sdkResult.intent.capabilityState).toBe(NotificationCapabilityState.Unsupported)
+		expect(sdkResult.intent.fallbackMode).toBe(NotificationFallbackMode.Drop)
+		expect(sdkResult.intent.handlingMode).toBe(NotificationHandlingMode.Drop)
+
+		const mcpResult = normalizeNotificationEvent({
+			type: "notification.mcp.channel",
+			properties: {
+				server: "mcp-gateway",
+				message: "rate limit warning",
+				level: "warning",
+				source: "mcp.server",
+				trust: "untrusted",
+			},
+		})
+
+		expect(mcpResult.ok).toBe(true)
+		if (!mcpResult.ok) {
+			expect.unreachable("Expected normalized mcp.channel intent")
+		}
+
+		expect(mcpResult.intent.channel).toBe(NotificationChannel.MCPChannel)
+		expect(mcpResult.intent.capabilityState).toBe(NotificationCapabilityState.InternalOnly)
+		expect(mcpResult.intent.fallbackMode).toBe(NotificationFallbackMode.FailClosed)
+		expect(mcpResult.intent.handlingMode).toBe(NotificationHandlingMode.FailClosed)
+		expect(mcpResult.intent.trustLevel).toBe("untrusted")
+	})
+
+	it("returns parse_failure for malformed event payload", () => {
+		const result = normalizeNotificationEvent({
+			type: "notification.task.system",
+			properties: {
+				level: "info",
+			},
+		})
+
+		expect(result.ok).toBe(false)
+		if (result.ok) {
+			expect.unreachable("Expected parse failure")
+		}
+
+		expect(result.kind).toBe("parse_failure")
+		expect(result.code).toBe("invalid-properties")
+		expect(result.rawType).toBe("notification.task.system")
+	})
+
+	it("builds per-channel fallback policy from negotiated host state", () => {
+		const capabilityByChannel = createNotificationCapabilityByChannelFromNegotiatedState(
+			CLOSED_HOST_DEFAULT_NOTIFICATION_NEGOTIATED_STATE_BY_CHANNEL,
+		)
+
+		expect(capabilityByChannel[NotificationChannel.SDKSystem]).toEqual({
+			state: NotificationCapabilityState.Unsupported,
+			fallbackMode: NotificationFallbackMode.Drop,
+		})
+		expect(capabilityByChannel[NotificationChannel.DesktopTerminal]).toEqual({
+			state: NotificationCapabilityState.Unsupported,
+			fallbackMode: NotificationFallbackMode.FailClosed,
+		})
+	})
+
+	it("captures compact closed-host parity smoke across all five channels", () => {
+		function summarize(
+			result: ReturnType<typeof normalizeNotificationEvent>,
+			errorMessage: string,
+		): {
+			capabilityState: NotificationCapabilityState
+			fallbackMode: NotificationFallbackMode
+			handlingMode: NotificationHandlingMode
+		} {
+			expect(result.ok).toBe(true)
+			if (!result.ok) {
+				expect.unreachable(errorMessage)
+			}
+
+			return {
+				capabilityState: result.intent.capabilityState,
+				fallbackMode: result.intent.fallbackMode,
+				handlingMode: result.intent.handlingMode,
+			}
+		}
+
+		const parityByChannel = {
+			[NotificationChannel.UIToast]: summarize(
+				normalizeNotificationEvent({
+					type: "notification.ui.toast",
+					properties: {
+						message: "Heads up",
+						variant: "info",
+					},
+				}),
+				"Expected normalized ui.toast parity entry",
+			),
+			[NotificationChannel.TaskSystem]: summarize(
+				normalizeNotificationEvent({
+					type: "notification.task.system",
+					properties: {
+						message: "Task completed",
+						level: "success",
+					},
+				}),
+				"Expected normalized task.system parity entry",
+			),
+			[NotificationChannel.SDKSystem]: summarize(
+				normalizeNotificationEvent({
+					type: "notification.sdk.system",
+					properties: {
+						code: "SESSION_RETRYING",
+						message: "Session is retrying",
+						level: "warning",
+						sourceEvent: "notification.task.system",
+					},
+				}),
+				"Expected normalized sdk.system parity entry",
+			),
+			[NotificationChannel.DesktopTerminal]: summarize(
+				normalizeNotificationEvent({
+					type: "notification.desktop.terminal",
+					properties: {
+						title: "Terminal ping",
+						message: "Agent needs your attention",
+						level: "warning",
+					},
+				}),
+				"Expected normalized desktop.terminal parity entry",
+			),
+			[NotificationChannel.MCPChannel]: summarize(
+				normalizeNotificationEvent({
+					type: "notification.mcp.channel",
+					properties: {
+						server: "mcp-gateway",
+						message: "rate limit warning",
+						level: "warning",
+						source: "mcp.server",
+						trust: "untrusted",
+					},
+				}),
+				"Expected normalized mcp.channel parity entry",
+			),
+		}
+
+		expect(parityByChannel).toEqual({
+			[NotificationChannel.UIToast]: {
+				capabilityState: NotificationCapabilityState.Supported,
+				fallbackMode: NotificationFallbackMode.None,
+				handlingMode: NotificationHandlingMode.Deliver,
+			},
+			[NotificationChannel.TaskSystem]: {
+				capabilityState: NotificationCapabilityState.Supported,
+				fallbackMode: NotificationFallbackMode.None,
+				handlingMode: NotificationHandlingMode.Deliver,
+			},
+			[NotificationChannel.SDKSystem]: {
+				capabilityState: NotificationCapabilityState.Unsupported,
+				fallbackMode: NotificationFallbackMode.Drop,
+				handlingMode: NotificationHandlingMode.Drop,
+			},
+			[NotificationChannel.DesktopTerminal]: {
+				capabilityState: NotificationCapabilityState.Unsupported,
+				fallbackMode: NotificationFallbackMode.FailClosed,
+				handlingMode: NotificationHandlingMode.FailClosed,
+			},
+			[NotificationChannel.MCPChannel]: {
+				capabilityState: NotificationCapabilityState.InternalOnly,
+				fallbackMode: NotificationFallbackMode.FailClosed,
+				handlingMode: NotificationHandlingMode.FailClosed,
+			},
+		})
+	})
+
+	it("fails fast when negotiated state conflicts with closed host fallback metadata", () => {
+		expect(() =>
+			createNotificationCapabilityByChannelFromNegotiatedState({
+				...CLOSED_HOST_DEFAULT_NOTIFICATION_NEGOTIATED_STATE_BY_CHANNEL,
+				[NotificationChannel.SDKSystem]: NotificationCapabilityState.Supported,
+			}),
+		).toThrow(
+			"Closed host notification policy mismatch: channel sdk.system cannot be supported/fallback_approved when fallback mode is drop.",
+		)
+	})
+
+	it("consumes supplied capability policy directly for normalization behavior", () => {
+		const options = createBehaviorallyDistinctPolicy()
+
+		const taskResult = normalizeNotificationEvent(
+			{
+				type: "notification.task.system",
+				properties: {
+					message: "Task transport request",
+					level: "success",
+				},
+			},
+			options,
+		)
+
+		expect(taskResult.ok).toBe(true)
+		if (!taskResult.ok) {
+			expect.unreachable("Expected normalized task.system intent")
+		}
+
+		expect(taskResult.intent.capabilityState).toBe(NotificationCapabilityState.Unsupported)
+		expect(taskResult.intent.fallbackMode).toBe(NotificationFallbackMode.Drop)
+		expect(taskResult.intent.handlingMode).toBe(NotificationHandlingMode.Drop)
+	})
+
+	it("applies injected boundary policy for both event and tool sources", () => {
+		const options = createBehaviorallyDistinctPolicy()
+
+		const eventBoundaryResult = normalizeNotificationBoundaryInput(
+			{
+				source: "event",
+				value: {
+					type: "notification.sdk.system",
+					properties: {
+						code: "POLICY_DROP",
+						message: "Drop path",
+						level: "warning",
+						sourceEvent: "notification.task.system",
+					},
+				},
+			},
+			options,
+		)
+
+		expect(eventBoundaryResult.ok).toBe(true)
+		if (!eventBoundaryResult.ok) {
+			expect.unreachable("Expected normalized event-boundary intent")
+		}
+
+		expect(eventBoundaryResult.intent.channel).toBe(NotificationChannel.SDKSystem)
+		expect(eventBoundaryResult.intent.fallbackMode).toBe(NotificationFallbackMode.None)
+		expect(eventBoundaryResult.intent.handlingMode).toBe(NotificationHandlingMode.Deliver)
+
+		const toolBoundaryResult = normalizeNotificationBoundaryInput(
+			{
+				source: "tool.execute.before",
+				value: {
+					tool: "question",
+					sessionID: "session-tool-policy",
+					callID: "call-tool-policy",
+				},
+			},
+			options,
+		)
+
+		expect(toolBoundaryResult.ok).toBe(true)
+		if (!toolBoundaryResult.ok) {
+			expect.unreachable("Expected normalized tool-boundary intent")
+		}
+
+		expect(toolBoundaryResult.intent.channel).toBe(NotificationChannel.DesktopTerminal)
+		expect(toolBoundaryResult.intent.fallbackMode).toBe(NotificationFallbackMode.None)
+		expect(toolBoundaryResult.intent.handlingMode).toBe(NotificationHandlingMode.Deliver)
+	})
+
+	it("preserves session.error detail via String(error) for truthy non-string values", () => {
+		const result = normalizeNotificationEvent({
+			type: "session.error",
+			properties: {
+				sessionID: "session-err-1",
+				error: new Error("Disk blew up"),
+			},
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized session.error intent")
+		}
+
+		expect(result.intent.payload.message).toBe("Error: Disk blew up")
+	})
+
+	it("normalizes direct desktop terminal events as generic semantic intents", () => {
+		const result = normalizeNotificationEvent({
+			type: "notification.desktop.terminal",
+			properties: {
+				title: "Question for you",
+				message: "Literal direct desktop payload",
+				level: "warning",
+			},
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized direct desktop terminal intent")
+		}
+
+		expect(result.intent.channel).toBe(NotificationChannel.DesktopTerminal)
+		if (result.intent.channel !== NotificationChannel.DesktopTerminal) {
+			expect.unreachable("Expected desktop terminal intent")
+		}
+
+		expect(result.intent.semanticIntent).toBe(DesktopTerminalSemanticIntent.Generic)
+		expect(result.intent.payload.title).toBe("Question for you")
+	})
+
+	it("does not invent permission dedupe keys when request id is missing", () => {
+		const result = normalizeNotificationEvent({
+			type: "permission.updated",
+			properties: {
+				sessionID: "session-perm-missing-id",
+			},
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized permission intent")
+		}
+
+		expect(result.intent.dedupeKey).toBeUndefined()
+	})
+
+	it("does not invent question dedupe keys when stable identifiers are missing", () => {
+		const eventResult = normalizeNotificationEvent({
+			type: "question.asked",
+			properties: {
+				sessionID: "session-question-missing-id",
+				questions: [],
+			},
+		})
+
+		expect(eventResult.ok).toBe(true)
+		if (!eventResult.ok) {
+			expect.unreachable("Expected normalized question.asked intent")
+		}
+
+		expect(eventResult.intent.dedupeKey).toBeUndefined()
+
+		const requestOnlyEventResult = normalizeNotificationEvent({
+			type: "question.asked",
+			properties: {
+				id: "question-request-only",
+				questions: [],
+			},
+		})
+
+		expect(requestOnlyEventResult.ok).toBe(true)
+		if (!requestOnlyEventResult.ok) {
+			expect.unreachable("Expected normalized request-only question.asked intent")
+		}
+
+		expect(requestOnlyEventResult.intent.dedupeKey).toBeUndefined()
+
+		const toolResult = normalizeNotificationToolExecuteBefore({
+			tool: "question",
+			sessionID: "session-question-missing-call",
+		})
+
+		expect(toolResult.ok).toBe(true)
+		if (!toolResult.ok) {
+			expect.unreachable("Expected normalized tool.execute.before intent")
+		}
+
+		expect(toolResult.intent.dedupeKey).toBeUndefined()
+	})
+
+	it("normalizes legacy question tool hook into desktop intent", () => {
+		const result = normalizeNotificationToolExecuteBefore({
+			tool: "question",
+			sessionID: "session-tool",
+			callID: "call-1",
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			expect.unreachable("Expected normalized tool.execute.before intent")
+		}
+
+		expect(result.intent.channel).toBe(NotificationChannel.DesktopTerminal)
+		if (result.intent.channel !== NotificationChannel.DesktopTerminal) {
+			expect.unreachable("Expected desktop terminal intent")
+		}
+
+		expect(result.intent.origin.source).toBe("tool.execute.before")
+		expect(result.intent.semanticIntent).toBe(DesktopTerminalSemanticIntent.Question)
+		expect(result.intent.dedupeKey).toBe("question:session-tool:call-1")
+	})
+})

--- a/workers/kdco-registry/tests/notify-normalize.test.ts
+++ b/workers/kdco-registry/tests/notify-normalize.test.ts
@@ -169,6 +169,55 @@ describe("notify normalization boundary", () => {
 		expect(mcpResult.intent.trustLevel).toBe("untrusted")
 	})
 
+	it("keeps mcp.channel fallback identity unique per message", () => {
+		const baseline = normalizeNotificationEvent({
+			type: "notification.mcp.channel",
+			properties: {
+				server: "mcp-gateway",
+				message: "rate limit warning",
+				level: "warning",
+				source: "mcp.server",
+				trust: "untrusted",
+			},
+		})
+
+		const distinctMessage = normalizeNotificationEvent({
+			type: "notification.mcp.channel",
+			properties: {
+				server: "mcp-gateway",
+				message: "gateway degraded",
+				level: "warning",
+				source: "mcp.server",
+				trust: "untrusted",
+			},
+		})
+
+		const repeatedBaseline = normalizeNotificationEvent({
+			type: "notification.mcp.channel",
+			properties: {
+				server: "mcp-gateway",
+				message: "rate limit warning",
+				level: "warning",
+				source: "mcp.server",
+				trust: "untrusted",
+			},
+		})
+
+		expect(baseline.ok).toBe(true)
+		expect(distinctMessage.ok).toBe(true)
+		expect(repeatedBaseline.ok).toBe(true)
+
+		if (!baseline.ok || !distinctMessage.ok || !repeatedBaseline.ok) {
+			expect.unreachable("Expected normalized mcp.channel intents")
+		}
+
+		expect(baseline.intent.notificationId).not.toBe(distinctMessage.intent.notificationId)
+		expect(baseline.intent.dedupeKey).not.toBe(distinctMessage.intent.dedupeKey)
+
+		expect(baseline.intent.notificationId).toBe(repeatedBaseline.intent.notificationId)
+		expect(baseline.intent.dedupeKey).toBe(repeatedBaseline.intent.dedupeKey)
+	})
+
 	it("returns parse_failure for malformed event payload", () => {
 		const result = normalizeNotificationEvent({
 			type: "notification.task.system",

--- a/workers/kdco-registry/tests/notify-packaging.test.ts
+++ b/workers/kdco-registry/tests/notify-packaging.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+const registryRoot = join(import.meta.dir, "..")
+
+function extractComponentManifestFiles(
+	registryContent: string,
+	componentName: string,
+): Set<string> {
+	const componentMatch = registryContent.match(
+		new RegExp(`"name"\\s*:\\s*"${componentName}"[\\s\\S]*?"files"\\s*:\\s*\\[([\\s\\S]*?)\\]`),
+	)
+
+	expect(componentMatch).toBeTruthy()
+	if (!componentMatch || !componentMatch[1]) {
+		throw new Error(`Expected ${componentName} component files array in registry manifest`)
+	}
+
+	return new Set(Array.from(componentMatch[1].matchAll(/"([^"]+)"/g), ([, filePath]) => filePath))
+}
+
+function collectNotifyPluginLocalImports(source: string): string[] {
+	return Array.from(source.matchAll(/from "\.\/notify\/([^"]+)"/g), ([, localImport]) => {
+		if (!localImport) {
+			throw new Error("Expected notify local import path")
+		}
+
+		return `plugins/notify/${localImport}.ts`
+	})
+}
+
+function collectNotifyHelperLocalImports(source: string): string[] {
+	return Array.from(source.matchAll(/from "\.\/([^"]+)"/g), ([, localImport]) => {
+		if (!localImport) {
+			throw new Error("Expected notify helper local import path")
+		}
+
+		return `plugins/notify/${localImport}.ts`
+	})
+}
+
+describe("kdco/notify packaging contract", () => {
+	it("keeps notify manifest files in parity with local ./notify/* imports", async () => {
+		const registryContent = await readFile(join(registryRoot, "registry.jsonc"), "utf-8")
+		const manifestFiles = extractComponentManifestFiles(registryContent, "notify")
+
+		const notifyPluginSource = await readFile(
+			join(registryRoot, "files", "plugins", "notify.ts"),
+			"utf-8",
+		)
+		const notifyNormalizeSource = await readFile(
+			join(registryRoot, "files", "plugins", "notify", "normalize.ts"),
+			"utf-8",
+		)
+
+		const expectedFiles = [
+			...collectNotifyPluginLocalImports(notifyPluginSource),
+			...collectNotifyHelperLocalImports(notifyNormalizeSource),
+		]
+
+		const missingManifestFiles = expectedFiles.filter((filePath) => !manifestFiles.has(filePath))
+		expect(missingManifestFiles).toEqual([])
+	})
+
+	it("prevents notify runtime source from importing monorepo-only CLI modules", async () => {
+		const notifyPluginSource = await readFile(
+			join(registryRoot, "files", "plugins", "notify.ts"),
+			"utf-8",
+		)
+		const notifyNormalizeSource = await readFile(
+			join(registryRoot, "files", "plugins", "notify", "normalize.ts"),
+			"utf-8",
+		)
+
+		expect(notifyPluginSource).not.toContain("packages/cli/src/")
+		expect(notifyNormalizeSource).not.toContain("packages/cli/src/")
+	})
+
+	it("keeps background-agents self-contained from notify helper imports", async () => {
+		const backgroundAgentsSource = await readFile(
+			join(registryRoot, "files", "plugins", "background-agents.ts"),
+			"utf-8",
+		)
+
+		expect(backgroundAgentsSource).not.toContain('from "./notify/')
+	})
+})

--- a/workers/kdco-registry/tests/notify-packaging.test.ts
+++ b/workers/kdco-registry/tests/notify-packaging.test.ts
@@ -83,6 +83,6 @@ describe("kdco/notify packaging contract", () => {
 			"utf-8",
 		)
 
-		expect(backgroundAgentsSource).not.toContain('from "./notify/')
+		expect(backgroundAgentsSource).not.toMatch(/from\s+["']\.\/notify(?:["']|\/)/)
 	})
 })

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -1,5 +1,49 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { Event } from "@opencode-ai/sdk"
+import {
+	NotificationChannel as HostNotificationChannel,
+	NotificationNegotiatedState as HostNotificationNegotiatedState,
+	type NotificationContractHandshake,
+	NotificationContractID,
+	NotificationContractSchemaVersion,
+} from "../../../packages/cli/src/notify/contract-compat"
+import {
+	NotificationCapabilityState,
+	NotificationChannel,
+	NotificationFallbackMode,
+	NotificationHandlingMode,
+	normalizeNotificationBoundaryInput,
+} from "../files/plugins/notify/normalize"
+
+function createHostHandshakeFixture(
+	input: { schemaVersion?: string; capabilities?: Record<string, { state: string }> } = {},
+): NotificationContractHandshake {
+	return {
+		contract: {
+			id: NotificationContractID,
+			schemaVersion: input.schemaVersion ?? NotificationContractSchemaVersion,
+		},
+		capabilities:
+			input.capabilities ??
+			({
+				[HostNotificationChannel.UIToast]: {
+					state: HostNotificationNegotiatedState.Supported,
+				},
+				[HostNotificationChannel.TaskSystem]: {
+					state: HostNotificationNegotiatedState.Supported,
+				},
+				[HostNotificationChannel.SDKSystem]: {
+					state: HostNotificationNegotiatedState.Unsupported,
+				},
+				[HostNotificationChannel.DesktopTerminal]: {
+					state: HostNotificationNegotiatedState.Unsupported,
+				},
+				[HostNotificationChannel.MCPChannel]: {
+					state: HostNotificationNegotiatedState.InternalOnly,
+				},
+			} satisfies NotificationContractHandshake["capabilities"]),
+	}
+}
 
 type SessionInfo = {
 	parentID?: string
@@ -35,9 +79,12 @@ mock.module("node-notifier", () => ({
 }))
 
 let NotifyPlugin: typeof import("../files/plugins/notify").NotifyPlugin
+let resolveNotificationRuntimePolicyFromHostHandshake: typeof import("../files/plugins/notify").resolveNotificationRuntimePolicyFromHostHandshake
 
 beforeAll(async () => {
-	;({ NotifyPlugin } = await import("../files/plugins/notify"))
+	;({ NotifyPlugin, resolveNotificationRuntimePolicyFromHostHandshake } = await import(
+		"../files/plugins/notify"
+	))
 })
 
 beforeEach(() => {
@@ -86,7 +133,12 @@ function mockFocusedTerminal(): void {
 	})
 }
 
-async function createPlugin(sessionInfoByID: Record<string, SessionInfo> = {}): Promise<{
+async function createPlugin(
+	sessionInfoByID: Record<string, SessionInfo> = {},
+	options: {
+		hostNotificationContractHandshake?: unknown
+	} = {},
+): Promise<{
 	hooks: Awaited<ReturnType<typeof NotifyPlugin>>
 	sessionGet: ReturnType<typeof mock>
 }> {
@@ -97,13 +149,19 @@ async function createPlugin(sessionInfoByID: Record<string, SessionInfo> = {}): 
 		},
 	}))
 
-	const hooks = await NotifyPlugin({
+	const pluginContext: Record<string, unknown> = {
 		client: {
 			session: {
 				get: sessionGet,
 			},
 		},
-	} as unknown as Parameters<typeof NotifyPlugin>[0])
+	}
+
+	if (options.hostNotificationContractHandshake !== undefined) {
+		pluginContext.notificationContractHandshake = options.hostNotificationContractHandshake
+	}
+
+	const hooks = await NotifyPlugin(pluginContext as unknown as Parameters<typeof NotifyPlugin>[0])
 
 	return { hooks, sessionGet }
 }
@@ -121,20 +179,247 @@ async function emitQuestionToolBefore(
 	sessionID: string,
 	callID: string,
 ): Promise<void> {
+	await emitToolBefore(hooks, {
+		tool: "question",
+		sessionID,
+		callID,
+	})
+}
+
+async function emitToolBefore(
+	hooks: Awaited<ReturnType<typeof NotifyPlugin>>,
+	input: unknown,
+): Promise<void> {
 	const hook = hooks["tool.execute.before"]
 	if (!hook) throw new Error("Notify plugin did not register tool.execute.before")
 
-	await (hook as (...args: unknown[]) => Promise<void>)(
-		{
-			tool: "question",
-			sessionID,
-			callID,
-		},
-		{},
-	)
+	await (hook as (...args: unknown[]) => Promise<void>)(input, {})
 }
 
+describe("notify host handshake mixed-version seam", () => {
+	it("accepts same-major drift, warns on unknown channels, and enforces host fail_closed runtime policy", async () => {
+		const hostHandshake = createHostHandshakeFixture({
+			schemaVersion: "1.2.0",
+			capabilities: {
+				[HostNotificationChannel.UIToast]: {
+					state: HostNotificationNegotiatedState.Supported,
+				},
+				[HostNotificationChannel.TaskSystem]: {
+					state: HostNotificationNegotiatedState.FallbackApproved,
+				},
+				[HostNotificationChannel.SDKSystem]: {
+					state: HostNotificationNegotiatedState.Unsupported,
+				},
+				[HostNotificationChannel.DesktopTerminal]: {
+					state: HostNotificationNegotiatedState.InternalOnly,
+				},
+				[HostNotificationChannel.MCPChannel]: {
+					state: HostNotificationNegotiatedState.InternalOnly,
+				},
+				"future.channel": {
+					state: HostNotificationNegotiatedState.Supported,
+				},
+			},
+		})
+
+		const policyResolution = resolveNotificationRuntimePolicyFromHostHandshake(hostHandshake)
+		expect(policyResolution.compatible).toBe(true)
+		if (!policyResolution.compatible) {
+			expect.unreachable("Expected same-major host handshake to be compatible")
+		}
+
+		expect(policyResolution.source).toBe("host-handshake")
+		expect(policyResolution.warnings.map((warning) => warning.code).sort()).toEqual([
+			"newer-schema-minor-or-patch",
+			"unknown-channel-ignored",
+		])
+		expect(
+			Object.hasOwn(policyResolution.normalizePolicy.capabilityByChannel ?? {}, "future.channel"),
+		).toBe(false)
+
+		const desktopEvent = {
+			type: "notification.desktop.terminal",
+			properties: {
+				title: "Terminal ping",
+				message: "Agent needs your attention",
+				level: "warning",
+			},
+		}
+
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+		const { hooks: defaultHooks } = await createPlugin()
+
+		await emitEvent(defaultHooks, desktopEvent)
+
+		expect(notificationPayloads).toHaveLength(1)
+
+		notificationPayloads.length = 0
+
+		const { hooks } = await createPlugin({}, { hostNotificationContractHandshake: hostHandshake })
+
+		await emitEvent(hooks, desktopEvent)
+
+		expect(notificationPayloads).toHaveLength(0)
+
+		const warningMessages = warnSpy.mock.calls.map((args) => String(args[0]))
+		expect(warningMessages.some((message) => message.includes("newer-schema-minor-or-patch"))).toBe(
+			true,
+		)
+		expect(warningMessages.some((message) => message.includes("unknown-channel-ignored"))).toBe(
+			true,
+		)
+		expect(warningMessages.some((message) => message.includes("fail_closed"))).toBe(true)
+	})
+
+	it("hard-fails plugin startup for unsupported schema major", async () => {
+		const incompatibleHandshake = createHostHandshakeFixture({
+			schemaVersion: "2.0.0",
+		})
+
+		const policyResolution =
+			resolveNotificationRuntimePolicyFromHostHandshake(incompatibleHandshake)
+		expect(policyResolution.compatible).toBe(false)
+		if (policyResolution.compatible) {
+			expect.unreachable("Expected incompatible host handshake")
+		}
+
+		expect(policyResolution.errors.map((issue) => issue.code)).toContain("unsupported-schema-major")
+
+		await expect(
+			createPlugin({}, { hostNotificationContractHandshake: incompatibleHandshake }),
+		).rejects.toThrow("unsupported-schema-major")
+	})
+
+	it("hard-fails plugin startup when a canonical channel is missing", async () => {
+		const missingRequiredChannelHandshake = createHostHandshakeFixture()
+		delete missingRequiredChannelHandshake.capabilities[HostNotificationChannel.DesktopTerminal]
+
+		const policyResolution = resolveNotificationRuntimePolicyFromHostHandshake(
+			missingRequiredChannelHandshake,
+		)
+		expect(policyResolution.compatible).toBe(false)
+		if (policyResolution.compatible) {
+			expect.unreachable("Expected incompatible host handshake")
+		}
+
+		expect(policyResolution.errors.map((issue) => issue.code)).toContain("missing-required-channel")
+
+		await expect(
+			createPlugin({}, { hostNotificationContractHandshake: missingRequiredChannelHandshake }),
+		).rejects.toThrow("missing-required-channel")
+	})
+
+	it("hard-fails plugin startup for unknown negotiated state on canonical channel", async () => {
+		const unknownStateHandshake = createHostHandshakeFixture()
+		unknownStateHandshake.capabilities[HostNotificationChannel.SDKSystem] = {
+			state: "legacy_supported",
+		}
+
+		const policyResolution =
+			resolveNotificationRuntimePolicyFromHostHandshake(unknownStateHandshake)
+		expect(policyResolution.compatible).toBe(false)
+		if (policyResolution.compatible) {
+			expect.unreachable("Expected incompatible host handshake")
+		}
+
+		expect(policyResolution.errors).toContainEqual(
+			expect.objectContaining({
+				code: "unknown-negotiated-state",
+				channel: HostNotificationChannel.SDKSystem,
+				state: "legacy_supported",
+			}),
+		)
+
+		await expect(
+			createPlugin({}, { hostNotificationContractHandshake: unknownStateHandshake }),
+		).rejects.toThrow("unknown-negotiated-state")
+	})
+})
+
 describe("notify plugin event compatibility and dedupe", () => {
+	it("proves host-handshake policy resolves mcp.channel fail_closed normalization and remains non-deliverable at runtime", async () => {
+		const hostHandshake = createHostHandshakeFixture()
+		hostHandshake.capabilities[HostNotificationChannel.MCPChannel] = {
+			state: HostNotificationNegotiatedState.Unsupported,
+		}
+
+		const mcpEvent = {
+			type: "notification.mcp.channel",
+			properties: {
+				server: "mcp-gateway",
+				message: "rate limit warning",
+				level: "warning",
+				source: "mcp.server",
+				trust: "untrusted",
+			},
+		}
+
+		const hostPolicyResolution = resolveNotificationRuntimePolicyFromHostHandshake(hostHandshake)
+		expect(hostPolicyResolution.compatible).toBe(true)
+		if (!hostPolicyResolution.compatible) {
+			expect.unreachable("Expected host notification handshake to be compatible")
+		}
+
+		expect(hostPolicyResolution.source).toBe("host-handshake")
+		expect(
+			hostPolicyResolution.normalizePolicy.capabilityByChannel?.[NotificationChannel.MCPChannel],
+		).toEqual({
+			state: NotificationCapabilityState.Unsupported,
+			fallbackMode: NotificationFallbackMode.FailClosed,
+		})
+
+		const normalizedDefaultMCPIntent = normalizeNotificationBoundaryInput({
+			source: "event",
+			value: mcpEvent,
+		})
+		expect(normalizedDefaultMCPIntent.ok).toBe(true)
+		if (!normalizedDefaultMCPIntent.ok) {
+			expect.unreachable("Expected normalized default-policy mcp.channel intent")
+		}
+
+		expect(normalizedDefaultMCPIntent.intent.channel).toBe(NotificationChannel.MCPChannel)
+		expect(normalizedDefaultMCPIntent.intent.capabilityState).toBe(
+			NotificationCapabilityState.InternalOnly,
+		)
+		expect(normalizedDefaultMCPIntent.intent.fallbackMode).toBe(NotificationFallbackMode.FailClosed)
+		expect(normalizedDefaultMCPIntent.intent.handlingMode).toBe(NotificationHandlingMode.FailClosed)
+
+		const normalizedMCPIntent = normalizeNotificationBoundaryInput(
+			{
+				source: "event",
+				value: mcpEvent,
+			},
+			hostPolicyResolution.normalizePolicy,
+		)
+		expect(normalizedMCPIntent.ok).toBe(true)
+		if (!normalizedMCPIntent.ok) {
+			expect.unreachable("Expected normalized mcp.channel intent")
+		}
+
+		expect(normalizedMCPIntent.intent.channel).toBe(NotificationChannel.MCPChannel)
+		expect(normalizedMCPIntent.intent.capabilityState).toBe(NotificationCapabilityState.Unsupported)
+		expect(normalizedMCPIntent.intent.fallbackMode).toBe(NotificationFallbackMode.FailClosed)
+		expect(normalizedMCPIntent.intent.handlingMode).toBe(NotificationHandlingMode.FailClosed)
+		expect(normalizedMCPIntent.intent.capabilityState).not.toBe(
+			normalizedDefaultMCPIntent.intent.capabilityState,
+		)
+
+		const { hooks: defaultHooks } = await createPlugin()
+		await emitEvent(defaultHooks, mcpEvent)
+		expect(notificationPayloads).toHaveLength(0)
+
+		notificationPayloads.length = 0
+
+		const { hooks: hostHandshakeHooks } = await createPlugin(
+			{},
+			{
+				hostNotificationContractHandshake: hostHandshake,
+			},
+		)
+		await emitEvent(hostHandshakeHooks, mcpEvent)
+		expect(notificationPayloads).toHaveLength(0)
+	})
+
 	it("dedupes permission notification when permission.asked and permission.updated describe same request", async () => {
 		const { hooks } = await createPlugin()
 
@@ -236,6 +521,65 @@ describe("notify plugin event compatibility and dedupe", () => {
 			"Ready for review",
 			"Ready for review",
 		])
+	})
+
+	it("delivers direct notification.desktop.terminal events through NotifyPlugin", async () => {
+		const { hooks } = await createPlugin()
+
+		await emitEvent(hooks, {
+			type: "notification.desktop.terminal",
+			properties: {
+				title: "Terminal ping",
+				message: "Agent needs your attention",
+				level: "warning",
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(1)
+		expect(notificationPayloads[0]).toMatchObject({
+			title: "Terminal ping",
+			message: "Agent needs your attention",
+		})
+	})
+
+	it("keeps direct notification.desktop.terminal payload literal when title matches legacy question", async () => {
+		const { hooks } = await createPlugin()
+
+		await emitEvent(hooks, {
+			type: "notification.desktop.terminal",
+			properties: {
+				title: "Question for you",
+				message: "Literal question body from direct desktop event",
+				level: "warning",
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(1)
+		expect(notificationPayloads[0]).toMatchObject({
+			title: "Question for you",
+			message: "Literal question body from direct desktop event",
+		})
+		expect(notificationPayloads[0]?.message).not.toBe("OpenCode needs your input")
+	})
+
+	it("notifies for session.error through NotifyPlugin", async () => {
+		const { hooks } = await createPlugin({
+			"session-error": { title: "Error Session" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-error",
+				error: "Disk blew up",
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(1)
+		expect(notificationPayloads[0]).toMatchObject({
+			title: "Something went wrong",
+			message: "Disk blew up",
+		})
 	})
 
 	it("dedupes ready notification when session.status idle and session.idle describe same transition", async () => {
@@ -414,5 +758,38 @@ describe("notify plugin event compatibility and dedupe", () => {
 		})
 
 		expect(notificationPayloads).toHaveLength(0)
+	})
+
+	it("logs and drops malformed legacy event payloads from normalization boundary", async () => {
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+		const { hooks } = await createPlugin()
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				status: {
+					type: "idle",
+				},
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(0)
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("[notify] Dropping event payload type=session.status"),
+		)
+	})
+
+	it("logs and drops malformed tool.execute.before payloads from normalization boundary", async () => {
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+		const { hooks } = await createPlugin()
+
+		await emitToolBefore(hooks, null)
+
+		expect(notificationPayloads).toHaveLength(0)
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("[notify] Dropping tool.execute.before payload"),
+		)
 	})
 })

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -137,6 +137,7 @@ async function createPlugin(
 	sessionInfoByID: Record<string, SessionInfo> = {},
 	options: {
 		hostNotificationContractHandshake?: unknown
+		useNullPrototypeContext?: boolean
 	} = {},
 ): Promise<{
 	hooks: Awaited<ReturnType<typeof NotifyPlugin>>
@@ -149,11 +150,13 @@ async function createPlugin(
 		},
 	}))
 
-	const pluginContext: Record<string, unknown> = {
-		client: {
-			session: {
-				get: sessionGet,
-			},
+	const pluginContext = (options.useNullPrototypeContext ? Object.create(null) : {}) as Record<
+		string,
+		unknown
+	>
+	pluginContext.client = {
+		session: {
+			get: sessionGet,
 		},
 	}
 
@@ -288,6 +291,22 @@ describe("notify host handshake mixed-version seam", () => {
 		await expect(
 			createPlugin({}, { hostNotificationContractHandshake: incompatibleHandshake }),
 		).rejects.toThrow("unsupported-schema-major")
+	})
+
+	it("ignores host handshake on null-prototype context envelope", async () => {
+		const incompatibleHandshake = createHostHandshakeFixture({
+			schemaVersion: "2.0.0",
+		})
+
+		await expect(
+			createPlugin(
+				{},
+				{
+					hostNotificationContractHandshake: incompatibleHandshake,
+					useNullPrototypeContext: true,
+				},
+			),
+		).resolves.toBeDefined()
 	})
 
 	it("hard-fails plugin startup when a canonical channel is missing", async () => {

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -293,7 +293,7 @@ describe("notify host handshake mixed-version seam", () => {
 		).rejects.toThrow("unsupported-schema-major")
 	})
 
-	it("ignores host handshake on null-prototype context envelope", async () => {
+	it("hard-fails incompatible host handshake even on null-prototype context envelope", async () => {
 		const incompatibleHandshake = createHostHandshakeFixture({
 			schemaVersion: "2.0.0",
 		})
@@ -306,7 +306,7 @@ describe("notify host handshake mixed-version seam", () => {
 					useNullPrototypeContext: true,
 				},
 			),
-		).resolves.toBeDefined()
+		).rejects.toThrow("unsupported-schema-major")
 	})
 
 	it("hard-fails plugin startup when a canonical channel is missing", async () => {


### PR DESCRIPTION
## Summary
- Adds a host-contract compatibility gate in the CLI (`packages/cli/src/notify/contract-compat.ts`) with mixed-version behavior (fail-closed on incompatible major, warn-and-continue for newer minor/patch, canonical channel/state validation).
- Refactors OCX notify handling to use a normalization boundary and negotiated runtime policy handling, including fail-closed enforcement when host handshake policy requires it.
- Bridges background-agent terminal task notifications to structured `notification.task.system` payloads and verifies normalization for both per-task and all-complete terminal notifications.
- Expands parity verification coverage for mixed-version seams and MCP/internal channel behavior via notify compatibility, normalize, and plugin/backend tests.
- Captures closure evidence in `docs/MANUAL_TESTING.md` with the release gate checklist and parity snapshot status.

## Known non-blocking limitations
- `sdk.system` remains negotiated as unsupported for this slice.
- `desktop.terminal` remains unsupported in host capability negotiation where delivery is not implemented.
- `mcp.channel` remains internal-only and fail-closed until a trust/source-aware user-facing surface is introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a notification contract compatibility gate and a runtime normalization boundary to keep host and plugin behavior consistent across versions, with parity and packaging guards to keep the CLI and shipped plugin in sync. Bridges background‑agent terminal notifications to structured `notification.task.system` events with reliable desktop fallback, and rejects null‑prototype host handshake envelopes.

- **New Features**
  - CLI compatibility gate (`packages/cli/src/notify/contract-compat.ts`): fail‑closed on incompatible major; warn‑and‑continue for newer minor/patch; canonical channel/state validation.
  - Notification normalization boundary (`workers/kdco-registry/files/plugins/notify/normalize.ts`): centralized handling for `ui.toast`, `task.system`, `sdk.system`, `desktop.terminal`, `mcp.channel`; enforces host handshake policy.
  - Background‑agent bridge: terminal task notifications converted to `notification.task.system` (per‑task and all‑complete).

- **Refactors**
  - Notify flow classifies the host handshake via the gate and routes through the normalization boundary; desktop backend uses a unified payload, prefers cmux with `node-notifier` fallback, exports `CmuxNotificationPayload` and runtime types, and fails closed on null‑prototype handshake envelopes.
  - Registry ships self‑contained helpers (`notify/contract-compat.ts`, `normalize.ts`, `task-system-event.ts`) and updates `registry.jsonc`; adds CLI↔shipped parity tests and a packaging import‑guard test; updates `docs/MANUAL_TESTING.md` with the Phase 2.10 release gate checklist.

<sup>Written for commit 70a7ed6778949b83dba7cd8cb9c24725132bf3f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

