### PR TITLE
perf(cli): Reduce Zod v4 bundle size

### DIFF
--- a/packages/cli/src/commands/opencode-overlay.ts
+++ b/packages/cli/src/commands/opencode-overlay.ts
@@ -16,7 +16,7 @@ import { tmpdir } from "node:os"
 import { basename, dirname, isAbsolute, join, relative } from "node:path"
 import { Glob } from "bun"
 import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
-import { z } from "zod"
+import { array, object, string } from "zod"
 import { findLocalConfigDir, OCX_CONFIG_FILE } from "../profile/paths"
 import { ConfigError } from "../utils/errors"
 import { validatePath } from "../utils/path-security"
@@ -270,12 +270,10 @@ async function assertSafeOverlayDestinationPath(
 	}
 }
 
-const projectOverlayPolicySchema = z
-	.object({
-		include: z.array(z.string()).optional(),
-		exclude: z.array(z.string()).optional(),
-	})
-	.passthrough()
+const projectOverlayPolicySchema = object({
+	include: array(string()).optional(),
+	exclude: array(string()).optional(),
+}).passthrough()
 
 function validatePolicyPatterns(
 	policyPath: string,

--- a/packages/cli/src/profile/schema.ts
+++ b/packages/cli/src/profile/schema.ts
@@ -1,4 +1,5 @@
-import { z } from "zod"
+import type { infer as ZodInfer } from "zod"
+import { boolean, object, record, string, unknown } from "zod"
 import { profileOcxConfigSchema } from "../schemas/ocx"
 
 /**
@@ -8,8 +9,7 @@ import { profileOcxConfigSchema } from "../schemas/ocx"
  * - 1-32 characters
  * Based on CCS variant-service.ts pattern.
  */
-export const profileNameSchema = z
-	.string()
+export const profileNameSchema = string()
 	.min(1, "Profile name is required")
 	.max(32, "Profile name must be 32 characters or less")
 	.regex(
@@ -17,20 +17,20 @@ export const profileNameSchema = z
 		"Profile name must start with a letter and contain only alphanumeric characters, dots, underscores, or hyphens",
 	)
 
-export type ProfileName = z.infer<typeof profileNameSchema>
+export type ProfileName = ZodInfer<typeof profileNameSchema>
 
 /**
  * Represents a loaded profile with all its data.
  */
-export const profileSchema = z.object({
+export const profileSchema = object({
 	/** Profile name (directory name) */
 	name: profileNameSchema,
 	/** OCX configuration from ocx.jsonc */
 	ocx: profileOcxConfigSchema,
 	/** OpenCode configuration from opencode.jsonc (optional, passthrough) */
-	opencode: z.record(z.string(), z.unknown()).optional(),
+	opencode: record(string(), unknown()).optional(),
 	/** Whether AGENTS.md exists in this profile */
-	hasAgents: z.boolean(),
+	hasAgents: boolean(),
 })
 
-export type Profile = z.infer<typeof profileSchema>
+export type Profile = ZodInfer<typeof profileSchema>

--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -4,7 +4,7 @@
  */
 
 import { posix as posixPath } from "node:path"
-import { z } from "zod"
+import { record, string, unknown } from "zod"
 import type { ComponentManifest, McpServer, RegistryIndex } from "../schemas/registry"
 import {
 	classifyRegistrySchemaIssue,
@@ -50,7 +50,7 @@ const LEGACY_TARGET_KIND_MAP = {
 } as const
 
 const packumentEnvelopeSchema = packumentSchema.extend({
-	versions: z.record(z.string(), z.unknown()),
+	versions: record(string(), unknown()),
 })
 
 function createCompatibilityError(

--- a/packages/cli/src/schemas/common.ts
+++ b/packages/cli/src/schemas/common.ts
@@ -5,7 +5,7 @@
  * Following Law 2: Parse at boundary - validate once, trust internally.
  */
 
-import { z } from "zod"
+import { string } from "zod"
 import { isAbsolutePath } from "../utils/path-helpers"
 
 /**
@@ -17,8 +17,7 @@ import { isAbsolutePath } from "../utils/path-helpers"
  * - Path traversal segments (..)
  * - Absolute paths (Unix and Windows, including UNC paths)
  */
-export const safeRelativePathSchema = z
-	.string()
+export const safeRelativePathSchema = string()
 	.refine((val) => !val.includes("\0"), "Path cannot contain null bytes")
 	.refine((val) => !val.split(/[/\\]/).some((seg) => seg === ".."), "Path cannot contain '..'")
 	.refine((val) => !isAbsolutePath(val), "Path must be relative, not absolute")

--- a/packages/cli/src/schemas/config.ts
+++ b/packages/cli/src/schemas/config.ts
@@ -9,7 +9,8 @@ import { existsSync } from "node:fs"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { parse as parseJsonc } from "jsonc-parser"
-import { z } from "zod"
+import type { infer as ZodInfer } from "zod"
+import { array, boolean, literal, object, record, string, unknown, enum as zEnum } from "zod"
 import { normalizeRegistryUrl } from "../utils/url"
 import { qualifiedComponentSchema } from "./registry"
 
@@ -20,38 +21,38 @@ import { qualifiedComponentSchema } from "./registry"
 /**
  * Registry configuration in ocx.jsonc
  */
-export const registryConfigSchema = z.object({
+export const registryConfigSchema = object({
 	/** Registry URL */
-	url: z.string().url("Registry URL must be a valid URL"),
+	url: string().url("Registry URL must be a valid URL"),
 
 	/** Optional auth headers (supports ${ENV_VAR} expansion) */
-	headers: z.record(z.string(), z.string()).optional(),
+	headers: record(string(), string()).optional(),
 })
 
-export type RegistryConfig = z.infer<typeof registryConfigSchema>
+export type RegistryConfig = ZodInfer<typeof registryConfigSchema>
 
 /**
  * Main OCX config schema (ocx.jsonc)
  * V2: Adds profile field for local profile selection
  */
-export const ocxConfigSchema = z.object({
+export const ocxConfigSchema = object({
 	/** Schema URL for IDE support */
-	$schema: z.string().optional(),
+	$schema: string().optional(),
 
 	/** Profile selection - specifies which global profile to layer with local config */
-	profile: z.string().optional(),
+	profile: string().optional(),
 
 	/** Configured registries */
-	registries: z.record(z.string(), registryConfigSchema).default({}),
+	registries: record(string(), registryConfigSchema).default({}),
 
 	/** Lock registries - prevent adding/removing (enterprise feature) */
-	lockRegistries: z.boolean().default(false),
+	lockRegistries: boolean().default(false),
 
 	/** Skip version compatibility checks */
-	skipCompatCheck: z.boolean().default(false),
+	skipCompatCheck: boolean().default(false),
 })
 
-export type OcxConfig = z.infer<typeof ocxConfigSchema>
+export type OcxConfig = ZodInfer<typeof ocxConfigSchema>
 
 export interface ReadOcxConfigOptions {
 	/**
@@ -73,57 +74,55 @@ export const RECEIPT_FILE = "receipt.jsonc"
  * Canonical ID format: "registryUrl::registryName/component@resolvedRevision"
  * Includes ownership tracking and sha256 baseline for integrity
  */
-export const installedComponentSchema = z.object({
+export const installedComponentSchema = object({
 	/** Registry URL where this was installed from */
-	registryUrl: z.string(),
+	registryUrl: string(),
 
 	/** Registry name (configured alias from ocx.jsonc) */
-	registryName: z.string(),
+	registryName: string(),
 
 	/** Component name */
-	name: z.string(),
+	name: string(),
 
 	/** Resolved version/revision (not tags) */
-	revision: z.string(),
+	revision: string(),
 
 	/** SHA-256 hash of installed files for integrity (baseline) */
-	hash: z.string(),
+	hash: string(),
 
 	/** Target files where installed (root-relative paths) with individual hashes */
-	files: z.array(
-		z.object({
+	files: array(
+		object({
 			/** File path relative to install root */
-			path: z.string(),
+			path: string(),
 			/** SHA-256 hash of this specific file */
-			hash: z.string(),
+			hash: string(),
 		}),
 	),
 
 	/** ISO timestamp of installation */
-	installedAt: z.string(),
+	installedAt: string(),
 
 	/** ISO timestamp of last update (optional, only set after update) */
-	updatedAt: z.string().optional(),
+	updatedAt: string().optional(),
 
 	/** Ownership metadata - who/what installed this component */
-	owner: z
-		.object({
-			/** Owner type: user, profile, or system */
-			type: z.enum(["user", "profile", "system"]),
-			/** Owner identifier (username, profile name, etc.) */
-			id: z.string().optional(),
-		})
-		.optional(),
+	owner: object({
+		/** Owner type: user, profile, or system */
+		type: zEnum(["user", "profile", "system"]),
+		/** Owner identifier (username, profile name, etc.) */
+		id: string().optional(),
+	}).optional(),
 
 	/**
 	 * OpenCode config provided by this component.
 	 * Stored for runtime instruction path resolution.
 	 * Install-root-relative paths in instructions array are resolved at runtime.
 	 */
-	opencode: z.record(z.string(), z.unknown()).optional(),
+	opencode: record(string(), unknown()).optional(),
 })
 
-export type InstalledComponent = z.infer<typeof installedComponentSchema>
+export type InstalledComponent = ZodInfer<typeof installedComponentSchema>
 
 /**
  * V1: Receipt file schema (.ocx/receipt.jsonc)
@@ -132,18 +131,18 @@ export type InstalledComponent = z.infer<typeof installedComponentSchema>
  *
  * Keys use canonical ID format: "registryUrl::registryName/component@resolvedRevision"
  */
-export const receiptSchema = z.object({
+export const receiptSchema = object({
 	/** Receipt format version */
-	version: z.literal(1),
+	version: literal(1),
 
 	/** Install root (for validation) */
-	root: z.string().optional(),
+	root: string().optional(),
 
 	/** Installed components, keyed by canonical ID */
-	installed: z.record(z.string(), installedComponentSchema).default({}),
+	installed: record(string(), installedComponentSchema).default({}),
 })
 
-export type Receipt = z.infer<typeof receiptSchema>
+export type Receipt = ZodInfer<typeof receiptSchema>
 
 // =============================================================================
 // OCX LOCKFILE SCHEMA (LEGACY - V1 compat)
@@ -153,67 +152,67 @@ export type Receipt = z.infer<typeof receiptSchema>
  * LEGACY V1: Installed component entry in lockfile
  * Key format: "alias/component" (e.g., "kdco/researcher")
  */
-export const legacyInstalledComponentSchema = z.object({
+export const legacyInstalledComponentSchema = object({
 	/** Registry alias this was installed from */
-	registry: z.string(),
+	registry: string(),
 
 	/** Version at time of install */
-	version: z.string(),
+	version: string(),
 
 	/** SHA-256 hash of installed files for integrity */
-	hash: z.string(),
+	hash: string(),
 
 	/** Target files where installed (clean paths, no alias prefix) */
-	files: z.array(z.string()),
+	files: array(string()),
 
 	/** ISO timestamp of installation */
-	installedAt: z.string(),
+	installedAt: string(),
 
 	/** ISO timestamp of last update (optional, only set after update) */
-	updatedAt: z.string().optional(),
+	updatedAt: string().optional(),
 })
 
-export type LegacyInstalledComponent = z.infer<typeof legacyInstalledComponentSchema>
+export type LegacyInstalledComponent = ZodInfer<typeof legacyInstalledComponentSchema>
 
 /**
  * Profile source tracking for profiles installed from registries.
  * Optional field in OcxLock - only present for profile installs.
  */
-export const installedFromSchema = z.object({
+export const installedFromSchema = object({
 	/** Registry alias this profile was installed from */
-	registry: z.string(),
+	registry: string(),
 
 	/** Component name in the registry */
-	component: z.string(),
+	component: string(),
 
 	/** Registry version at time of install */
-	version: z.string().optional(),
+	version: string().optional(),
 
 	/** SHA-256 hash of profile files for integrity */
-	hash: z.string(),
+	hash: string(),
 
 	/** ISO timestamp of installation */
-	installedAt: z.string(),
+	installedAt: string(),
 })
 
-export type InstalledFrom = z.infer<typeof installedFromSchema>
+export type InstalledFrom = ZodInfer<typeof installedFromSchema>
 
 /**
  * OCX lockfile schema (ocx.lock)
  * Keys are qualified component refs: "alias/component"
  */
-export const ocxLockSchema = z.object({
+export const ocxLockSchema = object({
 	/** Lockfile format version */
-	lockVersion: z.literal(1),
+	lockVersion: literal(1),
 
 	/** Profile source info (only present for profiles installed from registry) */
 	installedFrom: installedFromSchema.optional(),
 
 	/** Installed components, keyed by "alias/component" */
-	installed: z.record(qualifiedComponentSchema, legacyInstalledComponentSchema).default({}),
+	installed: record(qualifiedComponentSchema, legacyInstalledComponentSchema).default({}),
 })
 
-export type OcxLock = z.infer<typeof ocxLockSchema>
+export type OcxLock = ZodInfer<typeof ocxLockSchema>
 
 // =============================================================================
 // RECEIPT FILE HELPERS (V1)

--- a/packages/cli/src/schemas/ocx.ts
+++ b/packages/cli/src/schemas/ocx.ts
@@ -9,14 +9,15 @@
  */
 
 import { Glob } from "bun"
-import { z } from "zod"
+import type { infer as ZodInfer } from "zod"
+import { array, boolean, object, record, string } from "zod"
 import { safeRelativePathSchema } from "./common"
 import { registryConfigSchema } from "./config"
 
 /**
  * Validates that a string is a valid glob pattern.
  */
-const globPatternSchema = z.string().refine(
+const globPatternSchema = string().refine(
 	(pattern) => {
 		try {
 			new Glob(pattern)
@@ -39,18 +40,18 @@ const globPatternSchema = z.string().refine(
  * OpenCode configuration is stored separately in opencode.jsonc.
  * Profiles layer: global base + local overlay of same name (overlay wins).
  */
-export const profileOcxConfigSchema = z.object({
+export const profileOcxConfigSchema = object({
 	/** Schema URL for IDE support */
-	$schema: z.string().optional(),
+	$schema: string().optional(),
 
 	/** Path to OpenCode binary. Falls back to OPENCODE_BIN env var, then "opencode". */
-	bin: z.string().optional(),
+	bin: string().optional(),
 
 	/**
 	 * Configured registries for OCX profiles
 	 * Same format as ocx.jsonc registries
 	 */
-	registries: z.record(z.string(), registryConfigSchema).default({}),
+	registries: record(string(), registryConfigSchema).default({}),
 
 	/**
 	 * Optional default component path for installations
@@ -63,8 +64,7 @@ export const profileOcxConfigSchema = z.object({
 	 * Whether to set terminal/tmux window name when launching OpenCode.
 	 * Set to false to preserve your existing terminal title.
 	 */
-	renameWindow: z
-		.boolean()
+	renameWindow: boolean()
 		.default(true)
 		.describe("Set terminal/tmux window name when launching OpenCode"),
 
@@ -73,8 +73,7 @@ export const profileOcxConfigSchema = z.object({
 	 * Controls visibility of local config files.
 	 * Note: AGENTS.md is NOT excluded by default - uncomment in ocx.jsonc to exclude.
 	 */
-	exclude: z
-		.array(globPatternSchema)
+	exclude: array(globPatternSchema)
 		.default([
 			"**/CLAUDE.md",
 			"**/CONTEXT.md",
@@ -88,10 +87,9 @@ export const profileOcxConfigSchema = z.object({
 	 * V2: Glob patterns for project files to include (overrides exclude).
 	 * Use when you need specific files from otherwise excluded patterns.
 	 */
-	include: z
-		.array(globPatternSchema)
+	include: array(globPatternSchema)
 		.default([])
 		.describe("Glob patterns for project files to include (overrides exclude)"),
 })
 
-export type ProfileOcxConfig = z.infer<typeof profileOcxConfigSchema>
+export type ProfileOcxConfig = ZodInfer<typeof profileOcxConfigSchema>

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -6,7 +6,8 @@
  */
 
 import { isAbsolute, normalize } from "node:path"
-import { z } from "zod"
+import type { infer as ZodInfer } from "zod"
+import { any, array, boolean, number, object, record, string, union, enum as zEnum } from "zod"
 import {
 	OCX_DOMAIN,
 	REGISTRY_SCHEMA_LATEST_MAJOR,
@@ -31,8 +32,7 @@ import { PathValidationError, validatePath } from "../utils/path-security"
  * - npm:@scope/pkg
  * - npm:@scope/pkg@1.0.0
  */
-export const npmSpecifierSchema = z
-	.string()
+export const npmSpecifierSchema = string()
 	.refine((val) => val.startsWith("npm:"), {
 		message: 'npm specifier must start with "npm:" prefix',
 	})
@@ -50,7 +50,7 @@ export const npmSpecifierSchema = z
 		},
 	)
 
-export type NpmSpecifier = z.infer<typeof npmSpecifierSchema>
+export type NpmSpecifier = ZodInfer<typeof npmSpecifierSchema>
 
 // =============================================================================
 // OPENCODE NAMING CONSTRAINTS (from OpenCode docs)
@@ -65,8 +65,7 @@ export type NpmSpecifier = z.infer<typeof npmSpecifierSchema>
  *
  * Regex: ^[a-z0-9]+(-[a-z0-9]+)*$
  */
-export const openCodeNameSchema = z
-	.string()
+export const openCodeNameSchema = string()
 	.min(1, "Name cannot be empty")
 	.max(64, "Name cannot exceed 64 characters")
 	.regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
@@ -88,12 +87,13 @@ export const namespaceSchema = aliasSchema
  * Qualified component reference: alias/component
  * Used in CLI commands and lockfile keys
  */
-export const qualifiedComponentSchema = z
-	.string()
-	.regex(/^[a-z0-9]+(-[a-z0-9]+)*\/[a-z0-9]+(-[a-z0-9]+)*$/, {
+export const qualifiedComponentSchema = string().regex(
+	/^[a-z0-9]+(-[a-z0-9]+)*\/[a-z0-9]+(-[a-z0-9]+)*$/,
+	{
 		message:
 			'Must be in format "alias/component" (e.g., "kdco/researcher"). Both parts must be lowercase alphanumeric with hyphens.',
-	})
+	},
+)
 
 /**
  * Parse a qualified component reference into its alias and component tokens.
@@ -133,7 +133,7 @@ export function createQualifiedComponent(namespace: string, component: string): 
  * - Bare string: "utils" -> same registry alias (implicit)
  * - Qualified: "acme/utils" -> cross-registry (explicit)
  */
-export const dependencyRefSchema = z.string().refine(
+export const dependencyRefSchema = string().refine(
 	(dep) => {
 		// Either a bare component name or a qualified alias/component
 		const barePattern = /^[a-z0-9]+(-[a-z0-9]+)*$/
@@ -150,7 +150,7 @@ export const dependencyRefSchema = z.string().refine(
 // FILE TARGET SCHEMAS
 // =============================================================================
 
-export const componentTypeSchema = z.enum([
+export const componentTypeSchema = zEnum([
 	"agent",
 	"skill",
 	"plugin",
@@ -160,7 +160,7 @@ export const componentTypeSchema = z.enum([
 	"profile",
 ])
 
-export type ComponentType = z.infer<typeof componentTypeSchema>
+export type ComponentType = ZodInfer<typeof componentTypeSchema>
 
 /** Reserved targets (installer-owned files) */
 const RESERVED_TARGETS = new Set([".ocx", "ocx.lock"])
@@ -186,8 +186,7 @@ const BLOCKED_PATHS = [
  * Blocks protected paths that could compromise security or OCX functionality.
  * Validates path safety using schema-level checks.
  */
-export const targetPathSchema = z
-	.string()
+export const targetPathSchema = string()
 	.min(1, "Target path cannot be empty")
 	.refine(
 		(path) => {
@@ -219,67 +218,65 @@ export const targetPathSchema = z
  * OAuth configuration for MCP servers.
  * Supports advanced OAuth flows with custom client configuration.
  */
-export const oauthConfigSchema = z.object({
+export const oauthConfigSchema = object({
 	/** OAuth client ID */
-	clientId: z.string().optional(),
+	clientId: string().optional(),
 	/** OAuth scopes to request */
-	scopes: z.array(z.string()).optional(),
+	scopes: array(string()).optional(),
 	/** OAuth authorization URL */
-	authUrl: z.string().optional(),
+	authUrl: string().optional(),
 	/** OAuth token URL */
-	tokenUrl: z.string().optional(),
+	tokenUrl: string().optional(),
 })
 
-export type OAuthConfig = z.infer<typeof oauthConfigSchema>
+export type OAuthConfig = ZodInfer<typeof oauthConfigSchema>
 
 /**
  * Full MCP server configuration object
  */
-export const mcpServerObjectSchema = z
-	.object({
-		type: z.enum(["remote", "local"]),
-		/** Server URL (relaxed validation - allows non-URL strings) */
-		url: z.string().optional(),
-		/**
-		 * Command to run for local servers.
-		 * Can be a single string (e.g., "npx foo") or array (e.g., ["npx", "foo"])
-		 */
-		command: z.union([z.string(), z.array(z.string())]).optional(),
-		environment: z.record(z.string(), z.string()).optional(),
-		headers: z.record(z.string(), z.string()).optional(),
-		/**
-		 * OAuth configuration.
-		 * - true: Enable OAuth with defaults
-		 * - object: Enable OAuth with custom configuration
-		 */
-		oauth: z.union([z.boolean(), oauthConfigSchema]).optional(),
-		enabled: z.boolean().default(true),
-	})
-	.refine(
-		(data) => {
-			if (data.type === "remote" && !data.url) {
-				return false
-			}
-			if (data.type === "local" && !data.command) {
-				return false
-			}
-			return true
-		},
-		{
-			message: "Remote MCP servers require 'url', local servers require 'command'",
-		},
-	)
+export const mcpServerObjectSchema = object({
+	type: zEnum(["remote", "local"]),
+	/** Server URL (relaxed validation - allows non-URL strings) */
+	url: string().optional(),
+	/**
+	 * Command to run for local servers.
+	 * Can be a single string (e.g., "npx foo") or array (e.g., ["npx", "foo"])
+	 */
+	command: union([string(), array(string())]).optional(),
+	environment: record(string(), string()).optional(),
+	headers: record(string(), string()).optional(),
+	/**
+	 * OAuth configuration.
+	 * - true: Enable OAuth with defaults
+	 * - object: Enable OAuth with custom configuration
+	 */
+	oauth: union([boolean(), oauthConfigSchema]).optional(),
+	enabled: boolean().default(true),
+}).refine(
+	(data) => {
+		if (data.type === "remote" && !data.url) {
+			return false
+		}
+		if (data.type === "local" && !data.command) {
+			return false
+		}
+		return true
+	},
+	{
+		message: "Remote MCP servers require 'url', local servers require 'command'",
+	},
+)
 
-export type McpServer = z.infer<typeof mcpServerObjectSchema>
+export type McpServer = ZodInfer<typeof mcpServerObjectSchema>
 
 /**
  * Cargo-style MCP server reference:
  * - String: URL shorthand for remote server (e.g., "https://mcp.example.com")
  * - Object: Full configuration
  */
-export const mcpServerRefSchema = z.union([z.string(), mcpServerObjectSchema])
+export const mcpServerRefSchema = union([string(), mcpServerObjectSchema])
 
-export type McpServerRef = z.infer<typeof mcpServerRefSchema>
+export type McpServerRef = ZodInfer<typeof mcpServerRefSchema>
 
 // =============================================================================
 // COMPONENT FILE SCHEMA (Cargo-style: string path or full object)
@@ -289,26 +286,26 @@ export type McpServerRef = z.infer<typeof mcpServerRefSchema>
  * Full file configuration object.
  * Target validation is deferred to normalizeFile() where component type is known.
  */
-export const componentFileObjectSchema = z.object({
+export const componentFileObjectSchema = object({
 	/** Source path in registry */
-	path: z.string().min(1, "File path cannot be empty"),
+	path: string().min(1, "File path cannot be empty"),
 	/** Target path - validation deferred to normalizeFile() for type-aware checking */
-	target: z.string().min(1, "Target path cannot be empty"),
+	target: string().min(1, "Target path cannot be empty"),
 })
 
-export type ComponentFileObject = z.infer<typeof componentFileObjectSchema>
+export type ComponentFileObject = ZodInfer<typeof componentFileObjectSchema>
 
 /**
  * Cargo-style file schema:
  * - String: Path shorthand, target auto-inferred (e.g., "plugins/foo.ts" -> "plugins/foo.ts")
  * - Object: Full configuration with explicit target
  */
-export const componentFileSchema = z.union([
-	z.string().min(1, "File path cannot be empty"),
+export const componentFileSchema = union([
+	string().min(1, "File path cannot be empty"),
 	componentFileObjectSchema,
 ])
 
-export type ComponentFile = z.infer<typeof componentFileSchema>
+export type ComponentFile = ZodInfer<typeof componentFileSchema>
 
 // =============================================================================
 // OPENCODE CONFIG BLOCK SCHEMA
@@ -322,20 +319,18 @@ export type ComponentFile = z.infer<typeof componentFileSchema>
  * Provider configuration for AI model providers.
  * Supports custom API endpoints, headers, and environment variables.
  */
-export const providerConfigSchema = z
-	.object({
-		/** API base URL */
-		api: z.string().optional(),
-		/** Custom headers */
-		headers: z.record(z.string(), z.string()).optional(),
-		/** Environment variables for API keys */
-		env: z.record(z.string(), z.string()).optional(),
-		/** Whether provider is enabled */
-		enabled: z.boolean().optional(),
-	})
-	.passthrough()
+export const providerConfigSchema = object({
+	/** API base URL */
+	api: string().optional(),
+	/** Custom headers */
+	headers: record(string(), string()).optional(),
+	/** Environment variables for API keys */
+	env: record(string(), string()).optional(),
+	/** Whether provider is enabled */
+	enabled: boolean().optional(),
+}).passthrough()
 
-export type ProviderConfig = z.infer<typeof providerConfigSchema>
+export type ProviderConfig = ZodInfer<typeof providerConfigSchema>
 
 // -----------------------------------------------------------------------------
 // LSP, Formatter, Command Configuration
@@ -345,46 +340,40 @@ export type ProviderConfig = z.infer<typeof providerConfigSchema>
  * Language Server Protocol configuration.
  * Defines how to start and configure LSP servers.
  */
-export const lspConfigSchema = z
-	.object({
-		/** Command to run (string or array of args) */
-		command: z.union([z.string(), z.array(z.string())]).optional(),
-		/** Whether LSP is enabled */
-		enabled: z.boolean().optional(),
-	})
-	.passthrough()
+export const lspConfigSchema = object({
+	/** Command to run (string or array of args) */
+	command: union([string(), array(string())]).optional(),
+	/** Whether LSP is enabled */
+	enabled: boolean().optional(),
+}).passthrough()
 
-export type LspConfig = z.infer<typeof lspConfigSchema>
+export type LspConfig = ZodInfer<typeof lspConfigSchema>
 
 /**
  * Formatter configuration for code formatting.
  * Defines the command and file patterns to format.
  */
-export const formatterConfigSchema = z
-	.object({
-		/** Command to run (string or array of args) */
-		command: z.union([z.string(), z.array(z.string())]).optional(),
-		/** Glob pattern for files to format */
-		glob: z.string().optional(),
-	})
-	.passthrough()
+export const formatterConfigSchema = object({
+	/** Command to run (string or array of args) */
+	command: union([string(), array(string())]).optional(),
+	/** Glob pattern for files to format */
+	glob: string().optional(),
+}).passthrough()
 
-export type FormatterConfig = z.infer<typeof formatterConfigSchema>
+export type FormatterConfig = ZodInfer<typeof formatterConfigSchema>
 
 /**
  * Custom command configuration.
  * Defines executable commands with descriptions.
  */
-export const commandConfigSchema = z
-	.object({
-		/** Command description */
-		description: z.string().optional(),
-		/** The command to run */
-		run: z.string().optional(),
-	})
-	.passthrough()
+export const commandConfigSchema = object({
+	/** Command description */
+	description: string().optional(),
+	/** The command to run */
+	run: string().optional(),
+}).passthrough()
 
-export type CommandConfig = z.infer<typeof commandConfigSchema>
+export type CommandConfig = ZodInfer<typeof commandConfigSchema>
 
 // -----------------------------------------------------------------------------
 // TUI, Server, Keybind, Watcher Configuration
@@ -393,49 +382,43 @@ export type CommandConfig = z.infer<typeof commandConfigSchema>
 /**
  * TUI (Terminal User Interface) configuration.
  */
-export const tuiConfigSchema = z
-	.object({
-		/** Disable TUI features */
-		disabled: z.boolean().optional(),
-	})
-	.passthrough()
+export const tuiConfigSchema = object({
+	/** Disable TUI features */
+	disabled: boolean().optional(),
+}).passthrough()
 
-export type TuiConfig = z.infer<typeof tuiConfigSchema>
+export type TuiConfig = ZodInfer<typeof tuiConfigSchema>
 
 /**
  * Server configuration for OpenCode server mode.
  */
-export const serverConfigSchema = z
-	.object({
-		/** Server host */
-		host: z.string().optional(),
-		/** Server port */
-		port: z.number().optional(),
-	})
-	.passthrough()
+export const serverConfigSchema = object({
+	/** Server host */
+	host: string().optional(),
+	/** Server port */
+	port: number().optional(),
+}).passthrough()
 
-export type ServerConfig = z.infer<typeof serverConfigSchema>
+export type ServerConfig = ZodInfer<typeof serverConfigSchema>
 
 /**
  * Keybind configuration - maps action names to key combinations.
  */
-export const keybindConfigSchema = z.record(z.string(), z.string())
+export const keybindConfigSchema = record(string(), string())
 
-export type KeybindConfig = z.infer<typeof keybindConfigSchema>
+export type KeybindConfig = ZodInfer<typeof keybindConfigSchema>
 
 /**
  * File watcher configuration for automatic reloads.
  */
-export const watcherConfigSchema = z
-	.object({
-		/** Patterns to include */
-		include: z.array(z.string()).optional(),
-		/** Patterns to exclude */
-		exclude: z.array(z.string()).optional(),
-	})
-	.passthrough()
+export const watcherConfigSchema = object({
+	/** Patterns to include */
+	include: array(string()).optional(),
+	/** Patterns to exclude */
+	exclude: array(string()).optional(),
+}).passthrough()
 
-export type WatcherConfig = z.infer<typeof watcherConfigSchema>
+export type WatcherConfig = ZodInfer<typeof watcherConfigSchema>
 
 // -----------------------------------------------------------------------------
 // Agent Configuration
@@ -444,152 +427,138 @@ export type WatcherConfig = z.infer<typeof watcherConfigSchema>
 /**
  * Agent configuration options (matches opencode.json agent schema)
  */
-export const agentConfigSchema = z.object({
+export const agentConfigSchema = object({
 	/** Per-agent model override */
-	model: z.string().optional(),
+	model: string().optional(),
 
 	/** Agent description for self-documentation */
-	description: z.string().optional(),
+	description: string().optional(),
 
 	/** Maximum iterations/steps for the agent (must be positive integer) */
-	steps: z.number().int().positive().optional(),
+	steps: number().int().positive().optional(),
 
 	/** @deprecated Use `steps` instead (must be positive integer) */
-	maxSteps: z.number().int().positive().optional(),
+	maxSteps: number().int().positive().optional(),
 
 	/** Agent mode */
-	mode: z.enum(["primary", "subagent", "all"]).optional(),
+	mode: zEnum(["primary", "subagent", "all"]).optional(),
 
 	/** Tool enable/disable patterns */
-	tools: z.record(z.string(), z.boolean()).optional(),
+	tools: record(string(), boolean()).optional(),
 
 	/** Sampling temperature (provider-specific limits) */
-	temperature: z.number().optional(),
+	temperature: number().optional(),
 
 	/** Nucleus sampling parameter */
-	top_p: z.number().optional(),
+	top_p: number().optional(),
 
 	/** Additional prompt text */
-	prompt: z.string().optional(),
+	prompt: string().optional(),
 
 	/**
 	 * Permission matrix for agent operations.
 	 * Use `{ "*": "deny" }` for bash to enable read-only agent detection.
 	 */
-	permission: z
-		.record(
-			z.string(),
-			z.union([
-				z.enum(["ask", "allow", "deny"]),
-				z.record(z.string(), z.enum(["ask", "allow", "deny"])),
-			]),
-		)
-		.optional(),
+	permission: record(
+		string(),
+		union([zEnum(["ask", "allow", "deny"]), record(string(), zEnum(["ask", "allow", "deny"]))]),
+	).optional(),
 
 	/** UI color for the agent */
-	color: z.string().optional(),
+	color: string().optional(),
 
 	/** Whether the agent is disabled */
-	disable: z.boolean().optional(),
+	disable: boolean().optional(),
 
 	/** Custom options for the agent */
-	options: z.record(z.string(), z.any()).optional(),
+	options: record(string(), any()).optional(),
 })
 
-export type AgentConfig = z.infer<typeof agentConfigSchema>
+export type AgentConfig = ZodInfer<typeof agentConfigSchema>
 
 /**
  * Permission configuration schema (matches opencode.json permission schema)
  * Supports both simple values and per-path patterns
  */
-export const permissionConfigSchema = z
-	.object({
-		/**
-		 * Bash command permissions.
-		 * - Use `"allow"` for full bash access
-		 * - Use `{ "*": "deny" }` to deny all bash (required for read-only agent detection)
-		 * - Use patterns like `{ "git *": "allow", "*": "deny" }` for partial access
-		 */
-		bash: z
-			.union([
-				z.enum(["ask", "allow", "deny"]),
-				z.record(z.string(), z.enum(["ask", "allow", "deny"])),
-			])
-			.optional(),
-		/** File edit permissions */
-		edit: z
-			.union([
-				z.enum(["ask", "allow", "deny"]),
-				z.record(z.string(), z.enum(["ask", "allow", "deny"])),
-			])
-			.optional(),
-		/** MCP server permissions */
-		mcp: z.record(z.string(), z.enum(["ask", "allow", "deny"])).optional(),
-	})
-	.catchall(
-		z.union([
-			z.enum(["ask", "allow", "deny"]),
-			z.record(z.string(), z.enum(["ask", "allow", "deny"])),
-		]),
-	)
+export const permissionConfigSchema = object({
+	/**
+	 * Bash command permissions.
+	 * - Use `"allow"` for full bash access
+	 * - Use `{ "*": "deny" }` to deny all bash (required for read-only agent detection)
+	 * - Use patterns like `{ "git *": "allow", "*": "deny" }` for partial access
+	 */
+	bash: union([
+		zEnum(["ask", "allow", "deny"]),
+		record(string(), zEnum(["ask", "allow", "deny"])),
+	]).optional(),
+	/** File edit permissions */
+	edit: union([
+		zEnum(["ask", "allow", "deny"]),
+		record(string(), zEnum(["ask", "allow", "deny"])),
+	]).optional(),
+	/** MCP server permissions */
+	mcp: record(string(), zEnum(["ask", "allow", "deny"])).optional(),
+}).catchall(
+	union([zEnum(["ask", "allow", "deny"]), record(string(), zEnum(["ask", "allow", "deny"]))]),
+)
 
-export type PermissionConfig = z.infer<typeof permissionConfigSchema>
+export type PermissionConfig = ZodInfer<typeof permissionConfigSchema>
 
 /**
  * OpenCode configuration block
  * Mirrors opencode.json structure exactly for 1:1 mapping
  */
-export const opencodeConfigSchema = z.object({
+export const opencodeConfigSchema = object({
 	/** JSON Schema URL for IDE support */
-	$schema: z.string().optional(),
+	$schema: string().optional(),
 
 	/** UI theme name */
-	theme: z.string().optional(),
+	theme: string().optional(),
 
 	/** Logging level */
-	logLevel: z.string().optional(),
+	logLevel: string().optional(),
 
 	/** Username for display */
-	username: z.string().optional(),
+	username: string().optional(),
 
 	/** Default model to use */
-	model: z.string().optional(),
+	model: string().optional(),
 
 	/** Small/fast model for simple tasks */
-	small_model: z.string().optional(),
+	small_model: string().optional(),
 
 	/** Default agent to use */
-	default_agent: z.string().optional(),
+	default_agent: string().optional(),
 
 	/** MCP servers (matches opencode.json 'mcp' field) */
-	mcp: z.record(z.string(), mcpServerRefSchema).optional(),
+	mcp: record(string(), mcpServerRefSchema).optional(),
 
 	/** NPM plugin packages to add to opencode.json 'plugin' array */
-	plugin: z.array(z.string()).optional(),
+	plugin: array(string()).optional(),
 
 	/** Tool enable/disable patterns */
-	tools: z.record(z.string(), z.boolean()).optional(),
+	tools: record(string(), boolean()).optional(),
 
 	/** Per-agent configuration */
-	agent: z.record(z.string(), agentConfigSchema).optional(),
+	agent: record(string(), agentConfigSchema).optional(),
 
 	/** Global instructions to append */
-	instructions: z.array(z.string()).optional(),
+	instructions: array(string()).optional(),
 
 	/** Permission configuration */
 	permission: permissionConfigSchema.optional(),
 
 	/** Provider configurations */
-	provider: z.record(z.string(), providerConfigSchema).optional(),
+	provider: record(string(), providerConfigSchema).optional(),
 
 	/** LSP configurations */
-	lsp: z.record(z.string(), lspConfigSchema).optional(),
+	lsp: record(string(), lspConfigSchema).optional(),
 
 	/** Formatter configurations */
-	formatter: z.record(z.string(), formatterConfigSchema).optional(),
+	formatter: record(string(), formatterConfigSchema).optional(),
 
 	/** Custom command configurations */
-	command: z.record(z.string(), commandConfigSchema).optional(),
+	command: record(string(), commandConfigSchema).optional(),
 
 	/** TUI configuration */
 	tui: tuiConfigSchema.optional(),
@@ -604,22 +573,22 @@ export const opencodeConfigSchema = z.object({
 	watcher: watcherConfigSchema.optional(),
 
 	/** Enable auto-updates */
-	auto_update: z.boolean().optional(),
+	auto_update: boolean().optional(),
 
 	/** Enable auto-compaction */
-	auto_compact: z.boolean().optional(),
+	auto_compact: boolean().optional(),
 
 	/** Share configuration (boolean or URL string) */
-	share: z.union([z.boolean(), z.string()]).optional(),
+	share: union([boolean(), string()]).optional(),
 })
 
-export type OpencodeConfig = z.infer<typeof opencodeConfigSchema>
+export type OpencodeConfig = ZodInfer<typeof opencodeConfigSchema>
 
 // =============================================================================
 // COMPONENT MANIFEST SCHEMA
 // =============================================================================
 
-export const componentManifestSchema = z.object({
+export const componentManifestSchema = object({
 	/** Component name (clean, no alias prefix) */
 	name: openCodeNameSchema,
 
@@ -627,7 +596,7 @@ export const componentManifestSchema = z.object({
 	type: componentTypeSchema,
 
 	/** Human-readable description */
-	description: z.string().min(1).max(1024),
+	description: string().min(1).max(1024),
 
 	/**
 	 * Files to install (Cargo-style)
@@ -635,20 +604,20 @@ export const componentManifestSchema = z.object({
 	 * - Object: { path: "...", target: "..." } for explicit control
 	 * - Optional: bundles (deps-only) may have no files
 	 */
-	files: z.array(componentFileSchema).default([]),
+	files: array(componentFileSchema).default([]),
 
 	/**
 	 * Dependencies on other components (Cargo-style)
 	 * - Bare string: "utils" -> same registry alias (implicit)
 	 * - Qualified: "acme/utils" -> cross-registry (explicit)
 	 */
-	dependencies: z.array(dependencyRefSchema).default([]),
+	dependencies: array(dependencyRefSchema).default([]),
 
 	/** NPM dependencies to install (supports pkg@version syntax) */
-	npmDependencies: z.array(z.string()).optional(),
+	npmDependencies: array(string()).optional(),
 
 	/** NPM dev dependencies to install (supports pkg@version syntax) */
-	npmDevDependencies: z.array(z.string()).optional(),
+	npmDevDependencies: array(string()).optional(),
 
 	/**
 	 * OpenCode configuration to merge into opencode.json
@@ -657,7 +626,7 @@ export const componentManifestSchema = z.object({
 	opencode: opencodeConfigSchema.optional(),
 })
 
-export type ComponentManifest = z.infer<typeof componentManifestSchema>
+export type ComponentManifest = ZodInfer<typeof componentManifestSchema>
 
 // =============================================================================
 // NORMALIZER FUNCTIONS (Parse, Don't Validate - Law 2)
@@ -938,117 +907,111 @@ const semverRegex = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/
  * Omitting `name` or `version` is a validation error at parse time
  * (Law 4: Fail Fast, Fail Loud).
  */
-export const registrySchema = z
-	.object({
-		/** JSON Schema URL for IDE support */
-		$schema: z.string().optional(),
+export const registrySchema = object({
+	/** JSON Schema URL for IDE support */
+	$schema: string().optional(),
 
-		/** Registry display name (required — identifies the registry to users and tooling) */
-		name: z.string().min(1, "Registry name cannot be empty"),
+	/** Registry display name (required — identifies the registry to users and tooling) */
+	name: string().min(1, "Registry name cannot be empty"),
 
-		/** Registry version, semver (required — enables deterministic resolution and caching) */
-		version: z.string().regex(semverRegex, { message: "Version must be valid semver" }),
+	/** Registry version, semver (required — enables deterministic resolution and caching) */
+	version: string().regex(semverRegex, { message: "Version must be valid semver" }),
 
-		/** Registry author (required) */
-		author: z.string().min(1, "Author cannot be empty"),
+	/** Registry author (required) */
+	author: string().min(1, "Author cannot be empty"),
 
-		/** Minimum OpenCode version required (semver, e.g., "1.0.0") */
-		opencode: z
-			.string()
-			.regex(semverRegex, {
-				message: "OpenCode version must be valid semver",
-			})
-			.optional(),
+	/** Minimum OpenCode version required (semver, e.g., "1.0.0") */
+	opencode: string()
+		.regex(semverRegex, {
+			message: "OpenCode version must be valid semver",
+		})
+		.optional(),
 
-		/** Minimum OCX CLI version required (semver, e.g., "1.0.0") */
-		ocx: z
-			.string()
-			.regex(semverRegex, {
-				message: "OCX version must be valid semver",
-			})
-			.optional(),
+	/** Minimum OCX CLI version required (semver, e.g., "1.0.0") */
+	ocx: string()
+		.regex(semverRegex, {
+			message: "OCX version must be valid semver",
+		})
+		.optional(),
 
-		/** Components in this registry */
-		components: z.array(componentManifestSchema),
-	})
-	.refine(
-		(data) => {
-			// All dependencies must either:
-			// 1. Be a bare name that exists in this registry
-			// 2. Be a qualified cross-registry reference (validated at install time)
-			const componentNames = new Set(data.components.map((c) => c.name))
-			for (const component of data.components) {
-				for (const dep of component.dependencies) {
-					// Only validate bare (same-registry) dependencies
-					if (!dep.includes("/") && !componentNames.has(dep)) {
-						return false
-					}
+	/** Components in this registry */
+	components: array(componentManifestSchema),
+}).refine(
+	(data) => {
+		// All dependencies must either:
+		// 1. Be a bare name that exists in this registry
+		// 2. Be a qualified cross-registry reference (validated at install time)
+		const componentNames = new Set(data.components.map((c) => c.name))
+		for (const component of data.components) {
+			for (const dep of component.dependencies) {
+				// Only validate bare (same-registry) dependencies
+				if (!dep.includes("/") && !componentNames.has(dep)) {
+					return false
 				}
 			}
-			return true
-		},
-		{
-			message:
-				"Bare dependencies must reference components that exist in the registry. Use qualified references (e.g., 'other-registry/component') for cross-registry dependencies.",
-		},
-	)
+		}
+		return true
+	},
+	{
+		message:
+			"Bare dependencies must reference components that exist in the registry. Use qualified references (e.g., 'other-registry/component') for cross-registry dependencies.",
+	},
+)
 
-export type Registry = z.infer<typeof registrySchema>
+export type Registry = ZodInfer<typeof registrySchema>
 
 // =============================================================================
 // PACKUMENT SCHEMA (npm-style versioned component)
 // =============================================================================
 
-export const packumentSchema = z.object({
+export const packumentSchema = object({
 	/** Component name */
 	name: openCodeNameSchema,
 
 	/** Latest version */
-	"dist-tags": z.object({
-		latest: z.string(),
+	"dist-tags": object({
+		latest: string(),
 	}),
 
 	/** All versions */
-	versions: z.record(z.string(), componentManifestSchema),
+	versions: record(string(), componentManifestSchema),
 })
 
-export type Packument = z.infer<typeof packumentSchema>
+export type Packument = ZodInfer<typeof packumentSchema>
 
 // =============================================================================
 // REGISTRY INDEX SCHEMA
 // =============================================================================
 
-export const registryIndexSchema = z.object({
+export const registryIndexSchema = object({
 	/** JSON Schema URL for IDE support */
-	$schema: z.string().optional(),
+	$schema: string().optional(),
 
 	/** Registry author */
-	author: z.string(),
+	author: string(),
 
 	/** Minimum OpenCode version required */
-	opencode: z
-		.string()
+	opencode: string()
 		.regex(semverRegex, {
 			message: "OpenCode version must be valid semver",
 		})
 		.optional(),
 
 	/** Minimum OCX CLI version required */
-	ocx: z
-		.string()
+	ocx: string()
 		.regex(semverRegex, {
 			message: "OCX version must be valid semver",
 		})
 		.optional(),
 
 	/** Component summaries for search */
-	components: z.array(
-		z.object({
+	components: array(
+		object({
 			name: openCodeNameSchema,
 			type: componentTypeSchema,
-			description: z.string(),
+			description: string(),
 		}),
 	),
 })
 
-export type RegistryIndex = z.infer<typeof registryIndexSchema>
+export type RegistryIndex = ZodInfer<typeof registryIndexSchema>


### PR DESCRIPTION
## Summary
- Refactor CLI Zod usage to prefer named imports (`object`, `string`, `array`, etc.) instead of the `z` namespace to improve tree-shaking with Zod v4.
- Apply the import/schema-construction update across CLI schema and related validation modules without changing runtime behavior.

## Bundle Size Impact
- Baseline raw/gzip: `646010 / 160465`
- Post-change raw/gzip: `402765 / 119286`
- Delta raw/gzip: `-243245 / -41179`

## Verification
- ✅ `bun run --cwd packages/cli check`
- ✅ `bun run --cwd packages/cli test`
- ✅ `bun run --cwd packages/cli build`
- ✅ `bun run --cwd packages/cli test tests/schemas.test.ts tests/path-security.test.ts tests/profile/schema.test.ts tests/docs-contract.registry.test.ts`
- ✅ `bun run --cwd packages/cli test tests/verify.test.ts tests/registry/fetcher.test.ts tests/opencode-overlay.test.ts`
- ✅ Code review approved with no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor CLI schemas to use named imports from `zod` v4 for better tree-shaking, reducing the `packages/cli` bundle from 646,010 B to 402,765 B raw (160,465 B → 119,286 B gzip). No runtime behavior changes.

- **Refactors**
  - Replaced `z` namespace with named imports (`object`, `string`, `array`, etc.) and used `ZodInfer` for types across CLI schema/validation modules.
  - All CLI check/test/build tasks pass.

<sup>Written for commit 0b7fbfb9ed62c1c354bae392b8034ea6a1a1c21b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

