### PR TITLE
feat(cli,registry): Codex-aligned OSC title integration

### DIFF
--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -705,7 +705,7 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 			return
 		}
 
-		const gitInfo = await getGitInfo(projectDir)
+		const gitInfo = shouldRename ? await getGitInfo(projectDir) : { repoName: null, branch: null }
 		if (preSpawnSignalExitCode !== null) {
 			childExitCode = preSpawnSignalExitCode
 			return

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -24,6 +24,7 @@ import { handleError } from "../utils/handle-error"
 import { logger } from "../utils/logger"
 import { getGlobalConfigPath } from "../utils/paths"
 import {
+	canWriteOscTerminalTitle,
 	formatTerminalName,
 	restoreTerminalTitle,
 	saveTerminalTitle,
@@ -519,6 +520,11 @@ export function resolveStableOcxExecutablePath(opts: {
 		: path.resolve(opts.cwd, resolvedFromPath)
 }
 
+export interface OpenCodeTitleContext {
+	mayWriteOscTitle: boolean
+	baseTitle: string
+}
+
 /**
  * Builds environment variables to pass to the opencode process.
  * Returns a NEW object - does not mutate baseEnv.
@@ -541,6 +547,7 @@ export function buildOpenCodeEnv(opts: {
 	opencodeBin?: string
 	configDir?: string
 	configContent?: string
+	titleContext?: OpenCodeTitleContext
 }): Record<string, string | undefined> {
 	// Profile presence gates both OPENCODE_DISABLE_PROJECT_CONFIG and OPENCODE_CONFIG_DIR
 	const hasProfile = Boolean(opts.profileName)
@@ -551,6 +558,7 @@ export function buildOpenCodeEnv(opts: {
 		OCX_CONTEXT: _inheritedOcxContext,
 		OCX_BIN: _inheritedOcxBin,
 		OCX_PROFILE: _inheritedOcxProfile,
+		OCX_TITLE_CONTEXT: _inheritedOcxTitleContext,
 		...baseEnvWithoutDisableProjectConfig
 	} = opts.baseEnv
 
@@ -565,6 +573,7 @@ export function buildOpenCodeEnv(opts: {
 		...(hasProfile && { OCX_CONTEXT: "1" }),
 		...(hasProfile && opts.ocxBin && { OCX_BIN: opts.ocxBin }),
 		...(opts.profileName && { OCX_PROFILE: opts.profileName }),
+		...(opts.titleContext && { OCX_TITLE_CONTEXT: JSON.stringify(opts.titleContext) }),
 	}
 }
 
@@ -696,16 +705,22 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 			return
 		}
 
+		const gitInfo = await getGitInfo(projectDir)
+		if (preSpawnSignalExitCode !== null) {
+			childExitCode = preSpawnSignalExitCode
+			return
+		}
+
+		const baseTitle = formatTerminalName(projectDir, config.profileName ?? "default", gitInfo)
+		const titleContext: OpenCodeTitleContext = {
+			mayWriteOscTitle: shouldRename && canWriteOscTerminalTitle(),
+			baseTitle,
+		}
+
 		// Set terminal name only if enabled
 		if (shouldRename) {
 			saveTerminalTitle()
-			const gitInfo = await getGitInfo(projectDir)
-			if (preSpawnSignalExitCode !== null) {
-				childExitCode = preSpawnSignalExitCode
-				return
-			}
-
-			setTerminalName(formatTerminalName(projectDir, config.profileName ?? "default", gitInfo))
+			setTerminalName(baseTitle)
 		}
 
 		if (preSpawnSignalExitCode !== null) {
@@ -747,6 +762,7 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 					opencodeBin: resolvedOpenCodeLaunchBin,
 					configDir: mergedConfig?.path,
 					configContent,
+					titleContext,
 				}),
 				stdin: "inherit",
 				stdout: "inherit",

--- a/packages/cli/src/utils/terminal-title.ts
+++ b/packages/cli/src/utils/terminal-title.ts
@@ -14,6 +14,10 @@ import type { GitInfo } from "./git-context"
 
 const MAX_BRANCH_LENGTH = 20
 
+function isOscUnsafeControlCharacter(codePoint: number): boolean {
+	return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)
+}
+
 // ============================================================================
 // Terminal Title Stack (Save/Restore)
 // ============================================================================
@@ -91,13 +95,49 @@ export function setTmuxWindowName(name: string): void {
  */
 export function setTerminalTitle(title: string): void {
 	// Early exit: not a TTY
-	if (!isTTY) {
+	if (!canWriteOscTerminalTitle()) {
+		return
+	}
+
+	const sanitizedTitle = sanitizeOscTerminalTitle(title)
+	if (!sanitizedTitle) {
 		return
 	}
 
 	// OSC 0: Set window title and icon name
 	// Format: ESC ] 0 ; <title> BEL
-	process.stdout.write(`\x1b]0;${title}\x07`)
+	process.stdout.write(`\x1b]0;${sanitizedTitle}\x07`)
+}
+
+/**
+ * Sanitizes terminal title text before embedding it into OSC payloads.
+ *
+ * Replaces C0/C1 control characters (including BEL/ESC/CSI/ST) with spaces,
+ * then trims.
+ */
+export function sanitizeOscTerminalTitle(title: string): string {
+	let sanitizedTitle = ""
+
+	for (const character of title) {
+		const codePoint = character.codePointAt(0)
+		if (codePoint === undefined) {
+			continue
+		}
+
+		sanitizedTitle += isOscUnsafeControlCharacter(codePoint) ? " " : character
+	}
+
+	return sanitizedTitle.trim()
+}
+
+/**
+ * Determines whether OSC terminal-title writes are currently allowed.
+ *
+ * Centralizes launcher eligibility checks so child-process title context can
+ * inherit the same decision boundary.
+ */
+export function canWriteOscTerminalTitle(): boolean {
+	return isTTY
 }
 
 /**

--- a/packages/cli/tests/opencode.test.ts
+++ b/packages/cli/tests/opencode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { mkdir, readFile } from "node:fs/promises"
+import { mkdir, readFile, symlink } from "node:fs/promises"
 import { join } from "node:path"
 import {
 	buildOpenCodeEnv,
@@ -760,6 +760,41 @@ describe("oc command CLI contract", () => {
 			}
 			expect(parsedTitleContext.mayWriteOscTitle).toBe(false)
 			expect(parsedTitleContext.baseTitle).toContain("ocx[default]:")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("launches with --no-rename even when git is unavailable (regression)", async () => {
+		const testDir = await createTempDir("oc-contract-no-rename-no-git")
+		try {
+			const bunExecutable = Bun.which("bun")
+			if (!bunExecutable) {
+				throw new Error("bun executable is required for opencode CLI tests")
+			}
+
+			const isolatedBinDir = join(testDir, "isolated-bin")
+			await mkdir(isolatedBinDir, { recursive: true })
+			await symlink(bunExecutable, join(isolatedBinDir, "bun"))
+
+			const capturePath = join(testDir, "capture-no-git.ts")
+			const outputPath = join(testDir, "captured-no-git.json")
+			await Bun.write(
+				capturePath,
+				`const outputPath = process.argv[2];\nif (!outputPath) throw new Error("missing output path");\nawait Bun.write(outputPath, JSON.stringify({ ok: true }));\n`,
+			)
+
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "run", capturePath, outputPath],
+				testDir,
+				{
+					OPENCODE_BIN: "bun",
+					PATH: isolatedBinDir,
+				},
+			)
+
+			expect(result.exitCode).toBe(0)
+			expect(await Bun.file(outputPath).exists()).toBe(true)
 		} finally {
 			await cleanupTempDir(testDir)
 		}

--- a/packages/cli/tests/opencode.test.ts
+++ b/packages/cli/tests/opencode.test.ts
@@ -306,18 +306,53 @@ describe("buildOpenCodeEnv", () => {
 		expect(result.OCX_PROFILE).toBe("work")
 	})
 
+	it("exports dedicated OCX_TITLE_CONTEXT for profile and non-profile launches", () => {
+		const profileLaunch = buildOpenCodeEnv({
+			baseEnv: {},
+			profileName: "work",
+			titleContext: {
+				mayWriteOscTitle: true,
+				baseTitle: "ocx[work]:repo/main",
+			},
+		})
+		const nonProfileLaunch = buildOpenCodeEnv({
+			baseEnv: {},
+			titleContext: {
+				mayWriteOscTitle: false,
+				baseTitle: "ocx[default]:repo",
+			},
+		})
+
+		expect(profileLaunch.OCX_TITLE_CONTEXT).toBeDefined()
+		expect(nonProfileLaunch.OCX_TITLE_CONTEXT).toBeDefined()
+
+		expect(JSON.parse(profileLaunch.OCX_TITLE_CONTEXT as string)).toEqual({
+			mayWriteOscTitle: true,
+			baseTitle: "ocx[work]:repo/main",
+		})
+		expect(JSON.parse(nonProfileLaunch.OCX_TITLE_CONTEXT as string)).toEqual({
+			mayWriteOscTitle: false,
+			baseTitle: "ocx[default]:repo",
+		})
+	})
+
 	it("removes inherited OCX launch markers when no profile is active", () => {
 		const result = buildOpenCodeEnv({
 			baseEnv: {
 				OCX_CONTEXT: "1",
 				OCX_BIN: "/stale/ocx",
 				OCX_PROFILE: "stale",
+				OCX_TITLE_CONTEXT: JSON.stringify({
+					mayWriteOscTitle: true,
+					baseTitle: "stale",
+				}),
 			},
 		})
 
 		expect(result.OCX_CONTEXT).toBeUndefined()
 		expect(result.OCX_BIN).toBeUndefined()
 		expect(result.OCX_PROFILE).toBeUndefined()
+		expect(result.OCX_TITLE_CONTEXT).toBeUndefined()
 	})
 
 	it("preserves existing env vars that are not overwritten", () => {
@@ -691,6 +726,76 @@ describe("oc command CLI contract", () => {
 			expect(captured.opencodeBin).toBe(expectedOpencodeBin)
 			expect(captured.ocxBin).toBe(join(import.meta.dir, "..", "src", "index.ts"))
 			expect(captured.ocxBin).not.toBe(captured.argv0)
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("exports OCX_TITLE_CONTEXT for non-profile launches", async () => {
+		const testDir = await createTempDir("oc-contract-title-context-plain")
+		try {
+			const capturePath = join(testDir, "capture-title-context.ts")
+			const outputPath = join(testDir, "captured-title-context.json")
+			await Bun.write(
+				capturePath,
+				`const outputPath = process.argv[2];\nif (!outputPath) throw new Error("missing output path");\nconst payload = {\n  titleContext: process.env.OCX_TITLE_CONTEXT ?? null,\n};\nawait Bun.write(outputPath, JSON.stringify(payload));\n`,
+			)
+
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "run", capturePath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const captured = JSON.parse(await Bun.file(outputPath).text()) as {
+				titleContext?: string | null
+			}
+			expect(captured.titleContext).toBeDefined()
+
+			const parsedTitleContext = JSON.parse(captured.titleContext as string) as {
+				mayWriteOscTitle: boolean
+				baseTitle: string
+			}
+			expect(parsedTitleContext.mayWriteOscTitle).toBe(false)
+			expect(parsedTitleContext.baseTitle).toContain("ocx[default]:")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("exports OCX_TITLE_CONTEXT for profile launches", async () => {
+		const testDir = await createTempDir("oc-contract-title-context-profile")
+		try {
+			await createProfile(testDir, "work")
+
+			const capturePath = join(testDir, "capture-title-context.ts")
+			const outputPath = join(testDir, "captured-title-context.json")
+			await Bun.write(
+				capturePath,
+				`const outputPath = process.argv[2];\nif (!outputPath) throw new Error("missing output path");\nconst payload = {\n  titleContext: process.env.OCX_TITLE_CONTEXT ?? null,\n};\nawait Bun.write(outputPath, JSON.stringify(payload));\n`,
+			)
+
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--profile", "work", "run", capturePath, outputPath],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+
+			const captured = JSON.parse(await Bun.file(outputPath).text()) as {
+				titleContext?: string | null
+			}
+			expect(captured.titleContext).toBeDefined()
+
+			const parsedTitleContext = JSON.parse(captured.titleContext as string) as {
+				mayWriteOscTitle: boolean
+				baseTitle: string
+			}
+			expect(parsedTitleContext.mayWriteOscTitle).toBe(false)
+			expect(parsedTitleContext.baseTitle).toContain("ocx[work]:")
 		} finally {
 			await cleanupTempDir(testDir)
 		}

--- a/packages/cli/tests/terminal-title.test.ts
+++ b/packages/cli/tests/terminal-title.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import {
 	formatTerminalName,
 	isInsideTmux,
+	sanitizeOscTerminalTitle,
 	setTerminalName,
 	setTerminalTitle,
 	setTmuxWindowName,
@@ -143,6 +144,30 @@ describe("terminal-title", () => {
 				expect(() => setTerminalTitle(value)).not.toThrow()
 			})
 		}
+	})
+
+	describe("sanitizeOscTerminalTitle", () => {
+		it("removes control characters before OSC writes", () => {
+			const input = "\u0000ocx\u0007 title\u001b"
+
+			expect(sanitizeOscTerminalTitle(input)).toBe("ocx  title")
+		})
+
+		it("removes C1 control characters including ST and OSC introducer", () => {
+			const input = "title\u009cwith\u009dcontrols"
+
+			expect(sanitizeOscTerminalTitle(input)).toBe("title with controls")
+		})
+
+		it("removes adjacent DEL/C1 boundary characters", () => {
+			const input = "a\u007fb\u0080c\u009fd"
+
+			expect(sanitizeOscTerminalTitle(input)).toBe("a b c d")
+		})
+
+		it("returns empty string when sanitization removes all content", () => {
+			expect(sanitizeOscTerminalTitle("\u0007\u001b\u009b\u009c\u009d\u0000")).toBe("")
+		})
 	})
 
 	describe("setTmuxWindowName", () => {

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -5,7 +5,7 @@
  * Philosophy: "Notify the human when the AI needs them back, not for every micro-event."
  *
  * Features:
- * - Uses cmux native notifications when running inside cmux
+ * - Uses cmux native notifications and session status when running inside cmux
  * - Auto-detects terminal emulator (Ghostty, Kitty, iTerm, WezTerm, etc.)
  * - Suppresses notifications when terminal is focused (like Ghostty does)
  * - Click notification to focus terminal
@@ -13,6 +13,7 @@
  *
  * Uses cmux CLI first (if available), then node-notifier fallback:
  * - cmux: `cmux notify --title ... --subtitle ... --body ...`
+ * - cmux status: `cmux set-status <key> <value>` / `cmux clear-status <key>`
  * - macOS: terminal-notifier (native NSUserNotificationCenter)
  * - Windows: SnoreToast (native toast notifications)
  * - Linux: notify-send (native desktop notifications)
@@ -29,7 +30,19 @@ import detectTerminal from "detect-terminal"
 import notifier from "node-notifier"
 import type { OpencodeClient } from "./kdco-primitives/types"
 import { sendNotificationWithFallback } from "./notify/backend"
-import { canUseCmuxNotification, sendCmuxNotification } from "./notify/cmux"
+import {
+	canUseCmuxNotification,
+	clearCmuxStatus,
+	sendCmuxNotification,
+	sendCmuxStatus,
+} from "./notify/cmux"
+import {
+	buildCmuxSessionStatusTransitionForEvent,
+	buildCmuxSessionStatusTransitionForQuestionTool,
+	getCmuxSessionStatusText,
+	type CmuxSessionStatusTransition,
+} from "./notify/status"
+import { parseOscTitleContext, writeOscTitleBestEffort } from "./notify/title"
 
 interface NotifyConfig {
 	/** Notify for child/sub-session events (default: false) */
@@ -237,8 +250,58 @@ interface NotificationRuntime {
 const QUESTION_DEDUPE_WINDOW_MS = 1500
 const READY_DEDUPE_WINDOW_MS = 1500
 const PERMISSION_DEDUPE_WINDOW_MS = 1500
+const CMUX_SESSION_STATUS_KEY_PREFIX = "opencode.session"
+const CMUX_BUSY_ANIMATION_INTERVAL_MS = 80
+const CMUX_BUSY_ANIMATION_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const
 
 type RecentNotifications = Map<string, number>
+type SessionLogicalState = CmuxSessionStatusTransition["logicalState"]
+type CmuxSessionLogicalStateBySessionID = Map<
+	string,
+	SessionLogicalState
+>
+type TitleSessionLogicalStateBySessionID = Map<string, SessionLogicalState>
+type CmuxSessionStatusWriteIntent =
+	| {
+		readonly sessionID: string
+		readonly kind: "set-status"
+		readonly text: string
+	}
+	| {
+		readonly sessionID: string
+		readonly kind: "clear-status"
+	}
+
+function isCmuxSessionStatusWriteIntentEqual(
+	left: CmuxSessionStatusWriteIntent,
+	right: CmuxSessionStatusWriteIntent,
+): boolean {
+	if (left.kind !== right.kind) return false
+	if (left.kind === "clear-status" || right.kind === "clear-status") return true
+	return left.text === right.text
+}
+
+function buildCmuxSessionStatusWriteIntentForLogicalState(
+	sessionID: string,
+	logicalState: Exclude<CmuxSessionStatusTransition["logicalState"], "animated-busy">,
+): CmuxSessionStatusWriteIntent {
+	if (logicalState === "idle") {
+		return {
+			sessionID,
+			kind: "clear-status",
+		}
+	}
+
+	return {
+		sessionID,
+		kind: "set-status",
+		text: getCmuxSessionStatusText(logicalState),
+	}
+}
+
+function buildCmuxSessionStatusKey(sessionID: string): string {
+	return `${CMUX_SESSION_STATUS_KEY_PREFIX}.${sessionID}`
+}
 
 function toNonEmptyString(value: unknown): string | null {
 	if (typeof value !== "string") return null
@@ -496,9 +559,326 @@ export const NotifyPlugin: Plugin = async (ctx) => {
 	const notificationRuntime: NotificationRuntime = {
 		preferCmux: canUseCmuxNotification(),
 	}
+	const oscTitleContext = parseOscTitleContext()
+	const shouldSuppressCmuxSessionStatusWrites = oscTitleContext?.mayWriteOscTitle === true
 	const recentQuestionNotifications: RecentNotifications = new Map()
 	const recentReadyNotifications: RecentNotifications = new Map()
 	const recentPermissionNotifications: RecentNotifications = new Map()
+	const titleSessionLogicalStates: TitleSessionLogicalStateBySessionID = new Map()
+	const titleBusySessionIDs = new Set<string>()
+	let titleBusySpinnerFrameIndex = 0
+	let titleBusySpinnerTicker: ReturnType<typeof setInterval> | null = null
+	let lastWrittenOscTitle: string | null = null
+	const cmuxSessionLogicalStates: CmuxSessionLogicalStateBySessionID = new Map()
+	const committedCmuxSessionStatusWrites = new Map<string, CmuxSessionStatusWriteIntent>()
+	const pendingCmuxSessionStatusWrites = new Map<string, CmuxSessionStatusWriteIntent>()
+	const animatedBusySessionIDs = new Set<string>()
+	const busyAnimationFrameIndexBySessionID = new Map<string, number>()
+	let busyAnimationTicker: ReturnType<typeof setInterval> | null = null
+	let cmuxStatusUpdatesDisabled = shouldSuppressCmuxSessionStatusWrites
+	let isCmuxStatusDrainActive = false
+	let inFlightCmuxSessionStatusWrite: CmuxSessionStatusWriteIntent | null = null
+
+	const writeOscTitleIfNeeded = (title: string): void => {
+		if (!oscTitleContext?.mayWriteOscTitle) return
+		if (lastWrittenOscTitle === title) return
+
+		lastWrittenOscTitle = title
+		writeOscTitleBestEffort(title)
+	}
+
+	const buildBusySpinnerTitle = (): string => {
+		const frame =
+			CMUX_BUSY_ANIMATION_FRAMES[titleBusySpinnerFrameIndex] ?? CMUX_BUSY_ANIMATION_FRAMES[0]
+		titleBusySpinnerFrameIndex = (titleBusySpinnerFrameIndex + 1) % CMUX_BUSY_ANIMATION_FRAMES.length
+		return `${frame} ${oscTitleContext?.baseTitle ?? ""}`
+	}
+
+	const stopTitleBusySpinnerTicker = (): void => {
+		if (!titleBusySpinnerTicker) return
+
+		clearInterval(titleBusySpinnerTicker)
+		titleBusySpinnerTicker = null
+	}
+
+	const writeNextBusyOscTitleFrame = (): void => {
+		if (titleBusySessionIDs.size === 0) {
+			return
+		}
+
+		writeOscTitleIfNeeded(buildBusySpinnerTitle())
+	}
+
+	const startTitleBusySpinnerTicker = (): void => {
+		if (!oscTitleContext?.mayWriteOscTitle) return
+		if (titleBusySpinnerTicker || titleBusySessionIDs.size === 0) return
+
+		const interval = setInterval(() => {
+			if (titleBusySessionIDs.size === 0) {
+				stopTitleBusySpinnerTicker()
+				return
+			}
+
+			writeNextBusyOscTitleFrame()
+		}, CMUX_BUSY_ANIMATION_INTERVAL_MS)
+
+		;(interval as { unref?: () => void }).unref?.()
+		titleBusySpinnerTicker = interval
+	}
+
+	const startBusyOscTitleForSession = (sessionID: string): void => {
+		const wasBusy = titleBusySessionIDs.has(sessionID)
+		titleBusySessionIDs.add(sessionID)
+
+		if (!wasBusy && titleBusySessionIDs.size === 1) {
+			titleBusySpinnerFrameIndex = 0
+			writeNextBusyOscTitleFrame()
+		}
+
+		startTitleBusySpinnerTicker()
+	}
+
+	const stopBusyOscTitleForSession = (sessionID: string): void => {
+		titleBusySessionIDs.delete(sessionID)
+
+		if (titleBusySessionIDs.size > 0) {
+			return
+		}
+
+		stopTitleBusySpinnerTicker()
+		titleBusySpinnerFrameIndex = 0
+		if (oscTitleContext) {
+			writeOscTitleIfNeeded(oscTitleContext.baseTitle)
+		}
+	}
+
+	const applyOscTitleSessionStatusTransition = (
+		transition: CmuxSessionStatusTransition | null,
+	): void => {
+		if (!oscTitleContext?.mayWriteOscTitle || !transition) return
+
+		const previousLogicalState = titleSessionLogicalStates.get(transition.sessionID)
+		if (previousLogicalState === transition.logicalState) return
+
+		titleSessionLogicalStates.set(transition.sessionID, transition.logicalState)
+
+		if (transition.logicalState === "animated-busy") {
+			startBusyOscTitleForSession(transition.sessionID)
+			return
+		}
+
+		stopBusyOscTitleForSession(transition.sessionID)
+	}
+
+	const pruneCmuxSessionStateAfterTerminalClear = (sessionID: string): boolean => {
+		if (cmuxSessionLogicalStates.get(sessionID) !== "idle") return false
+		if (pendingCmuxSessionStatusWrites.has(sessionID)) return false
+		if (inFlightCmuxSessionStatusWrite?.sessionID === sessionID) return false
+
+		cmuxSessionLogicalStates.delete(sessionID)
+		committedCmuxSessionStatusWrites.delete(sessionID)
+		animatedBusySessionIDs.delete(sessionID)
+		busyAnimationFrameIndexBySessionID.delete(sessionID)
+
+		if (animatedBusySessionIDs.size === 0) {
+			stopBusyAnimationTicker()
+		}
+
+		return true
+	}
+
+	const stopBusyAnimationTicker = (): void => {
+		if (!busyAnimationTicker) return
+
+		clearInterval(busyAnimationTicker)
+		busyAnimationTicker = null
+	}
+
+	const clearBusyAnimationState = (): void => {
+		stopBusyAnimationTicker()
+		animatedBusySessionIDs.clear()
+		busyAnimationFrameIndexBySessionID.clear()
+	}
+
+	const getLatestCmuxSessionStatusWriteForSession = (
+		sessionID: string,
+	): CmuxSessionStatusWriteIntent | undefined => {
+		const pendingWrite = pendingCmuxSessionStatusWrites.get(sessionID)
+		if (pendingWrite) {
+			return pendingWrite
+		}
+
+		if (inFlightCmuxSessionStatusWrite?.sessionID === sessionID) {
+			return inFlightCmuxSessionStatusWrite
+		}
+
+		return committedCmuxSessionStatusWrites.get(sessionID)
+	}
+
+	const dequeueNextCmuxSessionStatusWrite = (): CmuxSessionStatusWriteIntent | null => {
+		const next = pendingCmuxSessionStatusWrites.values().next().value
+		if (!next) return null
+
+		pendingCmuxSessionStatusWrites.delete(next.sessionID)
+		return next
+	}
+
+	const runCmuxSessionStatusWrite = async (
+		writeIntent: CmuxSessionStatusWriteIntent,
+	): Promise<boolean> => {
+		const statusKey = buildCmuxSessionStatusKey(writeIntent.sessionID)
+		if (writeIntent.kind === "clear-status") {
+			return clearCmuxStatus({ key: statusKey })
+		}
+
+		return sendCmuxStatus({
+			key: statusKey,
+			text: writeIntent.text,
+		})
+	}
+
+	const drainCmuxSessionStatusWrites = async (): Promise<void> => {
+		if (isCmuxStatusDrainActive || cmuxStatusUpdatesDisabled) return
+
+		isCmuxStatusDrainActive = true
+
+		try {
+			while (!cmuxStatusUpdatesDisabled) {
+				const nextWriteIntent = dequeueNextCmuxSessionStatusWrite()
+				if (!nextWriteIntent) return
+
+				inFlightCmuxSessionStatusWrite = nextWriteIntent
+				const didUpdateStatus = await runCmuxSessionStatusWrite(nextWriteIntent)
+				inFlightCmuxSessionStatusWrite = null
+
+				if (!didUpdateStatus) {
+					cmuxStatusUpdatesDisabled = true
+					pendingCmuxSessionStatusWrites.clear()
+					clearBusyAnimationState()
+					return
+				}
+
+				if (
+					nextWriteIntent.kind === "clear-status" &&
+					pruneCmuxSessionStateAfterTerminalClear(nextWriteIntent.sessionID)
+				) {
+					continue
+				}
+
+				committedCmuxSessionStatusWrites.set(nextWriteIntent.sessionID, nextWriteIntent)
+			}
+		} finally {
+			inFlightCmuxSessionStatusWrite = null
+			isCmuxStatusDrainActive = false
+
+			if (!cmuxStatusUpdatesDisabled && pendingCmuxSessionStatusWrites.size > 0) {
+				void drainCmuxSessionStatusWrites()
+			}
+		}
+	}
+
+	const enqueueCmuxSessionStatusWrite = (writeIntent: CmuxSessionStatusWriteIntent): void => {
+		if (!notificationRuntime.preferCmux || cmuxStatusUpdatesDisabled) return
+
+		const latestWriteIntent = getLatestCmuxSessionStatusWriteForSession(writeIntent.sessionID)
+		if (latestWriteIntent && isCmuxSessionStatusWriteIntentEqual(latestWriteIntent, writeIntent)) return
+
+		pendingCmuxSessionStatusWrites.set(writeIntent.sessionID, writeIntent)
+		void drainCmuxSessionStatusWrites()
+	}
+
+	const enqueueNextBusyAnimationFrame = (sessionID: string): void => {
+		if (!animatedBusySessionIDs.has(sessionID)) return
+
+		const frameIndex = busyAnimationFrameIndexBySessionID.get(sessionID) ?? 0
+		const frameText = CMUX_BUSY_ANIMATION_FRAMES[frameIndex] ?? CMUX_BUSY_ANIMATION_FRAMES[0]
+
+		busyAnimationFrameIndexBySessionID.set(
+			sessionID,
+			(frameIndex + 1) % CMUX_BUSY_ANIMATION_FRAMES.length,
+		)
+
+		enqueueCmuxSessionStatusWrite({
+			sessionID,
+			kind: "set-status",
+			text: frameText,
+		})
+	}
+
+	const startBusyAnimationTicker = (): void => {
+		if (busyAnimationTicker || cmuxStatusUpdatesDisabled || animatedBusySessionIDs.size === 0) return
+
+		const interval = setInterval(() => {
+			if (cmuxStatusUpdatesDisabled) {
+				clearBusyAnimationState()
+				return
+			}
+
+			if (animatedBusySessionIDs.size === 0) {
+				stopBusyAnimationTicker()
+				return
+			}
+
+			for (const sessionID of animatedBusySessionIDs) {
+				enqueueNextBusyAnimationFrame(sessionID)
+			}
+		}, CMUX_BUSY_ANIMATION_INTERVAL_MS)
+
+		;(interval as { unref?: () => void }).unref?.()
+		busyAnimationTicker = interval
+	}
+
+	const startBusyAnimationForSession = (sessionID: string): void => {
+		const wasAnimating = animatedBusySessionIDs.has(sessionID)
+		animatedBusySessionIDs.add(sessionID)
+
+		if (!wasAnimating) {
+			busyAnimationFrameIndexBySessionID.set(sessionID, 0)
+			enqueueNextBusyAnimationFrame(sessionID)
+		}
+
+		startBusyAnimationTicker()
+	}
+
+	const stopBusyAnimationForSession = (sessionID: string): void => {
+		animatedBusySessionIDs.delete(sessionID)
+		busyAnimationFrameIndexBySessionID.delete(sessionID)
+
+		if (animatedBusySessionIDs.size === 0) {
+			stopBusyAnimationTicker()
+		}
+	}
+
+	const applyCmuxSessionStatusTransition = (
+		transition: CmuxSessionStatusTransition | null,
+	): void => {
+		if (!notificationRuntime.preferCmux || !transition || cmuxStatusUpdatesDisabled) return
+
+		const previousLogicalState = cmuxSessionLogicalStates.get(transition.sessionID)
+		if (previousLogicalState === transition.logicalState) return
+
+		cmuxSessionLogicalStates.set(transition.sessionID, transition.logicalState)
+
+		if (transition.logicalState === "animated-busy") {
+			startBusyAnimationForSession(transition.sessionID)
+			return
+		}
+
+		stopBusyAnimationForSession(transition.sessionID)
+		enqueueCmuxSessionStatusWrite(
+			buildCmuxSessionStatusWriteIntentForLogicalState(
+				transition.sessionID,
+				transition.logicalState,
+			),
+		)
+	}
+
+	const applyRuntimeSessionStatusTransition = (
+		transition: CmuxSessionStatusTransition | null,
+	): void => {
+		applyOscTitleSessionStatusTransition(transition)
+		applyCmuxSessionStatusTransition(transition)
+	}
 
 	const notifyQuestionIfNeeded = async (dedupeKey: string | null): Promise<void> => {
 		if (
@@ -557,27 +937,26 @@ export const NotifyPlugin: Plugin = async (ctx) => {
 	return {
 		"tool.execute.before": async (input: { tool: string; sessionID: string; callID: string }) => {
 			if (input.tool === "question") {
+				applyRuntimeSessionStatusTransition(
+					buildCmuxSessionStatusTransitionForQuestionTool(input.sessionID),
+				)
 				await notifyQuestionIfNeeded(buildQuestionToolDedupeKey(input.sessionID, input.callID))
 			}
 		},
 		event: async ({ event }: { event: Event }): Promise<void> => {
 			const runtimeEvent = event as { type: string; properties: Record<string, unknown> }
+			const runtimeSessionStatusTransition = buildCmuxSessionStatusTransitionForEvent(
+				runtimeEvent.type,
+				runtimeEvent.properties,
+			)
+			applyRuntimeSessionStatusTransition(runtimeSessionStatusTransition)
 
 			switch (runtimeEvent.type) {
-				case "session.status": {
-					const sessionID = runtimeEvent.properties.sessionID
-					const statusType =
-						runtimeEvent.properties.status && typeof runtimeEvent.properties.status === "object"
-							? ((runtimeEvent.properties.status as { type?: string }).type ?? undefined)
-							: undefined
-
-					if (sessionID && statusType === "idle") {
-						await notifySessionReadyIfNeeded(sessionID)
-					}
-					break
-				}
+				case "session.status":
 				case "session.idle": {
-					await notifySessionReadyIfNeeded(runtimeEvent.properties.sessionID)
+					if (runtimeSessionStatusTransition?.logicalState === "idle") {
+						await notifySessionReadyIfNeeded(runtimeSessionStatusTransition.sessionID)
+					}
 					break
 				}
 				case "session.error": {

--- a/workers/kdco-registry/files/plugins/notify/cmux.ts
+++ b/workers/kdco-registry/files/plugins/notify/cmux.ts
@@ -1,9 +1,19 @@
 import { TimeoutError, withTimeout } from "../kdco-primitives/with-timeout"
+import { canUseCmuxWorkflow } from "../worktree/terminal"
 
 interface CmuxNotificationPayload {
 	title: string
 	body: string
 	subtitle?: string
+}
+
+interface CmuxStatusPayload {
+	key: string
+	text: string
+}
+
+interface CmuxClearStatusPayload {
+	key: string
 }
 
 type ResolveExecutable = (command: string) => string | null | undefined
@@ -22,15 +32,20 @@ const spawnCmuxWithBun: SpawnCmuxProcess = (command) =>
 	})
 
 export const CMUX_NOTIFY_TIMEOUT_MS = 1500
+export const CMUX_STATUS_TIMEOUT_MS = CMUX_NOTIFY_TIMEOUT_MS
+
+type CmuxExecutionOptions = {
+	timeoutMs?: number
+	spawnProcess?: SpawnCmuxProcess
+	cmuxCommand?: string
+}
 
 export function canUseCmuxNotification(
 	env: EnvironmentVariables = process.env,
 	resolveExecutable: ResolveExecutable = resolveWithBunWhich,
+	cmuxCommand: string = "cmux",
 ): boolean {
-	const workspaceID = env.CMUX_WORKSPACE_ID?.trim()
-	if (!workspaceID) return false
-
-	return Boolean(resolveExecutable("cmux"))
+	return canUseCmuxWorkflow(env, resolveExecutable, cmuxCommand)
 }
 
 export function buildCmuxNotifyArgs(payload: CmuxNotificationPayload): string[] {
@@ -46,21 +61,28 @@ export function buildCmuxNotifyArgs(payload: CmuxNotificationPayload): string[] 
 	return args
 }
 
-export async function sendCmuxNotification(
-	payload: CmuxNotificationPayload,
-	options?: {
-		timeoutMs?: number
-		spawnProcess?: SpawnCmuxProcess
-	},
-): Promise<boolean> {
+export function buildCmuxStatusArgs(payload: CmuxStatusPayload): string[] {
+	return ["set-status", payload.key, payload.text]
+}
+
+export function buildCmuxClearStatusArgs(payload: CmuxClearStatusPayload): string[] {
+	return ["clear-status", payload.key]
+}
+
+async function executeCmuxCommand(commandArgs: string[], options?: CmuxExecutionOptions): Promise<boolean> {
 	const timeoutMs = options?.timeoutMs ?? CMUX_NOTIFY_TIMEOUT_MS
 	const spawnProcess = options?.spawnProcess ?? spawnCmuxWithBun
+	const cmuxCommand = options?.cmuxCommand ?? "cmux"
 
 	try {
-		const proc = spawnProcess(["cmux", ...buildCmuxNotifyArgs(payload)])
+		const proc = spawnProcess([cmuxCommand, ...commandArgs])
 
 		try {
-			const exitCode = await withTimeout(proc.exited, timeoutMs, "cmux notify timed out")
+			const exitCode = await withTimeout(
+				proc.exited,
+				timeoutMs,
+				`cmux ${commandArgs[0] ?? "command"} timed out`,
+			)
 			return exitCode === 0
 		} catch (error) {
 			if (error instanceof TimeoutError) {
@@ -76,4 +98,31 @@ export async function sendCmuxNotification(
 	} catch {
 		return false
 	}
+}
+
+export async function sendCmuxNotification(
+	payload: CmuxNotificationPayload,
+	options?: CmuxExecutionOptions,
+): Promise<boolean> {
+	return executeCmuxCommand(buildCmuxNotifyArgs(payload), options)
+}
+
+export async function sendCmuxStatus(
+	payload: CmuxStatusPayload,
+	options?: CmuxExecutionOptions,
+): Promise<boolean> {
+	return executeCmuxCommand(buildCmuxStatusArgs(payload), {
+		...options,
+		timeoutMs: options?.timeoutMs ?? CMUX_STATUS_TIMEOUT_MS,
+	})
+}
+
+export async function clearCmuxStatus(
+	payload: CmuxClearStatusPayload,
+	options?: CmuxExecutionOptions,
+): Promise<boolean> {
+	return executeCmuxCommand(buildCmuxClearStatusArgs(payload), {
+		...options,
+		timeoutMs: options?.timeoutMs ?? CMUX_STATUS_TIMEOUT_MS,
+	})
 }

--- a/workers/kdco-registry/files/plugins/notify/status.ts
+++ b/workers/kdco-registry/files/plugins/notify/status.ts
@@ -1,0 +1,83 @@
+type CmuxSessionLogicalState = "animated-busy" | "needs-input" | "error" | "idle"
+
+export type CmuxSessionStatusTransition = {
+	readonly sessionID: string
+	readonly logicalState: CmuxSessionLogicalState
+}
+
+function toNonEmptyString(value: unknown): string | null {
+	if (typeof value !== "string") return null
+
+	const normalized = value.trim()
+	if (!normalized) return null
+
+	return normalized
+}
+
+function toStatusType(properties: Record<string, unknown>): string | null {
+	const status = properties.status
+	if (!status || typeof status !== "object") return null
+
+	const statusType = toNonEmptyString((status as Record<string, unknown>).type)
+	if (!statusType) return null
+
+	return statusType.toLowerCase()
+}
+
+export function buildCmuxSessionStatusTransitionForEvent(
+	eventType: string,
+	properties: Record<string, unknown>,
+): CmuxSessionStatusTransition | null {
+	const sessionID = toNonEmptyString(properties.sessionID)
+	if (!sessionID) return null
+
+	if (
+		eventType === "question.asked" ||
+		eventType === "permission.asked" ||
+		eventType === "permission.updated"
+	) {
+		return { sessionID, logicalState: "needs-input" }
+	}
+
+	if (eventType === "session.idle") {
+		return { sessionID, logicalState: "idle" }
+	}
+
+	if (eventType === "session.error") {
+		return { sessionID, logicalState: "error" }
+	}
+
+	if (eventType !== "session.status") {
+		return null
+	}
+
+	const statusType = toStatusType(properties)
+	if (statusType === "idle") {
+		return { sessionID, logicalState: "idle" }
+	}
+
+	if (statusType === "busy" || statusType === "retry" || statusType === "running") {
+		return { sessionID, logicalState: "animated-busy" }
+	}
+
+	return null
+}
+
+export function buildCmuxSessionStatusTransitionForQuestionTool(
+	sessionID: unknown,
+): CmuxSessionStatusTransition | null {
+	const normalizedSessionID = toNonEmptyString(sessionID)
+	if (!normalizedSessionID) return null
+
+	return {
+		sessionID: normalizedSessionID,
+		logicalState: "needs-input",
+	}
+}
+
+export function getCmuxSessionStatusText(
+	logicalState: Exclude<CmuxSessionLogicalState, "idle" | "animated-busy">,
+): string {
+	if (logicalState === "needs-input") return "Needs input"
+	return "Error"
+}

--- a/workers/kdco-registry/files/plugins/notify/title.ts
+++ b/workers/kdco-registry/files/plugins/notify/title.ts
@@ -1,0 +1,80 @@
+export interface OscTitleContext {
+	readonly mayWriteOscTitle: boolean
+	readonly baseTitle: string
+}
+
+const OCX_TITLE_CONTEXT_ENV_KEY = "OCX_TITLE_CONTEXT"
+const OSC_TITLE_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/g
+
+function toNonEmptyString(value: unknown): string | null {
+	if (typeof value !== "string") {
+		return null
+	}
+
+	const normalized = value.trim()
+	if (!normalized) {
+		return null
+	}
+
+	return normalized
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function parseOscTitleContext(
+	env: Record<string, string | undefined> = process.env,
+): OscTitleContext | null {
+	const rawContext = toNonEmptyString(env[OCX_TITLE_CONTEXT_ENV_KEY])
+	if (!rawContext) {
+		return null
+	}
+
+	let parsedContext: unknown
+	try {
+		parsedContext = JSON.parse(rawContext)
+	} catch {
+		return null
+	}
+
+	if (!isRecord(parsedContext)) {
+		return null
+	}
+
+	if (typeof parsedContext.mayWriteOscTitle !== "boolean") {
+		return null
+	}
+
+	const baseTitle = toNonEmptyString(parsedContext.baseTitle)
+	if (!baseTitle) {
+		return null
+	}
+
+	return {
+		mayWriteOscTitle: parsedContext.mayWriteOscTitle,
+		baseTitle,
+	}
+}
+
+export function sanitizeOscTitleText(title: string): string {
+	return title.replace(OSC_TITLE_CONTROL_CHARACTERS, " ").trim()
+}
+
+export function writeOscTitleBestEffort(
+	title: string,
+	writer: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void {
+	const sanitizedTitle = sanitizeOscTitleText(title)
+	if (!sanitizedTitle) {
+		return
+	}
+
+	queueMicrotask(() => {
+		try {
+			writer.write(`\u001B]0;${sanitizedTitle}\u0007`)
+		} catch {
+			// Best-effort: title ownership belongs to launcher cleanup semantics.
+		}
+	})
+}

--- a/workers/kdco-registry/registry.jsonc
+++ b/workers/kdco-registry/registry.jsonc
@@ -58,7 +58,13 @@
 			"name": "notify",
 			"type": "plugin",
 			"description": "Native OS notifications - get notified when tasks complete",
-			"files": ["plugins/notify.ts", "plugins/notify/backend.ts", "plugins/notify/cmux.ts"],
+			"files": [
+				"plugins/notify.ts",
+				"plugins/notify/backend.ts",
+				"plugins/notify/cmux.ts",
+				"plugins/notify/status.ts",
+				"plugins/notify/title.ts"
+			],
 			"dependencies": ["kdco-primitives"],
 			"npmDevDependencies": ["node-notifier@10.0.1", "detect-terminal@2.0.0"]
 		},

--- a/workers/kdco-registry/tests/notify-cmux.test.ts
+++ b/workers/kdco-registry/tests/notify-cmux.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "bun:test"
 import {
+	buildCmuxClearStatusArgs,
 	buildCmuxNotifyArgs,
+	buildCmuxStatusArgs,
 	canUseCmuxNotification,
+	clearCmuxStatus,
 	sendCmuxNotification,
+	sendCmuxStatus,
 } from "../files/plugins/notify/cmux"
 
 describe("notify cmux integration", () => {
-	it("returns false when CMUX_WORKSPACE_ID is missing", () => {
+	it("returns false when no cmux context is available", () => {
 		const env = { PATH: "/usr/bin" }
 		const canUse = canUseCmuxNotification(env, () => "/usr/local/bin/cmux")
 
@@ -25,6 +29,26 @@ describe("notify cmux integration", () => {
 		const canUse = canUseCmuxNotification(env, () => "/usr/local/bin/cmux")
 
 		expect(canUse).toBe(true)
+	})
+
+	it("returns true when socket allowAll context is available", () => {
+		const env = {
+			CMUX_SOCKET_PATH: " /tmp/cmux.sock ",
+			CMUX_SOCKET_MODE: " allowAll ",
+		}
+		const canUse = canUseCmuxNotification(env, () => "/usr/local/bin/cmux")
+
+		expect(canUse).toBe(true)
+	})
+
+	it("returns false when socket mode does not allow external control", () => {
+		const env = {
+			CMUX_SOCKET_PATH: "/tmp/cmux.sock",
+			CMUX_SOCKET_MODE: "restricted",
+		}
+		const canUse = canUseCmuxNotification(env, () => "/usr/local/bin/cmux")
+
+		expect(canUse).toBe(false)
 	})
 
 	it("builds cmux notify args with subtitle", () => {
@@ -58,6 +82,23 @@ describe("notify cmux integration", () => {
 			"--body",
 			"Timeout while calling API",
 		])
+	})
+
+	it("builds cmux status args", () => {
+		const args = buildCmuxStatusArgs({
+			key: "opencode.session.abc",
+			text: "Needs input",
+		})
+
+		expect(args).toEqual(["set-status", "opencode.session.abc", "Needs input"])
+	})
+
+	it("builds cmux clear status args", () => {
+		const args = buildCmuxClearStatusArgs({
+			key: "opencode.session.abc",
+		})
+
+		expect(args).toEqual(["clear-status", "opencode.session.abc"])
 	})
 
 	it("returns true when cmux exits successfully", async () => {
@@ -105,6 +146,78 @@ describe("notify cmux integration", () => {
 			{
 				title: "Ready",
 				body: "Task complete",
+			},
+			{
+				timeoutMs: 10,
+				spawnProcess: () => ({
+					exited: new Promise<number>(() => {
+						// Simulate hung cmux process
+					}),
+					kill: () => {
+						killed = true
+					},
+				}),
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(killed).toBe(true)
+	})
+
+	it("sendCmuxStatus runs cmux status command", async () => {
+		const commands: string[][] = []
+
+		const sent = await sendCmuxStatus(
+			{
+				key: "opencode.session.abc",
+				text: "Busy",
+			},
+			{
+				spawnProcess: (command) => {
+					commands.push(command)
+					return {
+						exited: Promise.resolve(0),
+					}
+				},
+			},
+		)
+
+		expect(sent).toBe(true)
+		expect(commands).toEqual([
+			["cmux", "set-status", "opencode.session.abc", "Busy"],
+		])
+	})
+
+	it("clearCmuxStatus runs cmux clear status command", async () => {
+		const commands: string[][] = []
+
+		const sent = await clearCmuxStatus(
+			{
+				key: "opencode.session.abc",
+			},
+			{
+				spawnProcess: (command) => {
+					commands.push(command)
+					return {
+						exited: Promise.resolve(0),
+					}
+				},
+			},
+		)
+
+		expect(sent).toBe(true)
+		expect(commands).toEqual([
+			["cmux", "clear-status", "opencode.session.abc"],
+		])
+	})
+
+	it("sendCmuxStatus returns false on timeout and kills process", async () => {
+		let killed = false
+
+		const sent = await sendCmuxStatus(
+			{
+				key: "opencode.session.abc",
+				text: "Needs input",
 			},
 			{
 				timeoutMs: 10,

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import * as fsPromises from "node:fs/promises"
 import type { Event } from "@opencode-ai/sdk"
 
 type SessionInfo = {
@@ -9,12 +10,16 @@ type SessionInfo = {
 let mockedConfig: unknown | undefined
 let mockedTerminalName: string | null = null
 
+const CMUX_BUSY_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const
+const CMUX_BUSY_SPINNER_INTERVAL_MS = 80
+
 const notificationPayloads: Array<Record<string, unknown>> = []
 const notifyMock = mock((payload: Record<string, unknown>) => {
 	notificationPayloads.push(payload)
 })
 
 mock.module("node:fs/promises", () => ({
+	...fsPromises,
 	readFile: async () => {
 		if (mockedConfig === undefined) {
 			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
@@ -46,6 +51,9 @@ beforeEach(() => {
 	notificationPayloads.length = 0
 	notifyMock.mockClear()
 	delete process.env.CMUX_WORKSPACE_ID
+	delete process.env.CMUX_SOCKET_PATH
+	delete process.env.CMUX_SOCKET_MODE
+	delete process.env.OCX_TITLE_CONTEXT
 })
 
 afterEach(() => {
@@ -132,6 +140,15 @@ async function emitQuestionToolBefore(
 		},
 		{},
 	)
+}
+
+function decodeOscTitleWrite(chunk: unknown): string | null {
+	if (typeof chunk !== "string") return null
+
+	const match = /^\u001b\]0;(.*)\u0007$/.exec(chunk)
+	if (!match) return null
+
+	return match[1] ?? null
 }
 
 describe("notify plugin event compatibility and dedupe", () => {
@@ -414,5 +431,1038 @@ describe("notify plugin event compatibility and dedupe", () => {
 		})
 
 		expect(notificationPayloads).toHaveLength(0)
+	})
+
+	it("does not write OSC title when launcher contract disables writes", async () => {
+		process.env.OCX_TITLE_CONTEXT = JSON.stringify({
+			mayWriteOscTitle: false,
+			baseTitle: "ocx[default]:repo/main",
+		})
+
+		const writtenTitles: string[] = []
+		spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			const decodedTitle = decodeOscTitleWrite(chunk)
+			if (decodedTitle) {
+				writtenTitles.push(decodedTitle)
+			}
+			return true
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+		await Bun.sleep(0)
+
+		expect(writtenTitles).toHaveLength(0)
+	})
+
+	it("suppresses cmux status writes when OSC title ownership is active", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+		process.env.OCX_TITLE_CONTEXT = JSON.stringify({
+			mayWriteOscTitle: true,
+			baseTitle: "ocx[default]:repo/main",
+		})
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		spyOn(globalThis, "setInterval").mockImplementation(
+			((() => {
+				return {
+					unref: () => {
+						// no-op
+					},
+				} as ReturnType<typeof setInterval>
+			}) as unknown) as typeof setInterval,
+		)
+		spyOn(globalThis, "clearInterval").mockImplementation((() => {
+			// no-op
+		}) as typeof clearInterval)
+
+		const cmuxCommands: string[][] = []
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const writtenTitles: string[] = []
+		spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			const decodedTitle = decodeOscTitleWrite(chunk)
+			if (decodedTitle) {
+				writtenTitles.push(decodedTitle)
+			}
+			return true
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-1",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+		await Bun.sleep(0)
+
+		const statusCommands = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+
+		expect(statusCommands).toHaveLength(0)
+		expect(cmuxCommands.some((command) => command[1] === "notify")).toBe(true)
+		expect(writtenTitles).toEqual(["⠋ ocx[default]:repo/main", "ocx[default]:repo/main"])
+	})
+
+	it("keeps cmux status fallback when launcher contract disallows OSC title writes", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+		process.env.OCX_TITLE_CONTEXT = JSON.stringify({
+			mayWriteOscTitle: false,
+			baseTitle: "ocx[default]:repo/main",
+		})
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		spyOn(globalThis, "setInterval").mockImplementation(
+			((() => {
+				return {
+					unref: () => {
+						// no-op
+					},
+				} as ReturnType<typeof setInterval>
+			}) as unknown) as typeof setInterval,
+		)
+		spyOn(globalThis, "clearInterval").mockImplementation((() => {
+			// no-op
+		}) as typeof clearInterval)
+
+		const cmuxCommands: string[][] = []
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const writtenTitles: string[] = []
+		spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			const decodedTitle = decodeOscTitleWrite(chunk)
+			if (decodedTitle) {
+				writtenTitles.push(decodedTitle)
+			}
+			return true
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+		await Bun.sleep(0)
+
+		const statusCommands = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+
+		expect(statusCommands).toEqual([
+			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["cmux", "clear-status", "opencode.session.session-a"],
+		])
+		expect(writtenTitles).toHaveLength(0)
+	})
+
+	it("keeps OSC spinner active while any tracked session remains busy", async () => {
+		process.env.OCX_TITLE_CONTEXT = JSON.stringify({
+			mayWriteOscTitle: true,
+			baseTitle: "ocx[default]:repo/main",
+		})
+
+		let tickerCallback: (() => void) | null = null
+		let tickerIntervalMs: number | null = null
+		spyOn(globalThis, "setInterval").mockImplementation(
+			((callback: unknown, ms?: number) => {
+				if (typeof callback !== "function") {
+					throw new Error("Expected title ticker callback to be a function")
+				}
+
+				tickerCallback = callback as () => void
+				tickerIntervalMs = ms ?? null
+
+				return {
+					unref: () => {
+						// no-op
+					},
+				} as ReturnType<typeof setInterval>
+			}) as typeof setInterval,
+		)
+		spyOn(globalThis, "clearInterval").mockImplementation((() => {
+			// no-op
+		}) as typeof clearInterval)
+
+		const writtenTitles: string[] = []
+		spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			const decodedTitle = decodeOscTitleWrite(chunk)
+			if (decodedTitle) {
+				writtenTitles.push(decodedTitle)
+			}
+			return true
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+			"session-b": { title: "Session B" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: { type: "busy" },
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-b",
+				status: { type: "busy" },
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-a",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+		await Bun.sleep(0)
+
+		if (!tickerCallback) {
+			throw new Error("Expected title busy ticker callback to be captured")
+		}
+
+		expect(tickerIntervalMs).toBe(CMUX_BUSY_SPINNER_INTERVAL_MS)
+
+		tickerCallback()
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-b",
+				error: "boom",
+			},
+		})
+		await Bun.sleep(0)
+
+		expect(writtenTitles).toEqual([
+			"⠋ ocx[default]:repo/main",
+			"⠙ ocx[default]:repo/main",
+			"ocx[default]:repo/main",
+		])
+	})
+
+	it("restores base title for non-busy needs-input/error/idle transitions", async () => {
+		process.env.OCX_TITLE_CONTEXT = JSON.stringify({
+			mayWriteOscTitle: true,
+			baseTitle: "ocx[default]:repo/main",
+		})
+
+		spyOn(globalThis, "setInterval").mockImplementation(
+			((() => {
+				return {
+					unref: () => {
+						// no-op
+					},
+				} as ReturnType<typeof setInterval>
+			}) as unknown) as typeof setInterval,
+		)
+		spyOn(globalThis, "clearInterval").mockImplementation((() => {
+			// no-op
+		}) as typeof clearInterval)
+
+		const writtenTitles: string[] = []
+		spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			const decodedTitle = decodeOscTitleWrite(chunk)
+			if (decodedTitle) {
+				writtenTitles.push(decodedTitle)
+			}
+			return true
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: { type: "busy" },
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-a",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: { type: "busy" },
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-a",
+				error: "boom",
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: { type: "busy" },
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+		await Bun.sleep(0)
+
+		expect(writtenTitles).toEqual([
+			"⠋ ocx[default]:repo/main",
+			"ocx[default]:repo/main",
+			"⠋ ocx[default]:repo/main",
+			"ocx[default]:repo/main",
+			"⠋ ocx[default]:repo/main",
+			"ocx[default]:repo/main",
+		])
+	})
+
+	it("keeps title writes best-effort and non-blocking when stdout write fails", async () => {
+		process.env.OCX_TITLE_CONTEXT = JSON.stringify({
+			mayWriteOscTitle: true,
+			baseTitle: "ocx[default]:repo/main",
+		})
+
+		spyOn(globalThis, "setInterval").mockImplementation(
+			((() => {
+				return {
+					unref: () => {
+						// no-op
+					},
+				} as ReturnType<typeof setInterval>
+			}) as unknown) as typeof setInterval,
+		)
+		spyOn(globalThis, "clearInterval").mockImplementation((() => {
+			// no-op
+		}) as typeof clearInterval)
+
+		spyOn(process.stdout, "write").mockImplementation(() => {
+			throw new Error("write failed")
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		const startedAt = Date.now()
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: { type: "busy" },
+			},
+		})
+		const elapsedMs = Date.now() - startedAt
+
+		expect(elapsedMs).toBeLessThan(120)
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+		await Bun.sleep(0)
+	})
+
+	it("emits cmux spinner/Needs input/Error/Idle status transitions when cmux is enabled", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		const cmuxCommands: string[][] = []
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-1",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-a",
+				error: "boom",
+			},
+		})
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+		await Bun.sleep(0)
+
+		const statusCommands = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+
+		expect(statusCommands).toEqual([
+			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["cmux", "set-status", "opencode.session.session-a", "Needs input"],
+			["cmux", "set-status", "opencode.session.session-a", "Error"],
+			["cmux", "clear-status", "opencode.session.session-a"],
+		])
+	})
+
+	it("animates busy cmux status glyphs on deterministic ticker cadence", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		let tickerCallback: (() => void) | null = null
+		let tickerIntervalMs: number | null = null
+		spyOn(globalThis, "setInterval").mockImplementation(
+			((callback: unknown, ms?: number) => {
+				if (typeof callback !== "function") {
+					throw new Error("Expected notify busy ticker callback to be a function")
+				}
+
+				tickerCallback = callback as () => void
+				tickerIntervalMs = ms ?? null
+
+				return {
+					unref: () => {
+						// no-op
+					},
+				} as ReturnType<typeof setInterval>
+			}) as typeof setInterval,
+		)
+		spyOn(globalThis, "clearInterval").mockImplementation((() => {
+			// no-op
+		}) as typeof clearInterval)
+
+		const cmuxCommands: string[][] = []
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+		await Bun.sleep(0)
+
+		if (!tickerCallback) {
+			throw new Error("Expected busy ticker callback to be captured")
+		}
+
+		expect(tickerIntervalMs).toBe(CMUX_BUSY_SPINNER_INTERVAL_MS)
+
+		tickerCallback()
+		await Bun.sleep(0)
+		tickerCallback()
+		await Bun.sleep(0)
+		tickerCallback()
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+		await Bun.sleep(0)
+
+		const statusCommands = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+		const setStatusTexts = statusCommands
+			.filter((command) => command[1] === "set-status")
+			.map((command) => command[3])
+
+		expect(setStatusTexts.slice(0, 4)).toEqual(CMUX_BUSY_SPINNER_FRAMES.slice(0, 4))
+		expect(statusCommands[statusCommands.length - 1]).toEqual([
+			"cmux",
+			"clear-status",
+			"opencode.session.session-a",
+		])
+	})
+
+	it("lets non-busy override win after in-flight busy write completes", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		const cmuxCommands: string[][] = []
+		let shouldDelayFirstStatus = true
+		let resolveFirstStatusExit: ((exitCode: number) => void) | null = null
+
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+
+				if (command[1] === "set-status" && shouldDelayFirstStatus) {
+					shouldDelayFirstStatus = false
+					return {
+						exited: new Promise<number>((resolve) => {
+							resolveFirstStatusExit = resolve
+						}),
+						kill: () => {
+							// no-op
+						},
+					} as ReturnType<typeof Bun.spawn>
+				}
+
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+
+		await Bun.sleep(450)
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-a",
+				error: "boom",
+			},
+		})
+
+		const statusCommandsWhileFirstWriteIsPending = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+		expect(statusCommandsWhileFirstWriteIsPending).toEqual([
+			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+		])
+
+		if (!resolveFirstStatusExit) {
+			throw new Error("Expected delayed cmux status command to be captured")
+		}
+
+		resolveFirstStatusExit(0)
+		await Bun.sleep(0)
+		await Bun.sleep(0)
+
+		const finalStatusCommands = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+		expect(finalStatusCommands).toEqual([
+			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["cmux", "set-status", "opencode.session.session-a", "Error"],
+		])
+	})
+
+	it("coalesces overlapping cmux status transitions so latest state wins", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		const cmuxCommands: string[][] = []
+		let shouldDelayFirstStatus = true
+		let resolveFirstStatusExit: ((exitCode: number) => void) | null = null
+
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+
+				if (command[1] === "set-status" && shouldDelayFirstStatus) {
+					shouldDelayFirstStatus = false
+					return {
+						exited: new Promise<number>((resolve) => {
+							resolveFirstStatusExit = resolve
+						}),
+						kill: () => {
+							// no-op
+						},
+					} as ReturnType<typeof Bun.spawn>
+				}
+
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-1",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-a",
+				error: "boom",
+			},
+		})
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+
+		await Bun.sleep(0)
+
+		const statusCommandsWhileFirstIsPending = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+
+		expect(statusCommandsWhileFirstIsPending).toEqual([
+			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+		])
+
+		if (!resolveFirstStatusExit) {
+			throw new Error("Expected delayed cmux status command to be captured")
+		}
+
+		resolveFirstStatusExit(0)
+		await Bun.sleep(0)
+		await Bun.sleep(0)
+
+		const finalStatusCommands = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+
+		expect(finalStatusCommands).toEqual([
+			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["cmux", "clear-status", "opencode.session.session-a"],
+		])
+	})
+
+	it("constrains status process fan-out before failure resolves and disables future attempts", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		const cmuxCommands: string[][] = []
+		let shouldDelayFirstStatus = true
+		let resolveFirstStatusExit: ((exitCode: number) => void) | null = null
+
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+
+				if (command[1] === "set-status" && shouldDelayFirstStatus) {
+					shouldDelayFirstStatus = false
+					return {
+						exited: new Promise<number>((resolve) => {
+							resolveFirstStatusExit = resolve
+						}),
+						kill: () => {
+							// no-op
+						},
+					} as ReturnType<typeof Bun.spawn>
+				}
+
+				return {
+					exited: Promise.resolve(0),
+					kill: () => {
+						// no-op
+					},
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-1",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-a",
+				error: "boom",
+			},
+		})
+
+		await emitEvent(hooks, {
+			type: "session.idle",
+			properties: {
+				sessionID: "session-a",
+			},
+		})
+
+		await Bun.sleep(0)
+
+		const statusCommandsBeforeFailureResolves = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+		expect(statusCommandsBeforeFailureResolves).toHaveLength(1)
+
+		if (!resolveFirstStatusExit) {
+			throw new Error("Expected delayed cmux status command to be captured")
+		}
+
+		resolveFirstStatusExit(1)
+		await Bun.sleep(0)
+
+		await emitEvent(hooks, {
+			type: "session.status",
+			properties: {
+				sessionID: "session-a",
+				status: {
+					type: "busy",
+				},
+			},
+		})
+		await Bun.sleep(0)
+
+		const statusCommandsAfterFailure = cmuxCommands.filter(
+			(command) => command[1] === "set-status" || command[1] === "clear-status",
+		)
+		expect(statusCommandsAfterFailure).toHaveLength(1)
+	})
+
+	it("does not block question notifications when cmux status update is slow and disables status after failure", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+
+		spyOn(Bun, "which").mockImplementation((command: string) =>
+			command === "cmux" ? "/usr/local/bin/cmux" : null,
+		)
+
+		const cmuxCommands: string[][] = []
+		let firstStatusAttempt = true
+
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && command[0] === "cmux") {
+				cmuxCommands.push(command.map(String))
+
+				if (command[1] === "set-status") {
+					if (firstStatusAttempt) {
+						firstStatusAttempt = false
+						return {
+							exited: new Promise<number>((resolve) => {
+								setTimeout(() => resolve(1), 150)
+							}),
+							kill: () => {
+								// no-op
+							},
+						} as ReturnType<typeof Bun.spawn>
+					}
+
+					return {
+						exited: Promise.resolve(0),
+						kill: () => {
+							// no-op
+						},
+					} as ReturnType<typeof Bun.spawn>
+				}
+
+				if (command[1] === "notify") {
+					return {
+						exited: Promise.resolve(0),
+						kill: () => {
+							// no-op
+						},
+					} as ReturnType<typeof Bun.spawn>
+				}
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		const start = Date.now()
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-1",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+		const elapsedMs = Date.now() - start
+
+		expect(elapsedMs).toBeLessThan(120)
+		expect(cmuxCommands.some((command) => command[1] === "notify")).toBe(true)
+
+		await Bun.sleep(200)
+
+		await emitEvent(hooks, {
+			type: "session.error",
+			properties: {
+				sessionID: "session-a",
+				error: "boom",
+			},
+		})
+		await Bun.sleep(0)
+
+		const statusCommands = cmuxCommands.filter((command) => command[1] === "set-status")
+		expect(statusCommands).toHaveLength(1)
 	})
 })

--- a/workers/kdco-registry/tests/notify-status-state.test.ts
+++ b/workers/kdco-registry/tests/notify-status-state.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test"
+import {
+	buildCmuxSessionStatusTransitionForEvent,
+	buildCmuxSessionStatusTransitionForQuestionTool,
+	getCmuxSessionStatusText,
+} from "../files/plugins/notify/status"
+
+describe("notify cmux session status state mapping", () => {
+	it("maps question tool hook to needs-input", () => {
+		expect(buildCmuxSessionStatusTransitionForQuestionTool(" session-a ")).toEqual({
+			sessionID: "session-a",
+			logicalState: "needs-input",
+		})
+	})
+
+	it("maps question and permission events to needs-input", () => {
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("question.asked", {
+				sessionID: "session-a",
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "needs-input",
+		})
+
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("permission.asked", {
+				sessionID: "session-a",
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "needs-input",
+		})
+
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("permission.updated", {
+				sessionID: "session-a",
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "needs-input",
+		})
+	})
+
+	it("returns null for permission.updated without session ID", () => {
+		expect(buildCmuxSessionStatusTransitionForEvent("permission.updated", {})).toBeNull()
+	})
+
+	it("maps idle and animated busy session.status transitions", () => {
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.status", {
+				sessionID: "session-a",
+				status: { type: "idle" },
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "idle",
+		})
+
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.status", {
+				sessionID: "session-a",
+				status: { type: "busy" },
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "animated-busy",
+		})
+
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.status", {
+				sessionID: "session-a",
+				status: { type: "retry" },
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "animated-busy",
+		})
+	})
+
+	it("keeps legacy running alias mapped to animated busy", () => {
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.status", {
+				sessionID: "session-a",
+				status: { type: "running" },
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "animated-busy",
+		})
+	})
+
+	it("ignores unsupported session.status values", () => {
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.status", {
+				sessionID: "session-a",
+				status: { type: "paused" },
+			}),
+		).toBeNull()
+	})
+
+	it("maps session.error and session.idle", () => {
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.error", {
+				sessionID: "session-a",
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "error",
+		})
+
+		expect(
+			buildCmuxSessionStatusTransitionForEvent("session.idle", {
+				sessionID: "session-a",
+			}),
+		).toEqual({
+			sessionID: "session-a",
+			logicalState: "idle",
+		})
+	})
+
+	it("maps non-busy cmux status levels to stable text", () => {
+		expect(getCmuxSessionStatusText("needs-input")).toBe("Needs input")
+		expect(getCmuxSessionStatusText("error")).toBe("Error")
+	})
+})


