### PR TITLE
fix(registry): Harden worktree hook execution with fail-closed safety

### DIFF
--- a/facades/opencode-worktree/README.md
+++ b/facades/opencode-worktree/README.md
@@ -78,8 +78,9 @@ worktree_create:
 When called, this:
 1. Creates git worktree at `~/.local/share/opencode/worktree/<project-id>/feature/dark-mode`
 2. Syncs files based on `.opencode/worktree.jsonc` config
-3. Runs post-create hooks (e.g., `pnpm install`)
-4. Opens a new terminal with OpenCode running
+3. Resolves post-create hook approvals (once / always / reject)
+4. Runs only approved post-create hooks (e.g., `pnpm install`)
+5. Opens a new terminal with OpenCode running
 
 ### Deleting a Worktree
 
@@ -89,10 +90,32 @@ worktree_delete:
 ```
 
 When called, this:
-1. Runs pre-delete hooks (e.g., `docker compose down`)
-2. Commits all changes with snapshot message
-3. Removes git worktree with `--force`
-4. Cleans up session state
+1. Resolves pre-delete hook approvals (once / always / reject)
+2. Stores an approved pre-delete snapshot for this delete request only
+3. Defers pre-delete execution to `session.idle` cleanup
+4. Commits all changes with snapshot message
+5. Removes git worktree with `--force`
+6. Cleans up session state
+
+## Hook Trust & Approval Model
+
+Lifecycle hooks are **approval-gated**. Repository-defined commands are never executed until you explicitly approve the exact parsed command.
+
+- **Exact-text identity:** approvals are keyed by the exact command text loaded from JSONC (including whitespace/newline differences).
+- **Always:** stores durable allow approval for this project + exact command text, then runs.
+- **Once:** runs only for the current invocation and does not persist.
+- **Reject / dismiss / prompt unavailable:** hook is skipped (fail closed).
+
+### Skip Semantics
+
+- Skipped hooks are surfaced in tool output and logged concisely by hash.
+- Raw command text is shown only inside the approval prompt.
+
+### Deferred `preDelete` Safety
+
+`preDelete` runs are deferred until `session.idle`. During `worktree_delete`, the plugin stores the ordered approved snapshot for that specific delete event.
+
+At cleanup time, hooks run **only** when the current `preDelete` config still matches the stored approved snapshot. If config changed, snapshot data is missing, or state reads fail, hooks are skipped and cleanup continues safely.
 
 ## Platform Support
 

--- a/workers/kdco-registry/files/plugins/worktree.ts
+++ b/workers/kdco-registry/files/plugins/worktree.ts
@@ -50,7 +50,6 @@ import {
 	initStateDb,
 	removeSession,
 	setPendingDelete,
-	upsertHookApproval,
 } from "./worktree/state"
 import {
 	createHookApprovalSnapshot,
@@ -58,10 +57,10 @@ import {
 	matchHooksToApprovalSnapshot,
 	parseHookCommands,
 	resolveHookApprovals,
+	summarizeHookResolutionSkips,
 	shortCommandHash,
 	type HookResolution,
 	type ParsedHookCommand,
-	type HookType,
 } from "./worktree/hooks"
 import { openTerminal, type TerminalResult } from "./worktree/terminal"
 
@@ -819,28 +818,6 @@ async function runHooks(cwd: string, hooks: ParsedHookCommand[], log: Logger): P
 	}
 }
 
-function summarizeHookResolutionSkips(hookType: HookType, resolutions: HookResolution[]): string[] {
-	const skippedResolutions = resolutions.filter(
-		(resolution) => resolution.outcome === "skip" || resolution.outcome === "error-skip",
-	)
-	if (skippedResolutions.length === 0) {
-		return []
-	}
-
-	const skippedHashes = skippedResolutions
-		.map((resolution) => shortCommandHash(resolution.hook.commandHash))
-		.join(", ")
-	const hasErrorSkip = skippedResolutions.some((resolution) => resolution.outcome === "error-skip")
-	const reasonText = hasErrorSkip
-		? "approval unavailable or storage error"
-		: "approval rejected or dismissed"
-
-	return [
-		`⚠️ Skipped ${skippedResolutions.length} ${hookType} hook${skippedResolutions.length === 1 ? "" : "s"} (${reasonText}).`,
-		`   Hook hashes: ${skippedHashes}`,
-	]
-}
-
 async function resolveHooksForInvocation(
 	database: Database,
 	hooks: ParsedHookCommand[],
@@ -859,21 +836,6 @@ async function resolveHooksForInvocation(
 			}
 
 			return { ok: true, approved: approvalResult.value !== null }
-		},
-		writeDurableApproval: async (hook) => {
-			const writeResult = upsertHookApproval(database, {
-				hookType: hook.hookType,
-				commandHash: hook.commandHash,
-				commandText: hook.commandText,
-			})
-			if (!writeResult.ok) {
-				log.warn(
-					`[worktree] Hook approval persistence failed for ${hook.hookType}:${shortCommandHash(hook.commandHash)}: ${writeResult.error.message}`,
-				)
-				return { ok: false, error: writeResult.error.message }
-			}
-
-			return { ok: true }
 		},
 	})
 

--- a/workers/kdco-registry/files/plugins/worktree.ts
+++ b/workers/kdco-registry/files/plugins/worktree.ts
@@ -16,7 +16,7 @@ import { constants as fsConstants } from "node:fs"
 import { access, copyFile, cp, mkdir, rm, stat, symlink } from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
-import { type Plugin, tool } from "@opencode-ai/plugin"
+import { type Plugin, type ToolContext, tool } from "@opencode-ai/plugin"
 import type { Event } from "@opencode-ai/sdk"
 import type { OpencodeClient } from "./kdco-primitives/types"
 
@@ -42,13 +42,27 @@ import {
 import {
 	addSession,
 	clearPendingDelete,
+	getHookApproval,
 	getPendingDelete,
+	readPendingDeleteSnapshot,
 	getSession,
 	getWorktreePath,
 	initStateDb,
 	removeSession,
 	setPendingDelete,
+	upsertHookApproval,
 } from "./worktree/state"
+import {
+	createHookApprovalSnapshot,
+	hooksForCurrentInvocation,
+	matchHooksToApprovalSnapshot,
+	parseHookCommands,
+	resolveHookApprovals,
+	shortCommandHash,
+	type HookResolution,
+	type ParsedHookCommand,
+	type HookType,
+} from "./worktree/hooks"
 import { openTerminal, type TerminalResult } from "./worktree/terminal"
 
 /** Maximum retries for database initialization */
@@ -778,26 +792,93 @@ async function symlinkDirs(
 /**
  * Run hook commands in the worktree directory.
  */
-async function runHooks(cwd: string, commands: string[], log: Logger): Promise<void> {
-	for (const command of commands) {
-		log.info(`[worktree] Running hook: ${command}`)
+async function runHooks(cwd: string, hooks: ParsedHookCommand[], log: Logger): Promise<void> {
+	for (const hook of hooks) {
+		const hookRef = `${hook.hookType}:${shortCommandHash(hook.commandHash)}`
+		log.info(`[worktree] Running hook ${hookRef}`)
 		try {
 			// Use shell to properly handle quoted arguments and complex commands
-			const result = Bun.spawnSync(["bash", "-c", command], {
+			const result = Bun.spawnSync(["bash", "-c", hook.commandText], {
 				cwd,
 				stdout: "inherit",
 				stderr: "pipe",
 			})
 			if (result.exitCode !== 0) {
-				const stderr = result.stderr?.toString() || ""
+				const hasStderrOutput = Boolean(result.stderr && result.stderr.byteLength > 0)
 				log.warn(
-					`[worktree] Hook failed (exit ${result.exitCode}): ${command}${stderr ? `\n${stderr}` : ""}`,
+					`[worktree] Hook ${hookRef} failed (exit ${result.exitCode})${hasStderrOutput ? " with stderr output" : ""}`,
 				)
 			}
 		} catch (error) {
-			log.warn(`[worktree] Hook error: ${error}`)
+			log.warn(
+				`[worktree] Hook ${hookRef} execution error${
+					error instanceof Error && error.name ? ` (${error.name})` : ""
+				}`,
+			)
 		}
 	}
+}
+
+function summarizeHookResolutionSkips(hookType: HookType, resolutions: HookResolution[]): string[] {
+	const skippedResolutions = resolutions.filter(
+		(resolution) => resolution.outcome === "skip" || resolution.outcome === "error-skip",
+	)
+	if (skippedResolutions.length === 0) {
+		return []
+	}
+
+	const skippedHashes = skippedResolutions
+		.map((resolution) => shortCommandHash(resolution.hook.commandHash))
+		.join(", ")
+	const hasErrorSkip = skippedResolutions.some((resolution) => resolution.outcome === "error-skip")
+	const reasonText = hasErrorSkip
+		? "approval unavailable or storage error"
+		: "approval rejected or dismissed"
+
+	return [
+		`⚠️ Skipped ${skippedResolutions.length} ${hookType} hook${skippedResolutions.length === 1 ? "" : "s"} (${reasonText}).`,
+		`   Hook hashes: ${skippedHashes}`,
+	]
+}
+
+async function resolveHooksForInvocation(
+	database: Database,
+	hooks: ParsedHookCommand[],
+	toolCtx: ToolContext,
+	log: Logger,
+): Promise<{ resolutions: HookResolution[]; runnableHooks: ParsedHookCommand[] }> {
+	const resolutions = await resolveHookApprovals(hooks, {
+		toolContext: toolCtx,
+		readDurableApproval: async (hook) => {
+			const approvalResult = getHookApproval(database, hook.hookType, hook.commandHash)
+			if (!approvalResult.ok) {
+				log.warn(
+					`[worktree] Hook approval lookup failed for ${hook.hookType}:${shortCommandHash(hook.commandHash)}: ${approvalResult.error.message}`,
+				)
+				return { ok: false, error: approvalResult.error.message }
+			}
+
+			return { ok: true, approved: approvalResult.value !== null }
+		},
+		writeDurableApproval: async (hook) => {
+			const writeResult = upsertHookApproval(database, {
+				hookType: hook.hookType,
+				commandHash: hook.commandHash,
+				commandText: hook.commandText,
+			})
+			if (!writeResult.ok) {
+				log.warn(
+					`[worktree] Hook approval persistence failed for ${hook.hookType}:${shortCommandHash(hook.commandHash)}: ${writeResult.error.message}`,
+				)
+				return { ok: false, error: writeResult.error.message }
+			}
+
+			return { ok: true }
+		},
+	})
+
+	const runnableHooks = hooksForCurrentInvocation(resolutions)
+	return { resolutions, runnableHooks }
 }
 
 /**
@@ -845,11 +926,15 @@ async function loadWorktreeConfig(directory: string, log: Logger): Promise<Workt
   },
 
   "hooks": {
-    // Commands to run after worktree creation
+    // Commands run after worktree creation, but only after explicit approval
+    // Approval identity is exact command text (including whitespace/newlines)
+    // Choosing "always" stores durable approval for this project + exact text
+    // Choosing "once" runs this invocation only and is not persisted
     // Example: ["pnpm install", "docker compose up -d"]
     "postCreate": [],
 
-    // Commands to run before worktree deletion
+    // Commands evaluated during worktree_delete and deferred to session.idle cleanup
+    // Only approved hooks are snapshotted; config edits require re-approval
     // Example: ["docker compose down"]
     "preDelete": []
   }
@@ -967,6 +1052,7 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 					}
 
 					const worktreePath = result.value
+					const hookOutputLines: string[] = []
 
 					// Sync files from main worktree
 					const mainWorktreePath = directory // The repo root is the main worktree
@@ -981,9 +1067,34 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 						await symlinkDirs(mainWorktreePath, worktreePath, worktreeConfig.sync.symlinkDirs, log)
 					}
 
-					// Run postCreate hooks
-					if (worktreeConfig.hooks.postCreate.length > 0) {
-						await runHooks(worktreePath, worktreeConfig.hooks.postCreate, log)
+					// Resolve and run postCreate hooks only when explicitly approved.
+					const parsedPostCreateHooks = parseHookCommands(
+						"postCreate",
+						worktreeConfig.hooks.postCreate,
+					)
+					if (parsedPostCreateHooks.length > 0) {
+						const { resolutions, runnableHooks } = await resolveHooksForInvocation(
+							database,
+							parsedPostCreateHooks,
+							toolCtx,
+							log,
+						)
+
+						for (const resolution of resolutions) {
+							if (resolution.outcome === "run-once" || resolution.outcome === "run-and-persist") {
+								continue
+							}
+
+							log.warn(
+								`[worktree] ${resolution.hook.hookType} hook ${shortCommandHash(resolution.hook.commandHash)} skipped (${resolution.reason})`,
+							)
+						}
+
+						hookOutputLines.push(...summarizeHookResolutionSkips("postCreate", resolutions))
+
+						if (runnableHooks.length > 0) {
+							await runHooks(worktreePath, runnableHooks, log)
+						}
 					}
 
 					// Fork session with context (replaces --session resume)
@@ -1036,7 +1147,13 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 						return `❌ Failed to launch worktree terminal: ${terminalResult.error ?? "unknown error"}\nWorktree created at ${worktreePath}. Verify launch settings and retry.`
 					}
 
-					return `Worktree created at ${worktreePath}\n\nA new terminal has been opened with OpenCode.`
+					const outputLines = [`Worktree created at ${worktreePath}`]
+					if (hookOutputLines.length > 0) {
+						outputLines.push("", ...hookOutputLines)
+					}
+					outputLines.push("", "A new terminal has been opened with OpenCode.")
+
+					return outputLines.join("\n")
 				},
 			}),
 
@@ -1055,10 +1172,55 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 						return `No worktree associated with this session`
 					}
 
-					// Set pending delete for session.idle (atomic operation)
-					setPendingDelete(database, { branch: session.branch, path: session.path }, client)
+					const hookOutputLines: string[] = []
+					const worktreeConfig = await loadWorktreeConfig(directory, log)
+					const parsedPreDeleteHooks = parseHookCommands(
+						"preDelete",
+						worktreeConfig.hooks.preDelete,
+					)
+					let approvedHookSnapshot = createHookApprovalSnapshot([])
 
-					return `Worktree marked for cleanup. It will be removed when this session ends.`
+					if (parsedPreDeleteHooks.length > 0) {
+						const { resolutions, runnableHooks } = await resolveHooksForInvocation(
+							database,
+							parsedPreDeleteHooks,
+							toolCtx,
+							log,
+						)
+
+						for (const resolution of resolutions) {
+							if (resolution.outcome === "run-once" || resolution.outcome === "run-and-persist") {
+								continue
+							}
+
+							log.warn(
+								`[worktree] ${resolution.hook.hookType} hook ${shortCommandHash(resolution.hook.commandHash)} excluded from delete snapshot (${resolution.reason})`,
+							)
+						}
+
+						hookOutputLines.push(...summarizeHookResolutionSkips("preDelete", resolutions))
+						approvedHookSnapshot = createHookApprovalSnapshot(runnableHooks)
+					}
+
+					// Set pending delete for session.idle (atomic operation)
+					setPendingDelete(
+						database,
+						{
+							branch: session.branch,
+							path: session.path,
+							approvedPreDeleteHooks: approvedHookSnapshot,
+						},
+						client,
+					)
+
+					const outputLines = [
+						"Worktree marked for cleanup. It will be removed when this session ends.",
+					]
+					if (hookOutputLines.length > 0) {
+						outputLines.push("", ...hookOutputLines)
+					}
+
+					return outputLines.join("\n")
 				},
 			}),
 		},
@@ -1071,10 +1233,31 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 			if (pendingDelete) {
 				const { path: worktreePath, branch } = pendingDelete
 
-				// Run preDelete hooks before cleanup
+				// Run only the approved preDelete hook snapshot from delete scheduling.
 				const config = await loadWorktreeConfig(directory, log)
-				if (config.hooks.preDelete.length > 0) {
-					await runHooks(worktreePath, config.hooks.preDelete, log)
+				const parsedPreDeleteHooks = parseHookCommands("preDelete", config.hooks.preDelete)
+				const pendingDeleteSnapshotResult = readPendingDeleteSnapshot(database)
+
+				if (!pendingDeleteSnapshotResult.ok) {
+					log.warn(
+						`[worktree] Pending delete hook snapshot read failed; skipping preDelete hooks: ${pendingDeleteSnapshotResult.error.message}`,
+					)
+				} else if (!pendingDeleteSnapshotResult.value) {
+					log.warn(
+						`[worktree] Missing pending delete hook snapshot; skipping ${parsedPreDeleteHooks.length} preDelete hook(s).`,
+					)
+				} else {
+					const snapshotMatch = matchHooksToApprovalSnapshot(
+						parsedPreDeleteHooks,
+						pendingDeleteSnapshotResult.value,
+					)
+					if (!snapshotMatch.ok) {
+						log.warn(
+							`[worktree] Pending delete hook snapshot mismatch (${snapshotMatch.reason}); skipping preDelete hooks.`,
+						)
+					} else if (snapshotMatch.hooks.length > 0) {
+						await runHooks(worktreePath, snapshotMatch.hooks, log)
+					}
 				}
 
 				// Commit any uncommitted changes

--- a/workers/kdco-registry/files/plugins/worktree/hooks.ts
+++ b/workers/kdco-registry/files/plugins/worktree/hooks.ts
@@ -19,16 +19,15 @@ export type HookExecutionOutcome = "run-once" | "run-and-persist" | "skip" | "er
 export interface HookResolution {
 	hook: ParsedHookCommand
 	outcome: HookExecutionOutcome
+	reasonDetail?: string
 	reason:
 		| "durable-approved"
-		| "approved-once"
-		| "approved-always"
+		| "approved-by-permission"
 		| "rejected"
-		| "dismissed"
+		| "permission-denied"
 		| "prompt-unavailable"
 		| "prompt-error"
 		| "storage-read-error"
-		| "storage-write-error"
 }
 
 export interface HookApprovalReadResult {
@@ -43,101 +42,113 @@ export interface HookApprovalReadError {
 
 export type HookApprovalReadOutcome = HookApprovalReadResult | HookApprovalReadError
 
-export interface HookApprovalWriteResult {
-	ok: true
-}
-
-export interface HookApprovalWriteError {
-	ok: false
-	error: string
-}
-
-export type HookApprovalWriteOutcome = HookApprovalWriteResult | HookApprovalWriteError
-
 interface HookApprovalResolverOptions {
 	toolContext: ToolContext
 	readDurableApproval: (hook: ParsedHookCommand) => Promise<HookApprovalReadOutcome>
-	writeDurableApproval: (hook: ParsedHookCommand) => Promise<HookApprovalWriteOutcome>
 }
 
-type HookPromptDecision = "once" | "always" | "reject" | "dismissed" | "unavailable" | "error"
+type HookPromptDecision =
+	| { kind: "approved" }
+	| { kind: "rejected" }
+	| { kind: "denied"; detail?: string }
+	| { kind: "unavailable" }
+	| { kind: "error"; detail?: string }
 
-function toPromptMessage(hook: ParsedHookCommand): string {
-	return [
-		`Approve worktree ${hook.hookType} hook?`,
-		"",
-		"This command is defined in your repository config and will run locally:",
-		"",
-		hook.commandText,
-		"",
-		"Choose: once (run now), always (allow this exact command text for this project), or reject.",
-	].join("\n")
+function approvalPatternForHook(hook: ParsedHookCommand): string {
+	const visibleCommand = JSON.stringify(hook.commandText)
+		.replaceAll("*", "﹡")
+		.replaceAll("?", "﹖")
+	return `hash=${hook.commandHash}; command=${visibleCommand}`
 }
 
-function normalizePromptDecision(value: unknown): HookPromptDecision {
-	if (typeof value === "boolean") {
-		return value ? "once" : "reject"
+function getErrorMessage(error: unknown): string | undefined {
+	if (error instanceof Error && error.message.trim().length > 0) {
+		return error.message.trim()
 	}
 
-	if (typeof value === "string") {
-		const normalized = value.trim().toLowerCase()
-		if (normalized === "once") return "once"
-		if (normalized === "always") return "always"
-		if (normalized === "reject") return "reject"
-		if (normalized === "dismiss" || normalized === "dismissed" || normalized === "cancel") {
-			return "dismissed"
-		}
+	if (typeof error === "string" && error.trim().length > 0) {
+		return error.trim()
 	}
 
-	if (value && typeof value === "object") {
-		const record = value as Record<string, unknown>
-		const candidates = [record.value, record.choice, record.result, record.status, record.action]
-		for (const candidate of candidates) {
-			const normalizedCandidate = normalizePromptDecision(candidate)
-			if (normalizedCandidate !== "dismissed") {
-				return normalizedCandidate
-			}
-		}
+	return undefined
+}
 
-		if (record.dismissed === true || record.cancelled === true || record.canceled === true) {
-			return "dismissed"
-		}
+function getErrorIdentifier(error: unknown): string | undefined {
+	if (!error || typeof error !== "object") {
+		return undefined
 	}
 
-	return "dismissed"
+	if ("name" in error && typeof error.name === "string" && error.name.length > 0) {
+		return error.name
+	}
+
+	if ("_tag" in error && typeof error._tag === "string" && error._tag.length > 0) {
+		return error._tag
+	}
+
+	return undefined
+}
+
+function classifyAskError(error: unknown): HookPromptDecision {
+	const detail = getErrorMessage(error)
+	const identifier = getErrorIdentifier(error)
+	if (identifier === "PermissionRejectedError" || identifier === "PermissionCorrectedError") {
+		return { kind: "rejected" }
+	}
+
+	if (identifier === "PermissionDeniedError") {
+		return { kind: "denied", detail }
+	}
+
+	const loweredDetail = detail?.toLowerCase()
+	if (loweredDetail?.includes("rejected permission")) {
+		return { kind: "rejected" }
+	}
+
+	if (
+		loweredDetail?.includes("permission denied") ||
+		loweredDetail?.includes("prevents you from using this specific tool call")
+	) {
+		return { kind: "denied", detail }
+	}
+
+	return { kind: "error", detail }
 }
 
 async function askForHookApproval(
 	toolContext: ToolContext,
 	hook: ParsedHookCommand,
 ): Promise<HookPromptDecision> {
-	const ask = (toolContext as unknown as { ask?: (prompt: unknown) => Promise<unknown> }).ask
+	const ask = (
+		toolContext as unknown as {
+			ask?: (input: {
+				permission: string
+				patterns: string[]
+				always: string[]
+				metadata: Record<string, unknown>
+			}) => Promise<void>
+		}
+	).ask
 	if (typeof ask !== "function") {
-		return "unavailable"
+		return { kind: "unavailable" }
 	}
 
-	const promptPayload = {
-		type: "approval",
-		title: `Approve ${hook.hookType} hook`,
-		message: toPromptMessage(hook),
-		choices: [
-			{ value: "once", label: "Run once" },
-			{ value: "always", label: "Always run this exact command" },
-			{ value: "reject", label: "Reject" },
-		],
-		default: "reject",
-	}
+	const permissionPattern = approvalPatternForHook(hook)
 
 	try {
-		const response = await ask(promptPayload)
-		return normalizePromptDecision(response)
-	} catch {
-		try {
-			const fallbackResponse = await ask(toPromptMessage(hook))
-			return normalizePromptDecision(fallbackResponse)
-		} catch {
-			return "error"
-		}
+		await ask({
+			permission: `worktree.hook.${hook.hookType}`,
+			patterns: [permissionPattern],
+			always: [permissionPattern],
+			metadata: {
+				hookType: hook.hookType,
+				commandText: hook.commandText,
+				commandHash: hook.commandHash,
+			},
+		})
+		return { kind: "approved" }
+	} catch (error) {
+		return classifyAskError(error)
 	}
 }
 
@@ -160,50 +171,54 @@ export async function resolveHookApprovals(
 	const resolutions: HookResolution[] = []
 
 	for (const hook of parsedHooks) {
-		const durableApproval = await options.readDurableApproval(hook)
-		if (!durableApproval.ok) {
-			resolutions.push({ hook, outcome: "error-skip", reason: "storage-read-error" })
-			continue
-		}
-
-		if (durableApproval.approved) {
-			resolutions.push({ hook, outcome: "run-and-persist", reason: "durable-approved" })
-			continue
-		}
-
 		const promptDecision = await askForHookApproval(options.toolContext, hook)
-		if (promptDecision === "always") {
-			const persistResult = await options.writeDurableApproval(hook)
-			if (!persistResult.ok) {
-				resolutions.push({ hook, outcome: "error-skip", reason: "storage-write-error" })
+		if (promptDecision.kind === "approved") {
+			const durableApproval = await options.readDurableApproval(hook)
+			if (!durableApproval.ok) {
+				resolutions.push({
+					hook,
+					outcome: "error-skip",
+					reason: "storage-read-error",
+					reasonDetail: durableApproval.error,
+				})
 				continue
 			}
 
-			resolutions.push({ hook, outcome: "run-and-persist", reason: "approved-always" })
+			if (durableApproval.approved) {
+				resolutions.push({ hook, outcome: "run-and-persist", reason: "durable-approved" })
+				continue
+			}
+
+			resolutions.push({ hook, outcome: "run-once", reason: "approved-by-permission" })
 			continue
 		}
 
-		if (promptDecision === "once") {
-			resolutions.push({ hook, outcome: "run-once", reason: "approved-once" })
-			continue
-		}
-
-		if (promptDecision === "reject") {
+		if (promptDecision.kind === "rejected") {
 			resolutions.push({ hook, outcome: "skip", reason: "rejected" })
 			continue
 		}
 
-		if (promptDecision === "dismissed") {
-			resolutions.push({ hook, outcome: "skip", reason: "dismissed" })
+		if (promptDecision.kind === "denied") {
+			resolutions.push({
+				hook,
+				outcome: "skip",
+				reason: "permission-denied",
+				reasonDetail: promptDecision.detail,
+			})
 			continue
 		}
 
-		if (promptDecision === "unavailable") {
+		if (promptDecision.kind === "unavailable") {
 			resolutions.push({ hook, outcome: "error-skip", reason: "prompt-unavailable" })
 			continue
 		}
 
-		resolutions.push({ hook, outcome: "error-skip", reason: "prompt-error" })
+		resolutions.push({
+			hook,
+			outcome: "error-skip",
+			reason: "prompt-error",
+			reasonDetail: promptDecision.detail,
+		})
 	}
 
 	return resolutions
@@ -278,4 +293,105 @@ export function matchHooksToApprovalSnapshot(
 
 export function shortCommandHash(commandHash: string): string {
 	return commandHash.slice(0, 12)
+}
+
+function formatHookCommandPreview(commandText: string): string {
+	const firstLine = commandText
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => line.length > 0)
+
+	if (!firstLine) {
+		return "(empty command)"
+	}
+
+	if (firstLine.length <= 96) {
+		return firstLine
+	}
+
+	return `${firstLine.slice(0, 93)}...`
+}
+
+function summarizeReason(resolution: HookResolution): string {
+	if (resolution.reason === "rejected") {
+		return "user rejected approval"
+	}
+
+	if (resolution.reason === "permission-denied") {
+		return "blocked by permission rules"
+	}
+
+	if (resolution.reason === "prompt-unavailable") {
+		return "permission prompt unavailable"
+	}
+
+	if (resolution.reason === "prompt-error") {
+		return "permission request failed"
+	}
+
+	if (resolution.reason === "storage-read-error") {
+		return "approval storage read failed"
+	}
+
+	return resolution.reason
+}
+
+function hookToolName(hookType: HookType): string {
+	return hookType === "postCreate" ? "worktree_create" : "worktree_delete"
+}
+
+export function summarizeHookResolutionSkips(
+	hookType: HookType,
+	resolutions: HookResolution[],
+): string[] {
+	const skippedResolutions = resolutions.filter(
+		(resolution) => resolution.outcome === "skip" || resolution.outcome === "error-skip",
+	)
+	if (skippedResolutions.length === 0) {
+		return []
+	}
+
+	const hasPromptError = skippedResolutions.some(
+		(resolution) =>
+			resolution.reason === "prompt-unavailable" || resolution.reason === "prompt-error",
+	)
+	const hasStorageError = skippedResolutions.some(
+		(resolution) => resolution.reason === "storage-read-error",
+	)
+	const hasPermissionDenied = skippedResolutions.some(
+		(resolution) => resolution.reason === "permission-denied",
+	)
+
+	const lines = [
+		`⚠️ Skipped ${skippedResolutions.length} ${hookType} hook${skippedResolutions.length === 1 ? "" : "s"}.`,
+	]
+
+	if (hasPromptError) {
+		lines.push(
+			`   Approval could not be collected for at least one hook. Re-run ${hookToolName(hookType)} in an interactive session to approve these hooks (once or always).`,
+		)
+	}
+
+	if (hasPermissionDenied) {
+		lines.push(
+			`   At least one hook is blocked by existing permission rules (permission: worktree.hook.${hookType}).`,
+		)
+	}
+
+	if (hasStorageError) {
+		lines.push(
+			"   Local approval storage failed to read durable approvals; hooks stayed blocked for safety.",
+		)
+	}
+
+	for (const resolution of skippedResolutions) {
+		const hookRef = `${resolution.hook.hookType}:${shortCommandHash(resolution.hook.commandHash)}`
+		const commandPreview = formatHookCommandPreview(resolution.hook.commandText)
+		lines.push(`   - ${hookRef} (${summarizeReason(resolution)}): ${commandPreview}`)
+		if (resolution.reasonDetail) {
+			lines.push(`     detail: ${resolution.reasonDetail}`)
+		}
+	}
+
+	return lines
 }

--- a/workers/kdco-registry/files/plugins/worktree/hooks.ts
+++ b/workers/kdco-registry/files/plugins/worktree/hooks.ts
@@ -1,0 +1,281 @@
+import { createHash } from "node:crypto"
+import type { ToolContext } from "@opencode-ai/plugin"
+
+export type HookType = "postCreate" | "preDelete"
+
+export interface ParsedHookCommand {
+	hookType: HookType
+	commandText: string
+	commandHash: string
+}
+
+export interface HookApprovalSnapshot {
+	commandHashes: string[]
+	commandTexts: string[]
+}
+
+export type HookExecutionOutcome = "run-once" | "run-and-persist" | "skip" | "error-skip"
+
+export interface HookResolution {
+	hook: ParsedHookCommand
+	outcome: HookExecutionOutcome
+	reason:
+		| "durable-approved"
+		| "approved-once"
+		| "approved-always"
+		| "rejected"
+		| "dismissed"
+		| "prompt-unavailable"
+		| "prompt-error"
+		| "storage-read-error"
+		| "storage-write-error"
+}
+
+export interface HookApprovalReadResult {
+	ok: true
+	approved: boolean
+}
+
+export interface HookApprovalReadError {
+	ok: false
+	error: string
+}
+
+export type HookApprovalReadOutcome = HookApprovalReadResult | HookApprovalReadError
+
+export interface HookApprovalWriteResult {
+	ok: true
+}
+
+export interface HookApprovalWriteError {
+	ok: false
+	error: string
+}
+
+export type HookApprovalWriteOutcome = HookApprovalWriteResult | HookApprovalWriteError
+
+interface HookApprovalResolverOptions {
+	toolContext: ToolContext
+	readDurableApproval: (hook: ParsedHookCommand) => Promise<HookApprovalReadOutcome>
+	writeDurableApproval: (hook: ParsedHookCommand) => Promise<HookApprovalWriteOutcome>
+}
+
+type HookPromptDecision = "once" | "always" | "reject" | "dismissed" | "unavailable" | "error"
+
+function toPromptMessage(hook: ParsedHookCommand): string {
+	return [
+		`Approve worktree ${hook.hookType} hook?`,
+		"",
+		"This command is defined in your repository config and will run locally:",
+		"",
+		hook.commandText,
+		"",
+		"Choose: once (run now), always (allow this exact command text for this project), or reject.",
+	].join("\n")
+}
+
+function normalizePromptDecision(value: unknown): HookPromptDecision {
+	if (typeof value === "boolean") {
+		return value ? "once" : "reject"
+	}
+
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase()
+		if (normalized === "once") return "once"
+		if (normalized === "always") return "always"
+		if (normalized === "reject") return "reject"
+		if (normalized === "dismiss" || normalized === "dismissed" || normalized === "cancel") {
+			return "dismissed"
+		}
+	}
+
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>
+		const candidates = [record.value, record.choice, record.result, record.status, record.action]
+		for (const candidate of candidates) {
+			const normalizedCandidate = normalizePromptDecision(candidate)
+			if (normalizedCandidate !== "dismissed") {
+				return normalizedCandidate
+			}
+		}
+
+		if (record.dismissed === true || record.cancelled === true || record.canceled === true) {
+			return "dismissed"
+		}
+	}
+
+	return "dismissed"
+}
+
+async function askForHookApproval(
+	toolContext: ToolContext,
+	hook: ParsedHookCommand,
+): Promise<HookPromptDecision> {
+	const ask = (toolContext as unknown as { ask?: (prompt: unknown) => Promise<unknown> }).ask
+	if (typeof ask !== "function") {
+		return "unavailable"
+	}
+
+	const promptPayload = {
+		type: "approval",
+		title: `Approve ${hook.hookType} hook`,
+		message: toPromptMessage(hook),
+		choices: [
+			{ value: "once", label: "Run once" },
+			{ value: "always", label: "Always run this exact command" },
+			{ value: "reject", label: "Reject" },
+		],
+		default: "reject",
+	}
+
+	try {
+		const response = await ask(promptPayload)
+		return normalizePromptDecision(response)
+	} catch {
+		try {
+			const fallbackResponse = await ask(toPromptMessage(hook))
+			return normalizePromptDecision(fallbackResponse)
+		} catch {
+			return "error"
+		}
+	}
+}
+
+export function hashHookCommand(commandText: string): string {
+	return createHash("sha256").update(commandText).digest("hex")
+}
+
+export function parseHookCommands(hookType: HookType, commands: string[]): ParsedHookCommand[] {
+	return commands.map((commandText) => ({
+		hookType,
+		commandText,
+		commandHash: hashHookCommand(commandText),
+	}))
+}
+
+export async function resolveHookApprovals(
+	parsedHooks: ParsedHookCommand[],
+	options: HookApprovalResolverOptions,
+): Promise<HookResolution[]> {
+	const resolutions: HookResolution[] = []
+
+	for (const hook of parsedHooks) {
+		const durableApproval = await options.readDurableApproval(hook)
+		if (!durableApproval.ok) {
+			resolutions.push({ hook, outcome: "error-skip", reason: "storage-read-error" })
+			continue
+		}
+
+		if (durableApproval.approved) {
+			resolutions.push({ hook, outcome: "run-and-persist", reason: "durable-approved" })
+			continue
+		}
+
+		const promptDecision = await askForHookApproval(options.toolContext, hook)
+		if (promptDecision === "always") {
+			const persistResult = await options.writeDurableApproval(hook)
+			if (!persistResult.ok) {
+				resolutions.push({ hook, outcome: "error-skip", reason: "storage-write-error" })
+				continue
+			}
+
+			resolutions.push({ hook, outcome: "run-and-persist", reason: "approved-always" })
+			continue
+		}
+
+		if (promptDecision === "once") {
+			resolutions.push({ hook, outcome: "run-once", reason: "approved-once" })
+			continue
+		}
+
+		if (promptDecision === "reject") {
+			resolutions.push({ hook, outcome: "skip", reason: "rejected" })
+			continue
+		}
+
+		if (promptDecision === "dismissed") {
+			resolutions.push({ hook, outcome: "skip", reason: "dismissed" })
+			continue
+		}
+
+		if (promptDecision === "unavailable") {
+			resolutions.push({ hook, outcome: "error-skip", reason: "prompt-unavailable" })
+			continue
+		}
+
+		resolutions.push({ hook, outcome: "error-skip", reason: "prompt-error" })
+	}
+
+	return resolutions
+}
+
+export function hooksForCurrentInvocation(resolutions: HookResolution[]): ParsedHookCommand[] {
+	return resolutions
+		.filter(
+			(resolution) => resolution.outcome === "run-once" || resolution.outcome === "run-and-persist",
+		)
+		.map((resolution) => resolution.hook)
+}
+
+export function createHookApprovalSnapshot(hooks: ParsedHookCommand[]): HookApprovalSnapshot {
+	return {
+		commandHashes: hooks.map((hook) => hook.commandHash),
+		commandTexts: hooks.map((hook) => hook.commandText),
+	}
+}
+
+function snapshotHasConsistentLengths(snapshot: HookApprovalSnapshot): boolean {
+	return (
+		snapshot.commandTexts.length === 0 ||
+		snapshot.commandTexts.length === snapshot.commandHashes.length
+	)
+}
+
+export function matchHooksToApprovalSnapshot(
+	currentHooks: ParsedHookCommand[],
+	snapshot: HookApprovalSnapshot,
+): { ok: true; hooks: ParsedHookCommand[] } | { ok: false; reason: string } {
+	if (!snapshotHasConsistentLengths(snapshot)) {
+		return { ok: false, reason: "snapshot-length-mismatch" }
+	}
+
+	if (snapshot.commandHashes.length === 0) {
+		return { ok: true, hooks: [] }
+	}
+
+	const matchedHooks: ParsedHookCommand[] = []
+	let currentHookIndex = 0
+
+	for (let snapshotIndex = 0; snapshotIndex < snapshot.commandHashes.length; snapshotIndex++) {
+		const expectedHash = snapshot.commandHashes[snapshotIndex]
+		const expectedText = snapshot.commandTexts[snapshotIndex]
+		let foundMatch = false
+
+		while (currentHookIndex < currentHooks.length) {
+			const candidate = currentHooks[currentHookIndex]
+			currentHookIndex += 1
+
+			if (candidate.commandHash !== expectedHash) {
+				continue
+			}
+
+			if (expectedText !== undefined && candidate.commandText !== expectedText) {
+				continue
+			}
+
+			matchedHooks.push(candidate)
+			foundMatch = true
+			break
+		}
+
+		if (!foundMatch) {
+			return { ok: false, reason: "snapshot-not-found-in-current-config" }
+		}
+	}
+
+	return { ok: true, hooks: matchedHooks }
+}
+
+export function shortCommandHash(commandHash: string): string {
+	return commandHash.slice(0, 12)
+}

--- a/workers/kdco-registry/files/plugins/worktree/state.ts
+++ b/workers/kdco-registry/files/plugins/worktree/state.ts
@@ -49,6 +49,48 @@ export interface PendingSpawn {
 export interface PendingDelete {
 	branch: string
 	path: string
+	approvedPreDeleteHooks?: PendingDeleteHookSnapshot
+}
+
+export type HookType = "postCreate" | "preDelete"
+
+export interface HookApproval {
+	hookType: HookType
+	commandHash: string
+	commandText: string
+	approvedAt: string
+	updatedAt: string
+}
+
+export interface HookApprovalInput {
+	hookType: HookType
+	commandHash: string
+	commandText: string
+}
+
+export interface PendingDeleteHookSnapshot {
+	commandHashes: string[]
+	commandTexts: string[]
+}
+
+interface DbOkResult<T> {
+	ok: true
+	value: T
+}
+
+interface DbErrResult {
+	ok: false
+	error: Error
+}
+
+export type DbResult<T> = DbOkResult<T> | DbErrResult
+
+const DbResult = {
+	ok: <T>(value: T): DbOkResult<T> => ({ ok: true, value }),
+	err: (error: unknown): DbErrResult => ({
+		ok: false,
+		error: error instanceof Error ? error : new Error(String(error)),
+	}),
 }
 
 // =============================================================================
@@ -74,7 +116,39 @@ const pendingSpawnSchema = z.object({
 const pendingDeleteSchema = z.object({
 	branch: z.string().min(1),
 	path: z.string().min(1),
+	approvedPreDeleteHooks: z
+		.object({
+			commandHashes: z.array(z.string().min(1)),
+			commandTexts: z.array(z.string()).default([]),
+		})
+		.refine(
+			(snapshot) =>
+				snapshot.commandTexts.length === 0 ||
+				snapshot.commandTexts.length === snapshot.commandHashes.length,
+			"commandTexts must be empty or match commandHashes length",
+		)
+		.optional(),
 })
+
+const hookTypeSchema = z.enum(["postCreate", "preDelete"])
+
+const hookApprovalSchema = z.object({
+	hookType: hookTypeSchema,
+	commandHash: z.string().min(1),
+	commandText: z.string(),
+})
+
+const pendingDeleteHookSnapshotSchema = z
+	.object({
+		commandHashes: z.array(z.string().min(1)),
+		commandTexts: z.array(z.string()).default([]),
+	})
+	.refine(
+		(snapshot) =>
+			snapshot.commandTexts.length === 0 ||
+			snapshot.commandTexts.length === snapshot.commandHashes.length,
+		"commandTexts must be empty or match commandHashes length",
+	)
 
 // =============================================================================
 // DATABASE UTILITIES
@@ -180,9 +254,14 @@ export async function initStateDb(projectRoot: string): Promise<Database> {
 			type TEXT NOT NULL,
 			branch TEXT NOT NULL,
 			path TEXT NOT NULL,
-			session_id TEXT
+			session_id TEXT,
+			pre_delete_hook_hashes TEXT,
+			pre_delete_hook_texts TEXT
 		)
 	`)
