### PR TITLE
fix(cli): Resolve profile-scoped relative {file:...} references

### DIFF
--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -9,8 +9,16 @@
 
 import * as path from "node:path"
 import type { Command } from "commander"
+import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 import { ConfigResolver } from "../config/resolver"
-import { getProfileDir, getProfileOpencodeConfig } from "../profile/paths"
+import {
+	findLocalConfigDir,
+	getProfileDir,
+	getProfileOpencodeConfig,
+	OPENCODE_CONFIG_FILE,
+} from "../profile/paths"
+import { dedupePluginsByCanonicalName, extractCanonicalPluginName } from "../registry/merge"
+import { ConfigError } from "../utils/errors"
 import { getGitInfo } from "../utils/git-context"
 import { handleError } from "../utils/handle-error"
 import { logger } from "../utils/logger"
@@ -30,6 +38,370 @@ import {
 interface OpencodeOptions {
 	profile?: string
 	rename?: boolean
+}
+
+type OpencodeLeafOrigin = "profile" | "local"
+type OpencodePathSegment = string | number
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function formatJsoncParseError(parseErrors: ParseError[]): string {
+	if (parseErrors.length === 0) {
+		return "Unknown parse error"
+	}
+
+	const firstError = parseErrors[0]
+	if (!firstError) {
+		return "Unknown parse error"
+	}
+
+	return `${printParseErrorCode(firstError.error)} at offset ${firstError.offset}`
+}
+
+function pathSegmentsToKey(segments: OpencodePathSegment[]): string {
+	if (segments.length === 0) {
+		return "$"
+	}
+
+	let key = ""
+	for (const segment of segments) {
+		if (typeof segment === "number") {
+			key += `[${segment}]`
+			continue
+		}
+
+		key = key.length === 0 ? segment : `${key}.${segment}`
+	}
+
+	return key
+}
+
+function collectLeafOriginsForValue(
+	value: unknown,
+	origin: OpencodeLeafOrigin,
+	pathSegments: OpencodePathSegment[],
+	origins: Map<string, OpencodeLeafOrigin>,
+): void {
+	if (value === undefined) {
+		return
+	}
+
+	if (isPlainObject(value)) {
+		for (const [key, nestedValue] of Object.entries(value)) {
+			collectLeafOriginsForValue(nestedValue, origin, [...pathSegments, key], origins)
+		}
+		return
+	}
+
+	if (Array.isArray(value)) {
+		for (const [index, nestedValue] of value.entries()) {
+			collectLeafOriginsForValue(nestedValue, origin, [...pathSegments, index], origins)
+		}
+		return
+	}
+
+	origins.set(pathSegmentsToKey(pathSegments), origin)
+}
+
+function mergeInstructionArrayOrigins(
+	profileValues: string[],
+	localValues: string[],
+	pathSegments: OpencodePathSegment[],
+	origins: Map<string, OpencodeLeafOrigin>,
+): void {
+	const mergedValues = Array.from(new Set([...profileValues, ...localValues]))
+	const firstOwnerByValue = new Map<string, OpencodeLeafOrigin>()
+
+	for (const value of profileValues) {
+		if (!firstOwnerByValue.has(value)) {
+			firstOwnerByValue.set(value, "profile")
+		}
+	}
+
+	for (const value of localValues) {
+		if (!firstOwnerByValue.has(value)) {
+			firstOwnerByValue.set(value, "local")
+		}
+	}
+
+	for (const [index, value] of mergedValues.entries()) {
+		origins.set(
+			pathSegmentsToKey([...pathSegments, index]),
+			firstOwnerByValue.get(value) ?? "local",
+		)
+	}
+}
+
+function mergePluginArrayOrigins(
+	profileValues: string[],
+	localValues: string[],
+	pathSegments: OpencodePathSegment[],
+	origins: Map<string, OpencodeLeafOrigin>,
+): void {
+	const combined = [...profileValues, ...localValues]
+	const mergedValues = dedupePluginsByCanonicalName(combined)
+	const lastOwnerByCanonical = new Map<string, OpencodeLeafOrigin>()
+
+	for (let index = combined.length - 1; index >= 0; index--) {
+		const pluginSpecifier = combined[index]
+		if (!pluginSpecifier) {
+			continue
+		}
+
+		const canonicalName = extractCanonicalPluginName(pluginSpecifier)
+		if (!lastOwnerByCanonical.has(canonicalName)) {
+			lastOwnerByCanonical.set(canonicalName, index < profileValues.length ? "profile" : "local")
+		}
+	}
+
+	for (const [index, pluginSpecifier] of mergedValues.entries()) {
+		const canonicalName = extractCanonicalPluginName(pluginSpecifier)
+		origins.set(
+			pathSegmentsToKey([...pathSegments, index]),
+			lastOwnerByCanonical.get(canonicalName) ?? "local",
+		)
+	}
+}
+
+function isTopLevelOpencodeArrayPath(
+	pathSegments: OpencodePathSegment[],
+	expectedKey: "instructions" | "plugin",
+): boolean {
+	return pathSegments.length === 1 && pathSegments[0] === expectedKey
+}
+
+function mergeLeafOriginsAtPath(args: {
+	profileValue: unknown
+	localValue: unknown
+	pathSegments: OpencodePathSegment[]
+	origins: Map<string, OpencodeLeafOrigin>
+}): void {
+	const { profileValue, localValue, pathSegments, origins } = args
+
+	if (localValue === undefined) {
+		collectLeafOriginsForValue(profileValue, "profile", pathSegments, origins)
+		return
+	}
+
+	if (profileValue === undefined) {
+		collectLeafOriginsForValue(localValue, "local", pathSegments, origins)
+		return
+	}
+
+	if (isPlainObject(profileValue) && isPlainObject(localValue)) {
+		const keys = new Set([...Object.keys(profileValue), ...Object.keys(localValue)])
+		for (const key of keys) {
+			mergeLeafOriginsAtPath({
+				profileValue: profileValue[key],
+				localValue: localValue[key],
+				pathSegments: [...pathSegments, key],
+				origins,
+			})
+		}
+		return
+	}
+
+	if (Array.isArray(profileValue) && Array.isArray(localValue)) {
+		if (isTopLevelOpencodeArrayPath(pathSegments, "instructions")) {
+			if (
+				profileValue.every((value) => typeof value === "string") &&
+				localValue.every((value) => typeof value === "string")
+			) {
+				mergeInstructionArrayOrigins(profileValue, localValue, pathSegments, origins)
+				return
+			}
+		}
+
+		if (isTopLevelOpencodeArrayPath(pathSegments, "plugin")) {
+			if (
+				profileValue.every((value) => typeof value === "string") &&
+				localValue.every((value) => typeof value === "string")
+			) {
+				mergePluginArrayOrigins(profileValue, localValue, pathSegments, origins)
+				return
+			}
+		}
+	}
+
+	collectLeafOriginsForValue(localValue, "local", pathSegments, origins)
+}
+
+function buildMergedLeafOriginsForOpencodeConfig(args: {
+	profileConfig: Record<string, unknown>
+	localConfig: Record<string, unknown>
+}): Map<string, OpencodeLeafOrigin> {
+	const origins = new Map<string, OpencodeLeafOrigin>()
+
+	mergeLeafOriginsAtPath({
+		profileValue: args.profileConfig,
+		localValue: args.localConfig,
+		pathSegments: [],
+		origins,
+	})
+
+	return origins
+}
+
+function parseFileTokenReference(value: string): string | null {
+	if (!value.startsWith("{file:")) {
+		return null
+	}
+
+	if (!value.endsWith("}")) {
+		return null
+	}
+
+	const tokenPath = value.slice("{file:".length, -1)
+	return tokenPath.length > 0 ? tokenPath : null
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+	return /^[A-Za-z]:[\\/]/.test(value)
+}
+
+function isRelativeFileTokenPath(value: string): boolean {
+	if (value.startsWith("~")) {
+		return false
+	}
+
+	if (path.isAbsolute(value)) {
+		return false
+	}
+
+	if (isWindowsAbsolutePath(value)) {
+		return false
+	}
+
+	return true
+}
+
+function rewriteProfileRelativeFileTokenAtLeaf(args: {
+	value: string
+	pathSegments: OpencodePathSegment[]
+	origins: Map<string, OpencodeLeafOrigin>
+	profileDir: string
+}): string {
+	const tokenPath = parseFileTokenReference(args.value)
+	if (!tokenPath) {
+		return args.value
+	}
+
+	const leafPath = pathSegmentsToKey(args.pathSegments)
+	if (args.origins.get(leafPath) !== "profile") {
+		return args.value
+	}
+
+	if (!isRelativeFileTokenPath(tokenPath)) {
+		return args.value
+	}
+
+	return `{file:${path.resolve(args.profileDir, tokenPath)}}`
+}
+
+function rewriteProfileRelativeFileTokensInValue(args: {
+	value: unknown
+	pathSegments: OpencodePathSegment[]
+	origins: Map<string, OpencodeLeafOrigin>
+	profileDir: string
+}): unknown {
+	const { value, pathSegments, origins, profileDir } = args
+
+	if (typeof value === "string") {
+		return rewriteProfileRelativeFileTokenAtLeaf({
+			value,
+			pathSegments,
+			origins,
+			profileDir,
+		})
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item, index) =>
+			rewriteProfileRelativeFileTokensInValue({
+				value: item,
+				pathSegments: [...pathSegments, index],
+				origins,
+				profileDir,
+			}),
+		)
+	}
+
+	if (isPlainObject(value)) {
+		const rewritten: Record<string, unknown> = {}
+		for (const [key, nestedValue] of Object.entries(value)) {
+			rewritten[key] = rewriteProfileRelativeFileTokensInValue({
+				value: nestedValue,
+				pathSegments: [...pathSegments, key],
+				origins,
+				profileDir,
+			})
+		}
+		return rewritten
+	}
+
+	return value
+}
+
+async function loadLocalOpencodeConfigForProfileRewrite(
+	projectDir: string,
+): Promise<Record<string, unknown>> {
+	const localConfigDir = findLocalConfigDir(projectDir)
+	if (!localConfigDir) {
+		return {}
+	}
+
+	const localOpencodePath = path.join(localConfigDir, OPENCODE_CONFIG_FILE)
+	const localOpencodeFile = Bun.file(localOpencodePath)
+	if (!(await localOpencodeFile.exists())) {
+		return {}
+	}
+
+	let text: string
+	try {
+		text = await localOpencodeFile.text()
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : "Unknown read error"
+		throw new ConfigError(`Failed to read local OpenCode config at ${localOpencodePath}: ${reason}`)
+	}
+
+	const parseErrors: ParseError[] = []
+	const parsed = parseJsonc(text, parseErrors, { allowTrailingComma: true })
+	if (parseErrors.length > 0) {
+		const errorDetail = formatJsoncParseError(parseErrors)
+		throw new ConfigError(
+			`Invalid JSONC in local OpenCode config at ${localOpencodePath}: ${errorDetail}`,
+		)
+	}
+
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new ConfigError(
+			`Invalid local OpenCode config at ${localOpencodePath}: root must be an object`,
+		)
+	}
+
+	return parsed as Record<string, unknown>
+}
+
+async function rewriteProfileRelativeFileTokensInMergedConfig(args: {
+	mergedConfig: Record<string, unknown>
+	profileConfig: Record<string, unknown>
+	projectDir: string
+	profileDir: string
+}): Promise<Record<string, unknown>> {
+	const localConfig = await loadLocalOpencodeConfigForProfileRewrite(args.projectDir)
+	const leafOrigins = buildMergedLeafOriginsForOpencodeConfig({
+		profileConfig: args.profileConfig,
+		localConfig,
+	})
+
+	return rewriteProfileRelativeFileTokensInValue({
+		value: args.mergedConfig,
+		pathSegments: [],
+		origins: leafOrigins,
+		profileDir: args.profileDir,
+	}) as Record<string, unknown>
 }
 
 /**
@@ -246,19 +618,29 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 	}
 
 	// Build the config to pass to OpenCode
+	let opencodeConfigForLaunch = config.opencode
+	if (config.profileName) {
+		opencodeConfigForLaunch = await rewriteProfileRelativeFileTokensInMergedConfig({
+			mergedConfig: config.opencode,
+			profileConfig: profile?.opencode ?? {},
+			projectDir,
+			profileDir: getProfileDir(config.profileName),
+		})
+	}
+
 	// Merge discovered instructions with user-configured instructions
 	// Order: discovered/global/profile/registry/project first, then user config instructions last (highest priority)
-	const userInstructions = Array.isArray(config.opencode.instructions)
-		? config.opencode.instructions
+	const userInstructions = Array.isArray(opencodeConfigForLaunch.instructions)
+		? opencodeConfigForLaunch.instructions
 		: []
 	const allInstructions = [...config.instructions, ...userInstructions]
 	// Deduplicate while preserving last occurrence (last-wins)
 	const dedupedInstructions = dedupeLastWins(allInstructions)
 
 	const configToPass =
-		dedupedInstructions.length > 0 || Object.keys(config.opencode).length > 0
+		dedupedInstructions.length > 0 || Object.keys(opencodeConfigForLaunch).length > 0
 			? {
-					...config.opencode,
+					...opencodeConfigForLaunch,
 					instructions: dedupedInstructions.length > 0 ? dedupedInstructions : undefined,
 				}
 			: undefined

--- a/packages/cli/tests/opencode-overlay.test.ts
+++ b/packages/cli/tests/opencode-overlay.test.ts
@@ -29,6 +29,12 @@ interface OpencodeCapturePayload {
 	fileContents: Record<string, string>
 }
 
+interface PromptCapturePayload {
+	promptToken: string | null
+	resolvedPromptPath: string | null
+	promptContent: string | null
+}
+
 async function createProfile(testDir: string, name: string): Promise<string> {
 	const profileDir = join(testDir, "opencode", "profiles", name)
 	await mkdir(profileDir, { recursive: true })
@@ -125,6 +131,70 @@ async function runOcCapture(args: {
 async function readCapturePayload(payloadPath: string): Promise<OpencodeCapturePayload> {
 	const text = await readFile(payloadPath, "utf8")
 	return JSON.parse(text) as OpencodeCapturePayload
+}
+
+async function createPromptCaptureScript(testDir: string): Promise<string> {
+	const scriptPath = join(testDir, "capture-prompt.ts")
+
+	await Bun.write(
+		scriptPath,
+		[
+			'import { readFileSync } from "node:fs"',
+			'import { isAbsolute, resolve } from "node:path"',
+			"",
+			"const outputPath = process.env.OCX_CAPTURE_OUTPUT_PATH",
+			"if (!outputPath) {",
+			'  throw new Error("OCX_CAPTURE_OUTPUT_PATH is required")',
+			"}",
+			"",
+			"const configContent = process.env.OPENCODE_CONFIG_CONTENT ?? '{}'",
+			"const parsed = JSON.parse(configContent)",
+			"const promptToken = parsed?.agent?.planner?.prompt",
+			"",
+			"let resolvedPromptPath = null",
+			"let promptContent = null",
+			"",
+			"if (typeof promptToken === 'string' && promptToken.startsWith('{file:') && promptToken.endsWith('}')) {",
+			"  const tokenPath = promptToken.slice('{file:'.length, -1)",
+			"  resolvedPromptPath = isAbsolute(tokenPath) ? tokenPath : resolve(process.cwd(), tokenPath)",
+			"  promptContent = readFileSync(resolvedPromptPath, 'utf8')",
+			"}",
+			"",
+			"await Bun.write(",
+			"  outputPath,",
+			"  JSON.stringify({ promptToken, resolvedPromptPath, promptContent }, null, 2),",
+			")",
+		].join("\n"),
+	)
+
+	return scriptPath
+}
+
+async function runOcPromptCapture(args: {
+	testDir: string
+	profileName?: string
+	env?: Record<string, string | undefined>
+}): Promise<{ result: Awaited<ReturnType<typeof runCLIIsolated>>; payloadPath: string }> {
+	const scriptPath = await createPromptCaptureScript(args.testDir)
+	const payloadPath = join(args.testDir, "oc-prompt-capture.json")
+
+	const profileArgs = args.profileName ? ["--profile", args.profileName] : []
+	const result = await runCLIIsolated(
+		["oc", "--no-rename", ...profileArgs, scriptPath],
+		args.testDir,
+		{
+			OPENCODE_BIN: "bun",
+			OCX_CAPTURE_OUTPUT_PATH: payloadPath,
+			...args.env,
+		},
+	)
+
+	return { result, payloadPath }
+}
+
+async function readPromptCapturePayload(payloadPath: string): Promise<PromptCapturePayload> {
+	const text = await readFile(payloadPath, "utf8")
+	return JSON.parse(text) as PromptCapturePayload
 }
 
 async function listMergedDirs(tmpRoot: string): Promise<string[]> {
@@ -908,6 +978,80 @@ describe("ocx oc profile overlay integration", () => {
 
 			const payload = await readCapturePayload(payloadPath)
 			expect(payload.fileContents["agents/shared.md"]).toBe("from-project")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("resolves planner prompt from profile-owned relative file token when project has same relative path", async () => {
+		const testDir = await createTempDir("oc-overlay-profile-prompt-token")
+		try {
+			const profileDir = await createProfile(testDir, "work")
+			await mkdir(join(profileDir, "prompts"), { recursive: true })
+			await Bun.write(join(profileDir, "prompts", "planner.md"), "profile prompt")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							prompt: "{file:./prompts/planner.md}",
+						},
+					},
+				}),
+			)
+
+			await mkdir(join(testDir, "prompts"), { recursive: true })
+			await Bun.write(join(testDir, "prompts", "planner.md"), "project prompt")
+
+			const { result, payloadPath } = await runOcPromptCapture({
+				testDir,
+				profileName: "work",
+			})
+			expect(result.exitCode).toBe(0)
+
+			const payload = await readPromptCapturePayload(payloadPath)
+			expect(payload.promptContent).toBe("profile prompt")
+			expect(payload.promptToken).toBe(`{file:${join(profileDir, "prompts", "planner.md")}}`)
+			expect(payload.resolvedPromptPath).toBe(join(profileDir, "prompts", "planner.md"))
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("preserves missing-target failure behavior after profile token rewrite", async () => {
+		const testDir = await createTempDir("oc-overlay-profile-prompt-token-missing")
+		try {
+			const profileDir = await createProfile(testDir, "work")
+			const tmpRoot = join(testDir, "tmp")
+			await mkdir(tmpRoot, { recursive: true })
+
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							prompt: "{file:./prompts/missing-planner.md}",
+						},
+					},
+				}),
+			)
+
+			await mkdir(join(testDir, "prompts"), { recursive: true })
+			await Bun.write(join(testDir, "prompts", "missing-planner.md"), "project fallback")
+
+			const { result } = await runOcPromptCapture({
+				testDir,
+				profileName: "work",
+				env: {
+					TMPDIR: tmpRoot,
+				},
+			})
+			expect(result.exitCode).not.toBe(0)
+			expect(result.output).toContain(join(profileDir, "prompts", "missing-planner.md"))
+			expect(result.output).not.toContain(join(testDir, "prompts", "missing-planner.md"))
+
+			const leftovers = await listMergedDirs(tmpRoot)
+			expect(leftovers).toEqual([])
 		} finally {
 			await cleanupTempDir(testDir)
 		}

--- a/packages/cli/tests/opencode.test.ts
+++ b/packages/cli/tests/opencode.test.ts
@@ -17,6 +17,31 @@ async function createProfile(testDir: string, name: string): Promise<void> {
 	await Bun.write(join(profileDir, "ocx.jsonc"), "{}")
 }
 
+async function createConfigContentCaptureScript(testDir: string): Promise<{
+	scriptPath: string
+	outputPath: string
+}> {
+	const scriptPath = join(testDir, "capture-config-content.ts")
+	const outputPath = join(testDir, "captured-config-content.json")
+
+	await Bun.write(
+		scriptPath,
+		[
+			"const outputPath = process.argv[2]",
+			"if (!outputPath) {",
+			'  throw new Error("missing output path")',
+			"}",
+			"const payload = {",
+			"  configContent: process.env.OPENCODE_CONFIG_CONTENT ?? null,",
+			"  configDir: process.env.OPENCODE_CONFIG_DIR ?? null,",
+			"}",
+			"await Bun.write(outputPath, JSON.stringify(payload, null, 2))",
+		].join("\n"),
+	)
+
+	return { scriptPath, outputPath }
+}
+
 describe("dedupeLastWins", () => {
 	it("preserves last occurrence when duplicates exist", () => {
 		const result = dedupeLastWins(["a", "b", "a", "c"])
@@ -708,6 +733,344 @@ describe("oc command CLI contract", () => {
 			expect(captured.opencodeBin).toBe(expectedOpencodeBin)
 			expect(captured.opencodeBin).not.toBe("false")
 			expect(captured.ocxBin).toBe(join(import.meta.dir, "..", "src", "index.ts"))
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("rewrites profile-owned relative {file:...} tokens to absolute profile paths in OPENCODE_CONFIG_CONTENT (regression #175)", async () => {
+		const testDir = await createTempDir("oc-profile-relative-file-token-rewrite")
+		try {
+			await createProfile(testDir, "work")
+
+			const profileDir = join(testDir, "opencode", "profiles", "work")
+			await mkdir(join(profileDir, "prompts"), { recursive: true })
+			await Bun.write(join(profileDir, "prompts", "planner.md"), "profile planner")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							prompt: "{file:./prompts/planner.md}",
+						},
+					},
+				}),
+			)
+
+			await mkdir(join(testDir, "prompts"), { recursive: true })
+			await Bun.write(join(testDir, "prompts", "planner.md"), "project planner")
+
+			const { scriptPath, outputPath } = await createConfigContentCaptureScript(testDir)
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", scriptPath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const payloadText = await Bun.file(outputPath).text()
+			const payload = JSON.parse(payloadText) as {
+				configContent: string | null
+			}
+			expect(payload.configContent).not.toBeNull()
+
+			const parsedConfig = JSON.parse(payload.configContent as string) as {
+				agent?: { planner?: { prompt?: string } }
+			}
+			const plannerPrompt = parsedConfig.agent?.planner?.prompt
+			expect(plannerPrompt).toBe(`{file:${join(profileDir, "prompts", "planner.md")}}`)
+			expect(plannerPrompt).not.toBe("{file:./prompts/planner.md}")
+			expect(plannerPrompt).not.toContain(join(testDir, "prompts", "planner.md"))
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("rewrites only profile-owned relative file tokens per nested leaf path", async () => {
+		const testDir = await createTempDir("oc-profile-relative-file-token-nested-origins")
+		try {
+			await createProfile(testDir, "work")
+
+			const profileDir = join(testDir, "opencode", "profiles", "work")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							prompt: "{file:./prompts/profile-planner.md}",
+						},
+						researcher: {
+							prompt: "{file:./prompts/profile-researcher.md}",
+						},
+						reviewer: {
+							absolutePrompt: "{file:/tmp/absolute-prompt.md}",
+							tildePrompt: "{file:~/prompt.md}",
+							nonFileToken: "prefix {file:./prompts/not-a-token.md}",
+							numericValue: 7,
+						},
+					},
+					settings: {
+						enabled: true,
+					},
+				}),
+			)
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(localConfigDir, { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						researcher: {
+							prompt: "{file:./prompts/project-researcher.md}",
+						},
+						reviewer: {
+							localPrompt: "{file:./prompts/project-reviewer.md}",
+						},
+					},
+				}),
+			)
+
+			const { scriptPath, outputPath } = await createConfigContentCaptureScript(testDir)
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", scriptPath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const payload = JSON.parse(await Bun.file(outputPath).text()) as {
+				configContent: string | null
+			}
+			const parsedConfig = JSON.parse(payload.configContent as string) as {
+				agent?: {
+					planner?: { prompt?: string }
+					researcher?: { prompt?: string }
+					reviewer?: {
+						absolutePrompt?: string
+						tildePrompt?: string
+						nonFileToken?: string
+						localPrompt?: string
+						numericValue?: unknown
+					}
+				}
+				settings?: { enabled?: unknown }
+			}
+
+			expect(parsedConfig.agent?.planner?.prompt).toBe(
+				`{file:${join(profileDir, "prompts", "profile-planner.md")}}`,
+			)
+			expect(parsedConfig.agent?.researcher?.prompt).toBe("{file:./prompts/project-researcher.md}")
+			expect(parsedConfig.agent?.reviewer?.localPrompt).toBe("{file:./prompts/project-reviewer.md}")
+			expect(parsedConfig.agent?.reviewer?.absolutePrompt).toBe("{file:/tmp/absolute-prompt.md}")
+			expect(parsedConfig.agent?.reviewer?.tildePrompt).toBe("{file:~/prompt.md}")
+			expect(parsedConfig.agent?.reviewer?.nonFileToken).toBe(
+				"prefix {file:./prompts/not-a-token.md}",
+			)
+			expect(parsedConfig.agent?.reviewer?.numericValue).toBe(7)
+			expect(parsedConfig.settings?.enabled).toBe(true)
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("tracks top-level instructions array ownership with merge+dedupe semantics", async () => {
+		const testDir = await createTempDir("oc-profile-relative-file-token-top-level-instructions")
+		try {
+			await createProfile(testDir, "work")
+
+			const profileDir = join(testDir, "opencode", "profiles", "work")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					instructions: ["{file:./prompts/profile-only.md}", "{file:./prompts/shared.md}"],
+				}),
+			)
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(localConfigDir, { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "opencode.jsonc"),
+				JSON.stringify({
+					instructions: ["{file:./prompts/shared.md}", "{file:./prompts/local-only.md}"],
+				}),
+			)
+
+			const { scriptPath, outputPath } = await createConfigContentCaptureScript(testDir)
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", scriptPath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const payload = JSON.parse(await Bun.file(outputPath).text()) as {
+				configContent: string | null
+			}
+			const parsedConfig = JSON.parse(payload.configContent as string) as {
+				instructions?: string[]
+			}
+			const promptInstructions = (parsedConfig.instructions ?? []).filter((instruction) =>
+				instruction.includes("prompts/"),
+			)
+			expect(promptInstructions).toEqual([
+				`{file:${join(profileDir, "prompts", "profile-only.md")}}`,
+				`{file:${join(profileDir, "prompts", "shared.md")}}`,
+				"{file:./prompts/local-only.md}",
+			])
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("tracks top-level plugin canonical dedupe ownership without rewriting local winners", async () => {
+		const testDir = await createTempDir("oc-profile-relative-file-token-top-level-plugin")
+		try {
+			await createProfile(testDir, "work")
+
+			const profileDir = join(testDir, "opencode", "profiles", "work")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					plugin: [
+						"npm:@scope/tool@1.0.0",
+						"{file:./prompts/profile-plugin-token.md}",
+						"npm:keep-profile",
+					],
+				}),
+			)
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(localConfigDir, { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "opencode.jsonc"),
+				JSON.stringify({
+					plugin: ["npm:@scope/tool@2.0.0", "{file:./prompts/local-plugin-token.md}"],
+				}),
+			)
+
+			const { scriptPath, outputPath } = await createConfigContentCaptureScript(testDir)
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", scriptPath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const payload = JSON.parse(await Bun.file(outputPath).text()) as {
+				configContent: string | null
+			}
+			const parsedConfig = JSON.parse(payload.configContent as string) as {
+				plugin?: string[]
+			}
+			expect(parsedConfig.plugin).toEqual([
+				`{file:${join(profileDir, "prompts", "profile-plugin-token.md")}}`,
+				"npm:keep-profile",
+				"npm:@scope/tool@2.0.0",
+				"{file:./prompts/local-plugin-token.md}",
+			])
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("does not apply top-level instructions ownership rules to nested non-special arrays", async () => {
+		const testDir = await createTempDir("oc-profile-relative-file-token-nested-array-replace")
+		try {
+			await createProfile(testDir, "work")
+
+			const profileDir = join(testDir, "opencode", "profiles", "work")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							options: {
+								instructions: ["{file:./prompts/profile-nested.md}"],
+							},
+						},
+					},
+				}),
+			)
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(localConfigDir, { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							options: {
+								instructions: ["{file:./prompts/local-nested.md}"],
+							},
+						},
+					},
+				}),
+			)
+
+			const { scriptPath, outputPath } = await createConfigContentCaptureScript(testDir)
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", scriptPath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const payload = JSON.parse(await Bun.file(outputPath).text()) as {
+				configContent: string | null
+			}
+			const parsedConfig = JSON.parse(payload.configContent as string) as {
+				agent?: { planner?: { options?: { instructions?: string[] } } }
+			}
+
+			expect(parsedConfig.agent?.planner?.options?.instructions).toEqual([
+				"{file:./prompts/local-nested.md}",
+			])
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("keeps rewritten missing profile targets unresolved for upstream error handling", async () => {
+		const testDir = await createTempDir("oc-profile-relative-file-token-missing-target")
+		try {
+			await createProfile(testDir, "work")
+
+			const profileDir = join(testDir, "opencode", "profiles", "work")
+			await Bun.write(
+				join(profileDir, "opencode.jsonc"),
+				JSON.stringify({
+					agent: {
+						planner: {
+							prompt: "{file:./prompts/missing-planner.md}",
+						},
+					},
+				}),
+			)
+
+			const { scriptPath, outputPath } = await createConfigContentCaptureScript(testDir)
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", scriptPath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const payload = JSON.parse(await Bun.file(outputPath).text()) as {
+				configContent: string | null
+			}
+			const parsedConfig = JSON.parse(payload.configContent as string) as {
+				agent?: { planner?: { prompt?: string } }
+			}
+			expect(parsedConfig.agent?.planner?.prompt).toBe(
+				`{file:${join(profileDir, "prompts", "missing-planner.md")}}`,
+			)
 		} finally {
 			await cleanupTempDir(testDir)
 		}

--- a/packages/cli/tests/opencode.test.ts
+++ b/packages/cli/tests/opencode.test.ts
@@ -914,7 +914,7 @@ describe("oc command CLI contract", () => {
 				instructions?: string[]
 			}
 			const promptInstructions = (parsedConfig.instructions ?? []).filter((instruction) =>
-				instruction.includes("prompts/"),
+				instruction.replaceAll("\\", "/").includes("prompts/"),
 			)
 			expect(promptInstructions).toEqual([
 				`{file:${join(profileDir, "prompts", "profile-only.md")}}`,


### PR DESCRIPTION
## Summary
- Fixes issue #175 where profile-scoped runs (`ocx oc -p <profile>`) failed to resolve relative `{file:...}` prompt references correctly.
- Updates path resolution in `opencode` to use profile-aware context so relative file tokens resolve from the intended profile scope.
- Includes focused CLI tests in `opencode.test.ts` and `opencode-overlay.test.ts` covering the regression and overlay/profile behavior.

## Testing
- Added/updated automated tests for the profile-scoped `{file:...}` path resolution flow.

## Review Status
- Final implementation state has been reviewer-approved as safe to ship.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes profile-scoped `{file:...}` prompt paths by rewriting relative tokens from the active profile to absolute profile paths before launching OpenCode. Prompts now resolve to the profile directory during `oc --profile` runs (fixes #175).

- **Bug Fixes**
  - Rewrites only profile-owned relative `{file:...}` tokens; leaves absolute paths, `~`, and non-token strings unchanged.
  - Tracks merged config ownership per leaf to avoid cross-rewrites; special handling for top-level `instructions` (merge+dedupe) and `plugin` arrays (canonical dedupe, last-wins).
  - Reads local `.opencode/opencode.jsonc` with JSONC parsing via `jsonc-parser` to determine ownership; surfaces clear errors on invalid JSONC.
  - Preserves missing-target failures and no-profile behavior; adds focused CLI tests covering overlays, token rewrite, and the regression.
  - Normalizes path separators in prompt instruction assertions for cross-platform test stability.

<sup>Written for commit 49954ac92a26674e23cfec6084f7285f5c66c3ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