### PR DESCRIPTION
## Summary
- add codex-aligned terminal title context handling in CLI launch flow and wire `OCX_TITLE_CONTEXT` through runtime boundaries
- extend notify plugin cmux status/title handling with sanitization, deterministic busy-state transitions, and suppression of cmux status writes when OSC title ownership is active
- sync registry/runtime plugin assets (`notify/status.ts`, `notify/title.ts`) and expand notify/cmux/terminal-title test coverage for new behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns terminal title ownership between the CLI and runtime. Adds `OCX_TITLE_CONTEXT` and cmux session status integration with safe OSC writes, animated busy states, and suppression when OSC title is owned.

- **New Features**
  - CLI exports `OCX_TITLE_CONTEXT` with `mayWriteOscTitle` and `baseTitle`; centralizes `canWriteOscTerminalTitle()` and sanitizes OSC title payloads.
  - Notify plugin reads `OCX_TITLE_CONTEXT`; when allowed, writes a spinner to the terminal title during busy and restores the base title on needs-input/error/idle.
  - Suppresses cmux status writes when OSC title ownership is active; otherwise uses `cmux set-status`/`clear-status` with animated busy glyphs and stable texts (“Needs input”, “Error”).
  - Adds cmux status helpers and a deterministic ticker, coalesces writes, and disables cmux updates on failure; title writes are best-effort and non-blocking. Expanded tests and registry asset sync.

- **Bug Fixes**
  - Skip git probing when `--no-rename` to avoid requiring `git` and ensure launches succeed without it.

<sup>Written for commit 7bfaf498b562125b8d6729353253ef6e67697749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