+
+	ensurePendingOperationHookSnapshotColumns(db)
+	ensureHookApprovalsTable(db)
 
 	return db
 }
@@ -216,6 +295,58 @@ function addSessionColumn(db: Database, columnName: string, sql: string): void {
 	}
 }
 
+function ensurePendingOperationHookSnapshotColumns(db: Database): void {
+	const tableInfo = db.prepare("PRAGMA table_info(pending_operations)").all() as Array<{
+		name?: string
+	}>
+	const pendingOperationColumns = new Set(tableInfo.map((column) => column.name).filter(Boolean))
+
+	if (!pendingOperationColumns.has("pre_delete_hook_hashes")) {
+		addPendingOperationColumn(
+			db,
+			"pre_delete_hook_hashes",
+			"ALTER TABLE pending_operations ADD COLUMN pre_delete_hook_hashes TEXT",
+		)
+	}
+
+	if (!pendingOperationColumns.has("pre_delete_hook_texts")) {
+		addPendingOperationColumn(
+			db,
+			"pre_delete_hook_texts",
+			"ALTER TABLE pending_operations ADD COLUMN pre_delete_hook_texts TEXT",
+		)
+	}
+}
+
+function addPendingOperationColumn(db: Database, columnName: string, sql: string): void {
+	try {
+		db.exec(sql)
+	} catch (error) {
+		if (isDuplicateColumnError(error, columnName)) {
+			return
+		}
+
+		console.warn(`[worktree] Pending operation hook migration skipped: ${String(error)}`)
+	}
+}
+
+function ensureHookApprovalsTable(db: Database): void {
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS hook_approvals (
+				hook_type TEXT NOT NULL,
+				command_hash TEXT NOT NULL,
+				command_text TEXT NOT NULL,
+				approved_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (hook_type, command_hash)
+			)
+		`)
+	} catch (error) {
+		console.warn(`[worktree] Hook approval table migration skipped: ${String(error)}`)
+	}
+}
+
 function isDuplicateColumnError(error: unknown, columnName: string): boolean {
 	if (!(error instanceof Error)) {
 		return false
@@ -245,6 +376,84 @@ function normalizeSessionRow(row: Record<string, string | null>): Session {
 		profile: serialized.profile,
 		ocxBin: serialized.ocxBin,
 	}
+}
+
+function serializePendingDeleteHookSnapshot(snapshot?: PendingDeleteHookSnapshot): {
+	hashes: string | null
+	texts: string | null
+} {
+	if (!snapshot) {
+		return { hashes: null, texts: null }
+	}
+
+	const parsedSnapshot = pendingDeleteHookSnapshotSchema.parse(snapshot)
+	const commandTexts =
+		parsedSnapshot.commandTexts.length === parsedSnapshot.commandHashes.length
+			? parsedSnapshot.commandTexts
+			: Array.from({ length: parsedSnapshot.commandHashes.length }, () => "")
+
+	return {
+		hashes: JSON.stringify(parsedSnapshot.commandHashes),
+		texts: JSON.stringify(commandTexts),
+	}
+}
+
+function parseStringArrayJson(value: string | null | undefined, fieldName: string): string[] {
+	if (!value) {
+		return []
+	}
+
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(value)
+	} catch (error) {
+		throw new Error(
+			`Invalid ${fieldName} JSON payload: ${error instanceof Error ? error.message : String(error)}`,
+		)
+	}
+
+	if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+		throw new Error(`Invalid ${fieldName} payload: expected string[]`)
+	}
+
+	return parsed as string[]
+}
+
+function parsePendingDeleteHookSnapshotRow(row: {
+	preDeleteHookHashes?: string | null
+	preDeleteHookTexts?: string | null
+}): PendingDeleteHookSnapshot | null {
+	if (!row.preDeleteHookHashes) {
+		return null
+	}
+
+	const commandHashes = parseStringArrayJson(row.preDeleteHookHashes, "pre_delete_hook_hashes")
+	if (commandHashes.length === 0) {
+		return { commandHashes: [], commandTexts: [] }
+	}
+
+	const parsedCommandTexts = parseStringArrayJson(row.preDeleteHookTexts, "pre_delete_hook_texts")
+	const commandTexts =
+		parsedCommandTexts.length === commandHashes.length
+			? parsedCommandTexts
+			: Array.from({ length: commandHashes.length }, () => "")
+
+	return pendingDeleteHookSnapshotSchema.parse({
+		commandHashes,
+		commandTexts,
+	})
+}
+
+function hasMissingColumnError(error: unknown, columnName: string): boolean {
+	if (!(error instanceof Error)) {
+		return false
+	}
+
+	const normalizedMessage = error.message.toLowerCase()
+	return (
+		normalizedMessage.includes("no such column") &&
+		normalizedMessage.includes(columnName.toLowerCase())
+	)
 }
 
 // =============================================================================
@@ -456,13 +665,54 @@ export function setPendingDelete(db: Database, del: PendingDelete, client?: Open
 		)
 	}
 
-	// Atomic: replace any existing pending operation
-	const stmt = db.prepare(`
+	const serializedSnapshot = serializePendingDeleteHookSnapshot(parsed.approvedPreDeleteHooks)
+
+	try {
+		const stmt = db.prepare(`
+			INSERT OR REPLACE INTO pending_operations (
+				id,
+				type,
+				branch,
+				path,
+				session_id,
+				pre_delete_hook_hashes,
+				pre_delete_hook_texts
+			)
+			VALUES (1, 'delete', $branch, $path, NULL, $preDeleteHookHashes, $preDeleteHookTexts)
+		`)
+
+		stmt.run({
+			$branch: parsed.branch,
+			$path: parsed.path,
+			$preDeleteHookHashes: serializedSnapshot.hashes,
+			$preDeleteHookTexts: serializedSnapshot.texts,
+		})
+		return
+	} catch (error) {
+		if (
+			hasMissingColumnError(error, "pre_delete_hook_hashes") ||
+			hasMissingColumnError(error, "pre_delete_hook_texts")
+		) {
+			logWarn(
+				client,
+				"worktree",
+				`Pending delete snapshot persistence unavailable; scheduling cleanup without hooks: ${String(error)}`,
+			)
+		} else {
+			logWarn(
+				client,
+				"worktree",
+				`Pending delete snapshot write failed; scheduling cleanup without hooks: ${String(error)}`,
+			)
+		}
+	}
+
+	const fallbackStmt = db.prepare(`
 		INSERT OR REPLACE INTO pending_operations (id, type, branch, path, session_id)
 		VALUES (1, 'delete', $branch, $path, NULL)
 	`)
 
-	stmt.run({
+	fallbackStmt.run({
 		$branch: parsed.branch,
 		$path: parsed.path,
 	})
@@ -475,18 +725,69 @@ export function setPendingDelete(db: Database, del: PendingDelete, client?: Open
  * @returns PendingDelete if exists and type is 'delete', null otherwise
  */
 export function getPendingDelete(db: Database): PendingDelete | null {
-	const stmt = db.prepare(`
-		SELECT type, branch, path
-		FROM pending_operations
-		WHERE id = 1 AND type = 'delete'
-	`)
+	try {
+		const stmt = db.prepare(`
+			SELECT type, branch, path,
+				pre_delete_hook_hashes as preDeleteHookHashes,
+				pre_delete_hook_texts as preDeleteHookTexts
+			FROM pending_operations
+			WHERE id = 1 AND type = 'delete'
+		`)
 
-	const row = stmt.get() as Record<string, string> | null
-	if (!row) return null
+		const row = stmt.get() as {
+			branch: string
+			path: string
+			preDeleteHookHashes: string | null
+			preDeleteHookTexts: string | null
+		} | null
+		if (!row) return null
 
-	return {
-		branch: row.branch,
-		path: row.path,
+		let snapshot: PendingDeleteHookSnapshot | null
+		try {
+			snapshot = parsePendingDeleteHookSnapshotRow(row)
+		} catch (error) {
+			console.warn(
+				`[worktree] Pending delete snapshot is malformed; ignoring hook snapshot and continuing cleanup: ${error instanceof Error ? error.message : String(error)}`,
+			)
+			return {
+				branch: row.branch,
+				path: row.path,
+			}
+		}
+
+		if (!snapshot) {
+			return {
+				branch: row.branch,
+				path: row.path,
+			}
+		}
+
+		return {
+			branch: row.branch,
+			path: row.path,
+			approvedPreDeleteHooks: snapshot,
+		}
+	} catch (error) {
+		if (
+			hasMissingColumnError(error, "pre_delete_hook_hashes") ||
+			hasMissingColumnError(error, "pre_delete_hook_texts")
+		) {
+			const fallbackStmt = db.prepare(`
+				SELECT type, branch, path
+				FROM pending_operations
+				WHERE id = 1 AND type = 'delete'
+			`)
+
+			const fallbackRow = fallbackStmt.get() as { branch: string; path: string } | null
+			if (!fallbackRow) return null
+
+			return {
+				branch: fallbackRow.branch,
+				path: fallbackRow.path,
+			}
+		}
+
+		throw error
 	}
 }
 
@@ -499,4 +800,144 @@ export function getPendingDelete(db: Database): PendingDelete | null {
 export function clearPendingDelete(db: Database): void {
 	const stmt = db.prepare(`DELETE FROM pending_operations WHERE id = 1 AND type = 'delete'`)
 	stmt.run()
+}
+
+export function readPendingDeleteSnapshot(
+	db: Database,
+): DbResult<PendingDeleteHookSnapshot | null> {
+	try {
+		const stmt = db.prepare(`
+			SELECT pre_delete_hook_hashes as preDeleteHookHashes,
+				pre_delete_hook_texts as preDeleteHookTexts
+			FROM pending_operations
+			WHERE id = 1 AND type = 'delete'
+		`)
+
+		const row = stmt.get() as {
+			preDeleteHookHashes: string | null
+			preDeleteHookTexts: string | null
+		} | null
+		if (!row) {
+			return DbResult.ok(null)
+		}
+
+		return DbResult.ok(parsePendingDeleteHookSnapshotRow(row))
+	} catch (error) {
+		return DbResult.err(error)
+	}
+}
+
+export function writePendingDeleteSnapshot(
+	db: Database,
+	snapshot: PendingDeleteHookSnapshot,
+): DbResult<void> {
+	try {
+		const serializedSnapshot = serializePendingDeleteHookSnapshot(snapshot)
+		const stmt = db.prepare(`
+			UPDATE pending_operations
+			SET pre_delete_hook_hashes = $preDeleteHookHashes,
+				pre_delete_hook_texts = $preDeleteHookTexts
+			WHERE id = 1 AND type = 'delete'
+		`)
+
+		stmt.run({
+			$preDeleteHookHashes: serializedSnapshot.hashes,
+			$preDeleteHookTexts: serializedSnapshot.texts,
+		})
+
+		return DbResult.ok(undefined)
+	} catch (error) {
+		return DbResult.err(error)
+	}
+}
+
+// =============================================================================
+// HOOK APPROVAL CRUD
+// =============================================================================
+
+export function upsertHookApproval(db: Database, input: HookApprovalInput): DbResult<void> {
+	try {
+		const parsed = hookApprovalSchema.parse(input)
+		const now = new Date().toISOString()
+
+		const stmt = db.prepare(`
+			INSERT INTO hook_approvals (hook_type, command_hash, command_text, approved_at, updated_at)
+			VALUES ($hookType, $commandHash, $commandText, $approvedAt, $updatedAt)
+			ON CONFLICT(hook_type, command_hash) DO UPDATE SET
+				command_text = excluded.command_text,
+				updated_at = excluded.updated_at
+		`)
+
+		stmt.run({
+			$hookType: parsed.hookType,
+			$commandHash: parsed.commandHash,
+			$commandText: parsed.commandText,
+			$approvedAt: now,
+			$updatedAt: now,
+		})
+
+		return DbResult.ok(undefined)
+	} catch (error) {
+		return DbResult.err(error)
+	}
+}
+
+export function getHookApproval(
+	db: Database,
+	hookType: HookType,
+	commandHash: string,
+): DbResult<HookApproval | null> {
+	try {
+		const parsedHookType = hookTypeSchema.parse(hookType)
+		const normalizedCommandHash = z.string().min(1).parse(commandHash)
+
+		const stmt = db.prepare(`
+			SELECT
+				hook_type as hookType,
+				command_hash as commandHash,
+				command_text as commandText,
+				approved_at as approvedAt,
+				updated_at as updatedAt
+			FROM hook_approvals
+			WHERE hook_type = $hookType AND command_hash = $commandHash
+		`)
+
+		const row = stmt.get({
+			$hookType: parsedHookType,
+			$commandHash: normalizedCommandHash,
+		}) as HookApproval | null
+
+		if (!row) {
+			return DbResult.ok(null)
+		}
+
+		return DbResult.ok({
+			hookType: row.hookType,
+			commandHash: row.commandHash,
+			commandText: row.commandText,
+			approvedAt: row.approvedAt,
+			updatedAt: row.updatedAt,
+		})
+	} catch (error) {
+		return DbResult.err(error)
+	}
+}
+
+export function deleteHookApproval(
+	db: Database,
+	hookType: HookType,
+	commandHash: string,
+): DbResult<void> {
+	try {
+		const parsedHookType = hookTypeSchema.parse(hookType)
+		const normalizedCommandHash = z.string().min(1).parse(commandHash)
+
+		const stmt = db.prepare(
+			`DELETE FROM hook_approvals WHERE hook_type = $hookType AND command_hash = $commandHash`,
+		)
+		stmt.run({ $hookType: parsedHookType, $commandHash: normalizedCommandHash })
+		return DbResult.ok(undefined)
+	} catch (error) {
+		return DbResult.err(error)
+	}
 }

--- a/workers/kdco-registry/registry.jsonc
+++ b/workers/kdco-registry/registry.jsonc
@@ -70,7 +70,8 @@
 				"plugins/worktree.ts",
 				"plugins/worktree/state.ts",
 				"plugins/worktree/terminal.ts",
-				"plugins/worktree/launch-context.ts"
+				"plugins/worktree/launch-context.ts",
+				"plugins/worktree/hooks.ts"
 			],
 			"dependencies": ["kdco-primitives"],
 			"npmDevDependencies": ["jsonc-parser@3.3.1", "zod@4.3.5"]

--- a/workers/kdco-registry/schemas/worktree.json
+++ b/workers/kdco-registry/schemas/worktree.json
@@ -40,19 +40,19 @@
 		},
 		"hooks": {
 			"type": "object",
-			"description": "Lifecycle hooks",
+			"description": "Lifecycle hooks (approval-gated; commands run only after explicit consent)",
 			"properties": {
 				"postCreate": {
 					"type": "array",
 					"items": { "type": "string" },
 					"default": [],
-					"description": "Commands to run after worktree creation. Example: [\"bun install\"]"
+					"description": "Commands evaluated after worktree creation. Exact command text (including whitespace/newlines) is the approval identity hash. Selecting always stores durable approval for this project + exact text; selecting once allows only the current invocation. Example: [\"bun install\"]"
 				},
 				"preDelete": {
 					"type": "array",
 					"items": { "type": "string" },
 					"default": [],
-					"description": "Commands to run before worktree deletion. Example: [\"docker compose down\"]"
+					"description": "Commands evaluated during worktree_delete. Only hooks approved for that delete request are snapshotted and replayed at session.idle cleanup if current hashes still match exactly; config edits require re-approval. Example: [\"docker compose down\"]"
 				}
 			},
 			"additionalProperties": false

--- a/workers/kdco-registry/tests/worktree-hooks-runtime.test.ts
+++ b/workers/kdco-registry/tests/worktree-hooks-runtime.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "bun:test"
+import type { ToolContext } from "@opencode-ai/plugin"
+import {
+	createHookApprovalSnapshot,
+	hashHookCommand,
+	hooksForCurrentInvocation,
+	matchHooksToApprovalSnapshot,
+	parseHookCommands,
+	resolveHookApprovals,
+} from "../files/plugins/worktree/hooks"
+
+function createToolContext(ask?: (prompt: unknown) => Promise<unknown>): ToolContext {
+	const baseContext = {
+		sessionID: "session-1",
+		messageID: "message-1",
+		agent: "plan",
+		directory: "/tmp/project",
+		worktree: "/tmp/project",
+		abort: new AbortController().signal,
+		metadata: (_input: { title?: string; metadata?: Record<string, unknown> }) => {},
+		ask: async () => undefined,
+	}
+
+	if (!ask) {
+		return {
+			...baseContext,
+			ask: undefined,
+		} as unknown as ToolContext
+	}
+
+	return {
+		...baseContext,
+		ask,
+	} as unknown as ToolContext
+}
+
+function approvalKey(hookType: "postCreate" | "preDelete", commandHash: string): string {
+	return `${hookType}:${commandHash}`
+}
+
+describe("worktree hook runtime approvals", () => {
+	it("uses exact command text for command hash identity", () => {
+		const base = hashHookCommand("pnpm install")
+		const trailingSpace = hashHookCommand("pnpm install ")
+		const trailingNewline = hashHookCommand("pnpm install\n")
+
+		expect(base).not.toBe(trailingSpace)
+		expect(base).not.toBe(trailingNewline)
+		expect(trailingSpace).not.toBe(trailingNewline)
+	})
+
+	it("invalidates durable approval when command text changes", async () => {
+		const approvedHooks = parseHookCommands("postCreate", ["pnpm install"])
+		const updatedHooks = parseHookCommands("postCreate", ["pnpm install --frozen-lockfile"])
+		const approvals = new Set([approvalKey("postCreate", approvedHooks[0].commandHash)])
+
+		const resolutions = await resolveHookApprovals(updatedHooks, {
+			toolContext: createToolContext(async () => "reject"),
+			readDurableApproval: async (hook) => ({
+				ok: true,
+				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
+			}),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+
+		expect(resolutions[0]?.outcome).toBe("skip")
+		expect(hooksForCurrentInvocation(resolutions)).toEqual([])
+	})
+
+	it("skips unapproved hooks when user rejects", async () => {
+		const hooks = parseHookCommands("postCreate", ["docker compose up -d"])
+
+		const resolutions = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => "reject"),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+
+		expect(resolutions[0]?.outcome).toBe("skip")
+		expect(hooksForCurrentInvocation(resolutions)).toHaveLength(0)
+	})
+
+	it("runs once only for the current invocation", async () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm install"])
+		const approvals = new Set<string>()
+
+		const firstInvocation = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => "once"),
+			readDurableApproval: async (hook) => ({
+				ok: true,
+				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
+			}),
+			writeDurableApproval: async (hook) => {
+				approvals.add(approvalKey(hook.hookType, hook.commandHash))
+				return { ok: true }
+			},
+		})
+
+		expect(firstInvocation[0]?.outcome).toBe("run-once")
+		expect(hooksForCurrentInvocation(firstInvocation)).toHaveLength(1)
+		expect(approvals.size).toBe(0)
+
+		const secondInvocation = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(),
+			readDurableApproval: async (hook) => ({
+				ok: true,
+				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
+			}),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+
+		expect(secondInvocation[0]?.outcome).toBe("error-skip")
+		expect(hooksForCurrentInvocation(secondInvocation)).toHaveLength(0)
+	})
+
+	it("persists always approvals and reuses them on future invocations", async () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm install"])
+		const approvals = new Set<string>()
+
+		const firstInvocation = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => "always"),
+			readDurableApproval: async (hook) => ({
+				ok: true,
+				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
+			}),
+			writeDurableApproval: async (hook) => {
+				approvals.add(approvalKey(hook.hookType, hook.commandHash))
+				return { ok: true }
+			},
+		})
+
+		expect(firstInvocation[0]?.outcome).toBe("run-and-persist")
+		expect(approvals.size).toBe(1)
+
+		const secondInvocation = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => {
+				throw new Error("prompt unavailable")
+			}),
+			readDurableApproval: async (hook) => ({
+				ok: true,
+				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
+			}),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+
+		expect(secondInvocation[0]?.outcome).toBe("run-and-persist")
+		expect(hooksForCurrentInvocation(secondInvocation)).toHaveLength(1)
+	})
+
+	it("preserves hook order and multiplicity for mixed approvals", async () => {
+		const commands = ["echo approved", "echo denied", "echo approved", "echo denied"]
+		const hooks = parseHookCommands("preDelete", commands)
+		const approvedHash = hooks[0].commandHash
+
+		const resolutions = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => "reject"),
+			readDurableApproval: async (hook) => ({
+				ok: true,
+				approved: hook.commandHash === approvedHash,
+			}),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+
+		const runnable = hooksForCurrentInvocation(resolutions)
+		expect(runnable.map((hook) => hook.commandText)).toEqual(["echo approved", "echo approved"])
+	})
+
+	it("models preDelete timing as approve-on-delete and execute-on-idle", async () => {
+		const preDeleteHooks = parseHookCommands("preDelete", ["docker compose down"])
+
+		const resolutions = await resolveHookApprovals(preDeleteHooks, {
+			toolContext: createToolContext(async () => "once"),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+
+		const approvedForDeleteInvocation = hooksForCurrentInvocation(resolutions)
+		const snapshot = createHookApprovalSnapshot(approvedForDeleteInvocation)
+
+		const idleMatch = matchHooksToApprovalSnapshot(preDeleteHooks, snapshot)
+		expect(idleMatch.ok).toBe(true)
+		expect(idleMatch.ok ? idleMatch.hooks.map((hook) => hook.commandText) : []).toEqual([
+			"docker compose down",
+		])
+	})
+
+	it("skips deferred preDelete hooks when config changes before idle", () => {
+		const scheduledHooks = parseHookCommands("preDelete", ["docker compose down"])
+		const approvedSnapshot = createHookApprovalSnapshot(scheduledHooks)
+
+		const editedHooks = parseHookCommands("preDelete", ["docker compose down --remove-orphans"])
+		const matchResult = matchHooksToApprovalSnapshot(editedHooks, approvedSnapshot)
+
+		expect(matchResult.ok).toBe(false)
+	})
+
+	it("fails closed when storage read/write or prompt path errors", async () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm install"])
+
+		const readFailure = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => "once"),
+			readDurableApproval: async () => ({ ok: false, error: "db read failed" }),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+		expect(readFailure[0]?.outcome).toBe("error-skip")
+
+		const writeFailure = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => "always"),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+			writeDurableApproval: async () => ({ ok: false, error: "db write failed" }),
+		})
+		expect(writeFailure[0]?.outcome).toBe("error-skip")
+
+		const promptFailure = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => {
+				throw new Error("interactive unavailable")
+			}),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+			writeDurableApproval: async () => ({ ok: true }),
+		})
+		expect(promptFailure[0]?.outcome).toBe("error-skip")
+		expect(hooksForCurrentInvocation(promptFailure)).toHaveLength(0)
+	})
+})

--- a/workers/kdco-registry/tests/worktree-hooks-runtime.test.ts
+++ b/workers/kdco-registry/tests/worktree-hooks-runtime.test.ts
@@ -7,9 +7,10 @@ import {
 	matchHooksToApprovalSnapshot,
 	parseHookCommands,
 	resolveHookApprovals,
+	summarizeHookResolutionSkips,
 } from "../files/plugins/worktree/hooks"
 
-function createToolContext(ask?: (prompt: unknown) => Promise<unknown>): ToolContext {
+function createToolContext(ask?: (input: unknown) => Promise<void>): ToolContext {
 	const baseContext = {
 		sessionID: "session-1",
 		messageID: "message-1",
@@ -38,6 +39,12 @@ function approvalKey(hookType: "postCreate" | "preDelete", commandHash: string):
 	return `${hookType}:${commandHash}`
 }
 
+function permissionError(name: string, message: string): Error {
+	const error = new Error(message)
+	error.name = name
+	return error
+}
+
 describe("worktree hook runtime approvals", () => {
 	it("uses exact command text for command hash identity", () => {
 		const base = hashHookCommand("pnpm install")
@@ -55,96 +62,152 @@ describe("worktree hook runtime approvals", () => {
 		const approvals = new Set([approvalKey("postCreate", approvedHooks[0].commandHash)])
 
 		const resolutions = await resolveHookApprovals(updatedHooks, {
-			toolContext: createToolContext(async () => "reject"),
+			toolContext: createToolContext(async () => undefined),
 			readDurableApproval: async (hook) => ({
 				ok: true,
 				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
 			}),
-			writeDurableApproval: async () => ({ ok: true }),
 		})
 
-		expect(resolutions[0]?.outcome).toBe("skip")
-		expect(hooksForCurrentInvocation(resolutions)).toEqual([])
+		expect(resolutions[0]?.outcome).toBe("run-once")
+		expect(resolutions[0]?.reason).toBe("approved-by-permission")
+		expect(hooksForCurrentInvocation(resolutions)).toHaveLength(1)
 	})
 
 	it("skips unapproved hooks when user rejects", async () => {
 		const hooks = parseHookCommands("postCreate", ["docker compose up -d"])
 
 		const resolutions = await resolveHookApprovals(hooks, {
-			toolContext: createToolContext(async () => "reject"),
+			toolContext: createToolContext(async () => {
+				throw permissionError("PermissionRejectedError", "rejected")
+			}),
 			readDurableApproval: async () => ({ ok: true, approved: false }),
-			writeDurableApproval: async () => ({ ok: true }),
 		})
 
 		expect(resolutions[0]?.outcome).toBe("skip")
+		expect(resolutions[0]?.reason).toBe("rejected")
 		expect(hooksForCurrentInvocation(resolutions)).toHaveLength(0)
 	})
 
-	it("runs once only for the current invocation", async () => {
+	it("skips hooks denied by existing permission rules", async () => {
+		const hooks = parseHookCommands("preDelete", ["docker compose down"])
+
+		const resolutions = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => {
+				throw permissionError(
+					"PermissionDeniedError",
+					"The user has specified a rule which prevents you from using this specific tool call.",
+				)
+			}),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+		})
+
+		expect(resolutions[0]?.outcome).toBe("skip")
+		expect(resolutions[0]?.reason).toBe("permission-denied")
+		expect(hooksForCurrentInvocation(resolutions)).toHaveLength(0)
+	})
+
+	it("gives permission deny precedence over legacy durable approvals", async () => {
 		const hooks = parseHookCommands("postCreate", ["pnpm install"])
-		const approvals = new Set<string>()
+		let readDurableApprovalInvocations = 0
+
+		const resolutions = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async () => {
+				throw permissionError(
+					"PermissionDeniedError",
+					"The user has specified a rule which prevents you from using this specific tool call.",
+				)
+			}),
+			readDurableApproval: async () => {
+				readDurableApprovalInvocations += 1
+				return { ok: true, approved: true }
+			},
+		})
+
+		expect(readDurableApprovalInvocations).toBe(0)
+		expect(resolutions[0]?.outcome).toBe("skip")
+		expect(resolutions[0]?.reason).toBe("permission-denied")
+		expect(hooksForCurrentInvocation(resolutions)).toHaveLength(0)
+	})
+
+	it("requests approval with permission API payload", async () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm install"])
+		let askPayload: Record<string, unknown> | undefined
+
+		const resolutions = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async (payload) => {
+				askPayload = payload as Record<string, unknown>
+			}),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+		})
+
+		expect(askPayload).toBeDefined()
+		expect(askPayload?.permission).toBe("worktree.hook.postCreate")
+		expect(askPayload?.patterns).toEqual([`hash=${hooks[0].commandHash}; command="pnpm install"`])
+		expect(askPayload?.always).toEqual([`hash=${hooks[0].commandHash}; command="pnpm install"`])
+		expect(askPayload?.metadata).toEqual({
+			hookType: "postCreate",
+			commandText: "pnpm install",
+			commandHash: hooks[0].commandHash,
+		})
+		expect(resolutions[0]?.outcome).toBe("run-once")
+		expect(resolutions[0]?.reason).toBe("approved-by-permission")
+	})
+
+	it("includes readable command text in permission pattern for approval UI", async () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm run check:* --scope ?core"])
+		let askPayload: Record<string, unknown> | undefined
+
+		await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(async (payload) => {
+				askPayload = payload as Record<string, unknown>
+			}),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
+		})
+
+		const pattern = (askPayload?.patterns as string[] | undefined)?.[0]
+		expect(pattern).toContain("pnpm run check:")
+		expect(pattern).toContain("--scope")
+		expect(pattern).toContain("﹡")
+		expect(pattern).toContain("﹖")
+	})
+
+	it("runs approved hooks and does not persist once approvals locally", async () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm install"])
 
 		const firstInvocation = await resolveHookApprovals(hooks, {
-			toolContext: createToolContext(async () => "once"),
-			readDurableApproval: async (hook) => ({
-				ok: true,
-				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
-			}),
-			writeDurableApproval: async (hook) => {
-				approvals.add(approvalKey(hook.hookType, hook.commandHash))
-				return { ok: true }
-			},
+			toolContext: createToolContext(async () => undefined),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
 		})
 
 		expect(firstInvocation[0]?.outcome).toBe("run-once")
 		expect(hooksForCurrentInvocation(firstInvocation)).toHaveLength(1)
-		expect(approvals.size).toBe(0)
 
 		const secondInvocation = await resolveHookApprovals(hooks, {
 			toolContext: createToolContext(),
-			readDurableApproval: async (hook) => ({
-				ok: true,
-				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
-			}),
-			writeDurableApproval: async () => ({ ok: true }),
+			readDurableApproval: async () => ({ ok: true, approved: false }),
 		})
 
 		expect(secondInvocation[0]?.outcome).toBe("error-skip")
+		expect(secondInvocation[0]?.reason).toBe("prompt-unavailable")
 		expect(hooksForCurrentInvocation(secondInvocation)).toHaveLength(0)
 	})
 
-	it("persists always approvals and reuses them on future invocations", async () => {
+	it("reuses durable approvals only after permission check", async () => {
 		const hooks = parseHookCommands("postCreate", ["pnpm install"])
-		const approvals = new Set<string>()
+		let askInvocations = 0
 
-		const firstInvocation = await resolveHookApprovals(hooks, {
-			toolContext: createToolContext(async () => "always"),
-			readDurableApproval: async (hook) => ({
-				ok: true,
-				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
-			}),
-			writeDurableApproval: async (hook) => {
-				approvals.add(approvalKey(hook.hookType, hook.commandHash))
-				return { ok: true }
-			},
-		})
-
-		expect(firstInvocation[0]?.outcome).toBe("run-and-persist")
-		expect(approvals.size).toBe(1)
-
-		const secondInvocation = await resolveHookApprovals(hooks, {
+		const resolutions = await resolveHookApprovals(hooks, {
 			toolContext: createToolContext(async () => {
-				throw new Error("prompt unavailable")
+				askInvocations += 1
 			}),
-			readDurableApproval: async (hook) => ({
-				ok: true,
-				approved: approvals.has(approvalKey(hook.hookType, hook.commandHash)),
-			}),
-			writeDurableApproval: async () => ({ ok: true }),
+			readDurableApproval: async () => ({ ok: true, approved: true }),
 		})
 
-		expect(secondInvocation[0]?.outcome).toBe("run-and-persist")
-		expect(hooksForCurrentInvocation(secondInvocation)).toHaveLength(1)
+		expect(askInvocations).toBe(1)
+		expect(resolutions[0]?.outcome).toBe("run-and-persist")
+		expect(resolutions[0]?.reason).toBe("durable-approved")
+		expect(hooksForCurrentInvocation(resolutions)).toHaveLength(1)
 	})
 
 	it("preserves hook order and multiplicity for mixed approvals", async () => {
@@ -153,12 +216,19 @@ describe("worktree hook runtime approvals", () => {
 		const approvedHash = hooks[0].commandHash
 
 		const resolutions = await resolveHookApprovals(hooks, {
-			toolContext: createToolContext(async () => "reject"),
+			toolContext: createToolContext(async (payload) => {
+				const record = payload as { patterns?: string[] }
+				const pattern = record.patterns?.[0] ?? ""
+				if (pattern.includes(approvedHash)) {
+					return
+				}
+
+				throw permissionError("PermissionRejectedError", "rejected")
+			}),
 			readDurableApproval: async (hook) => ({
 				ok: true,
 				approved: hook.commandHash === approvedHash,
 			}),
-			writeDurableApproval: async () => ({ ok: true }),
 		})
 
 		const runnable = hooksForCurrentInvocation(resolutions)
@@ -169,9 +239,8 @@ describe("worktree hook runtime approvals", () => {
 		const preDeleteHooks = parseHookCommands("preDelete", ["docker compose down"])
 
 		const resolutions = await resolveHookApprovals(preDeleteHooks, {
-			toolContext: createToolContext(async () => "once"),
+			toolContext: createToolContext(async () => undefined),
 			readDurableApproval: async () => ({ ok: true, approved: false }),
-			writeDurableApproval: async () => ({ ok: true }),
 		})
 
 		const approvedForDeleteInvocation = hooksForCurrentInvocation(resolutions)
@@ -194,31 +263,48 @@ describe("worktree hook runtime approvals", () => {
 		expect(matchResult.ok).toBe(false)
 	})
 
-	it("fails closed when storage read/write or prompt path errors", async () => {
+	it("fails closed when storage read or prompt path errors", async () => {
 		const hooks = parseHookCommands("postCreate", ["pnpm install"])
 
 		const readFailure = await resolveHookApprovals(hooks, {
-			toolContext: createToolContext(async () => "once"),
+			toolContext: createToolContext(async () => undefined),
 			readDurableApproval: async () => ({ ok: false, error: "db read failed" }),
-			writeDurableApproval: async () => ({ ok: true }),
 		})
 		expect(readFailure[0]?.outcome).toBe("error-skip")
+		expect(readFailure[0]?.reason).toBe("storage-read-error")
+		expect(readFailure[0]?.reasonDetail).toBe("db read failed")
 
-		const writeFailure = await resolveHookApprovals(hooks, {
-			toolContext: createToolContext(async () => "always"),
+		const promptUnavailable = await resolveHookApprovals(hooks, {
+			toolContext: createToolContext(),
 			readDurableApproval: async () => ({ ok: true, approved: false }),
-			writeDurableApproval: async () => ({ ok: false, error: "db write failed" }),
 		})
-		expect(writeFailure[0]?.outcome).toBe("error-skip")
+		expect(promptUnavailable[0]?.outcome).toBe("error-skip")
+		expect(promptUnavailable[0]?.reason).toBe("prompt-unavailable")
 
 		const promptFailure = await resolveHookApprovals(hooks, {
 			toolContext: createToolContext(async () => {
 				throw new Error("interactive unavailable")
 			}),
 			readDurableApproval: async () => ({ ok: true, approved: false }),
-			writeDurableApproval: async () => ({ ok: true }),
 		})
 		expect(promptFailure[0]?.outcome).toBe("error-skip")
+		expect(promptFailure[0]?.reason).toBe("prompt-error")
+		expect(promptFailure[0]?.reasonDetail).toBe("interactive unavailable")
 		expect(hooksForCurrentInvocation(promptFailure)).toHaveLength(0)
+	})
+
+	it("returns actionable skip guidance when approval prompt is unavailable", () => {
+		const hooks = parseHookCommands("postCreate", ["pnpm install"])
+		const lines = summarizeHookResolutionSkips("postCreate", [
+			{
+				hook: hooks[0],
+				outcome: "error-skip",
+				reason: "prompt-unavailable",
+			},
+		])
+
+		expect(lines.join("\n")).toContain("Re-run worktree_create in an interactive session")
+		expect(lines.join("\n")).toContain("postCreate")
+		expect(lines.join("\n")).toContain("pnpm install")
 	})
 })

--- a/workers/kdco-registry/tests/worktree-state.test.ts
+++ b/workers/kdco-registry/tests/worktree-state.test.ts
@@ -13,15 +13,20 @@ import {
 	addSession,
 	clearPendingDelete,
 	clearPendingSpawn,
+	deleteHookApproval,
 	getAllSessions,
+	getHookApproval,
 	getPendingDelete,
 	getPendingSpawn,
 	getSession,
 	getWorktreePath,
 	initStateDb,
+	readPendingDeleteSnapshot,
 	removeSession,
 	setPendingDelete,
 	setPendingSpawn,
+	upsertHookApproval,
+	writePendingDeleteSnapshot,
 } from "../files/plugins/worktree/state"
 
 /** Use temp directory for test databases to avoid polluting user's system */
@@ -84,6 +89,12 @@ describe("worktree-state", () => {
 				.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='pending_operations'")
 				.get()
 			expect(pendingTable).toBeTruthy()
+
+			// Check hook_approvals table exists
+			const hookApprovalsTable = db
+				.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='hook_approvals'")
+				.get()
+			expect(hookApprovalsTable).toBeTruthy()
 
 			db.close()
 		})
@@ -149,11 +160,23 @@ describe("worktree-state", () => {
 				name: string
 			}>
 			const columns = new Set(tableInfo.map((column) => column.name))
-			migratedDb.close()
 
 			expect(columns.has("launch_mode")).toBe(true)
 			expect(columns.has("profile")).toBe(true)
 			expect(columns.has("ocx_bin")).toBe(true)
+
+			const pendingTableInfo = migratedDb
+				.prepare("PRAGMA table_info(pending_operations)")
+				.all() as Array<{ name: string }>
+			const pendingColumns = new Set(pendingTableInfo.map((column) => column.name))
+			expect(pendingColumns.has("pre_delete_hook_hashes")).toBe(true)
+			expect(pendingColumns.has("pre_delete_hook_texts")).toBe(true)
+
+			const hookApprovalsTable = migratedDb
+				.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='hook_approvals'")
+				.get()
+			expect(hookApprovalsTable).toBeTruthy()
+			migratedDb.close()
 		})
 	})
 
@@ -700,6 +723,194 @@ describe("worktree-state", () => {
 					path: "",
 				}),
 			).toThrow()
+		})
+
+		it("persists and reloads approved preDelete hook snapshot", () => {
+			setPendingDelete(db, {
+				branch: "snapshot-delete",
+				path: "/snapshot/path",
+				approvedPreDeleteHooks: {
+					commandHashes: ["hash-a", "hash-b", "hash-a"],
+					commandTexts: ["echo a", "echo b", "echo a"],
+				},
+			})
+
+			const pendingDelete = getPendingDelete(db)
+			expect(pendingDelete).toEqual({
+				branch: "snapshot-delete",
+				path: "/snapshot/path",
+				approvedPreDeleteHooks: {
+					commandHashes: ["hash-a", "hash-b", "hash-a"],
+					commandTexts: ["echo a", "echo b", "echo a"],
+				},
+			})
+
+			const snapshotResult = readPendingDeleteSnapshot(db)
+			expect(snapshotResult.ok).toBe(true)
+			expect(snapshotResult.ok ? snapshotResult.value : null).toEqual({
+				commandHashes: ["hash-a", "hash-b", "hash-a"],
+				commandTexts: ["echo a", "echo b", "echo a"],
+			})
+		})
+
+		it("writePendingDeleteSnapshot updates snapshot data for existing delete", () => {
+			setPendingDelete(db, {
+				branch: "snapshot-update",
+				path: "/snapshot/update",
+			})
+
+			const writeResult = writePendingDeleteSnapshot(db, {
+				commandHashes: ["hash-1", "hash-2"],
+				commandTexts: ["echo 1", "echo 2"],
+			})
+			expect(writeResult.ok).toBe(true)
+
+			const snapshotResult = readPendingDeleteSnapshot(db)
+			expect(snapshotResult.ok).toBe(true)
+			expect(snapshotResult.ok ? snapshotResult.value : null).toEqual({
+				commandHashes: ["hash-1", "hash-2"],
+				commandTexts: ["echo 1", "echo 2"],
+			})
+		})
+
+		it("fails closed when pending-delete snapshot payload is corrupt", () => {
+			setPendingDelete(db, {
+				branch: "corrupt-snapshot-branch",
+				path: "/corrupt/snapshot/path",
+				approvedPreDeleteHooks: {
+					commandHashes: ["hash-ok"],
+					commandTexts: ["echo ok"],
+				},
+			})
+
+			db.prepare(
+				`UPDATE pending_operations
+				 SET pre_delete_hook_hashes = $hashes,
+				 	 pre_delete_hook_texts = $texts
+				 WHERE id = 1 AND type = 'delete'`,
+			).run({
+				$hashes: "{not-json}",
+				$texts: '["echo ok"]',
+			})
+
+			const warnSpy = spyOn(console, "warn")
+			try {
+				expect(() => getPendingDelete(db)).not.toThrow()
+
+				const pendingDelete = getPendingDelete(db)
+				expect(pendingDelete).toEqual({
+					branch: "corrupt-snapshot-branch",
+					path: "/corrupt/snapshot/path",
+				})
+
+				const snapshotReadResult = readPendingDeleteSnapshot(db)
+				expect(snapshotReadResult.ok).toBe(false)
+				expect(warnSpy).toHaveBeenCalled()
+			} finally {
+				warnSpy.mockRestore()
+			}
+		})
+	})
+
+	describe("Hook Approval CRUD", () => {
+		let db: Database
+		const projectRoot = () => path.join(testDir, "hook-approval-project")
+
+		beforeEach(async () => {
+			fs.mkdirSync(projectRoot(), { recursive: true })
+			db = await initStateDb(projectRoot())
+		})
+
+		afterEach(() => {
+			db.close()
+		})
+
+		it("stores and reads durable hook approval by hook_type + command_hash", () => {
+			const writeResult = upsertHookApproval(db, {
+				hookType: "postCreate",
+				commandHash: "hash-post-create",
+				commandText: "pnpm install",
+			})
+			expect(writeResult.ok).toBe(true)
+
+			const readResult = getHookApproval(db, "postCreate", "hash-post-create")
+			expect(readResult.ok).toBe(true)
+			expect(readResult.ok ? readResult.value?.commandText : null).toBe("pnpm install")
+		})
+
+		it("updates command_text and updated_at on approval upsert", async () => {
+			const firstWrite = upsertHookApproval(db, {
+				hookType: "preDelete",
+				commandHash: "hash-shared",
+				commandText: "docker compose down",
+			})
+			expect(firstWrite.ok).toBe(true)
+
+			const firstRead = getHookApproval(db, "preDelete", "hash-shared")
+			expect(firstRead.ok).toBe(true)
+			const initialUpdatedAt = firstRead.ok ? firstRead.value?.updatedAt : null
+
+			await Bun.sleep(5)
+
+			const secondWrite = upsertHookApproval(db, {
+				hookType: "preDelete",
+				commandHash: "hash-shared",
+				commandText: "docker compose down --remove-orphans",
+			})
+			expect(secondWrite.ok).toBe(true)
+
+			const secondRead = getHookApproval(db, "preDelete", "hash-shared")
+			expect(secondRead.ok).toBe(true)
+			expect(secondRead.ok ? secondRead.value?.commandText : null).toBe(
+				"docker compose down --remove-orphans",
+			)
+			expect(
+				secondRead.ok && secondRead.value && initialUpdatedAt
+					? secondRead.value.updatedAt >= initialUpdatedAt
+					: false,
+			).toBe(true)
+		})
+
+		it("deletes durable hook approval", () => {
+			expect(
+				upsertHookApproval(db, {
+					hookType: "postCreate",
+					commandHash: "hash-delete",
+					commandText: "bun install",
+				}).ok,
+			).toBe(true)
+
+			expect(deleteHookApproval(db, "postCreate", "hash-delete").ok).toBe(true)
+			const readResult = getHookApproval(db, "postCreate", "hash-delete")
+			expect(readResult.ok).toBe(true)
+			expect(readResult.ok ? readResult.value : undefined).toBeNull()
+		})
+
+		it("isolates hook approvals across projects via separate sqlite files", async () => {
+			const projectA = path.join(testDir, "project-a")
+			const projectB = path.join(testDir, "project-b")
+			fs.mkdirSync(projectA, { recursive: true })
+			fs.mkdirSync(projectB, { recursive: true })
+
+			const dbA = await initStateDb(projectA)
+			const dbB = await initStateDb(projectB)
+
+			try {
+				expect(
+					upsertHookApproval(dbA, {
+						hookType: "postCreate",
+						commandHash: "shared-hash",
+						commandText: "pnpm install",
+					}).ok,
+				).toBe(true)
+
+				const approvalInProjectB = getHookApproval(dbB, "postCreate", "shared-hash")
+				expect(approvalInProjectB.ok).toBe(true)
+				expect(approvalInProjectB.ok ? approvalInProjectB.value : undefined).toBeNull()
+			} finally {
+				dbA.close()
+				dbB.close()
+			}
 		})
 	})
 


### PR DESCRIPTION
## Summary

Hardens repo-local worktree hook execution by requiring explicit user approval before running `postCreate` and `preDelete` hooks. Approvals are durable, scoped to the exact command text, and stored in the worktree SQLite database.

Key changes:
- **Approval identity** is derived from a hash of the exact parsed command text (`commandHash`); any whitespace or newline change invalidates prior approval.
- **Durable approvals** persist in `hook_approvals`; pending delete operations store an approved snapshot that is revalidated during idle cleanup.
- **Fail-closed behavior**: unknown or unavailable prompt, storage, or error paths skip hook execution rather than proceed unsafely.
- **Approved subset** preserves original command order and multiplicity.
- Schema, documentation, and tests updated to cover the new behavior.
- Fixed corrupt pending-delete snapshot handling and improved logging hygiene based on review feedback.

## Testing

- [x] Type checking passes
- [x] `worktree-state.test.ts`
- [x] `worktree-hooks-runtime.test.ts` (new)
- [x] Worktree launch preflight tests
- [x] CLI worktree registry contract tests

## Notes

- Does **not** include local `~/.config/opencode/profiles/cliproxy` symlink changes (personal/local, not repo-tracked).
- Files changed:
  - `workers/kdco-registry/files/plugins/worktree/hooks.ts` (new)
  - `workers/kdco-registry/files/plugins/worktree.ts`
  - `workers/kdco-registry/files/plugins/worktree/state.ts`
  - `workers/kdco-registry/tests/worktree-hooks-runtime.test.ts` (new)
  - `workers/kdco-registry/tests/worktree-state.test.ts`
  - `workers/kdco-registry/schemas/worktree.json`
  - `workers/kdco-registry/registry.jsonc`
  - `facades/opencode-worktree/README.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit, permission‑gated approval before running worktree `postCreate` and `preDelete` hooks. Approvals are stored per exact command text in the worktree SQLite DB, and hooks fail closed if prompts or storage aren’t available.

- **New Features**
  - Hook approvals use the opencode permission prompt; patterns include the exact command text for clear decisions.
  - `preDelete` hooks are snapshotted at delete time and revalidated at `session.idle`; only exact matches run.
  - `worktree_create`/`worktree_delete` show concise summaries for skipped hooks with short hashes and guidance.

- **Bug Fixes**
  - Denied permission rules take precedence and block hooks before reading durable approvals.
  - Corrupt or missing pending-delete snapshots no longer break cleanup; hooks are skipped safely.
  - Logging avoids leaking raw command text outside approval prompts.

<sup>Written for commit 3643d00f92c607549d087092d90ed62fd67eedc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

