### PR TITLE
fix(cli): Restore Windows standalone binary output and add smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,7 @@ jobs:
             ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
       - name: Build Windows binaries
-        run: |
-          bun run scripts/build-binary.ts --target=windows-x64
-          bun run scripts/build-binary.ts --target=windows-x64-baseline
+        run: bun run build:binary:windows
         working-directory: packages/cli
       - name: Upload Windows binary artifacts
         uses: actions/upload-artifact@v6
@@ -133,23 +131,8 @@ jobs:
         with:
           name: ocx-windows-binaries
           path: packages/cli/dist/bin
-      - name: Exercise Windows binaries in PowerShell
-        run: |
-          .\packages\cli\dist\bin\ocx-windows-x64.exe --version
-          .\packages\cli\dist\bin\ocx-windows-x64.exe --help
-          .\packages\cli\dist\bin\ocx-windows-x64.exe help
-          .\packages\cli\dist\bin\ocx-windows-x64.exe
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
-      - name: Exercise Windows baseline binary in cmd.exe
-        run: |
-          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
-          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
-      - name: Assert Windows binary smoke output
-        run: bun test tests/binary-smoke.test.ts
+      - name: Run Windows binary smoke tests
+        run: bun run test:binary-smoke
         working-directory: packages/cli
         env:
-          OCX_DIST_TESTS: "1"
           OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe;${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64-baseline.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
           files: packages/cli/junit.xml
           report_type: test_results
 
-  windows-binary-smoke:
-    name: Windows Binary Smoke
-    runs-on: windows-latest
+  build-windows-binaries:
+    name: Build Windows Binaries
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -97,19 +97,59 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
-      - name: Build Windows binary
+      - name: Build Windows binaries
         run: |
           bun run scripts/build-binary.ts --target=windows-x64
+          bun run scripts/build-binary.ts --target=windows-x64-baseline
         working-directory: packages/cli
-      - name: Exercise Windows binary in PowerShell
+      - name: Upload Windows binary artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ocx-windows-binaries
+          path: packages/cli/dist/bin/ocx-windows-x64*.exe
+          if-no-files-found: error
+
+  windows-binary-smoke:
+    name: Windows Binary Smoke
+    runs-on: windows-latest
+    needs: build-windows-binaries
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            .turbo
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - name: Download Windows binary artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: ocx-windows-binaries
+          path: packages/cli/dist/bin
+      - name: Exercise Windows binaries in PowerShell
         run: |
           .\packages\cli\dist\bin\ocx-windows-x64.exe --version
           .\packages\cli\dist\bin\ocx-windows-x64.exe --help
           .\packages\cli\dist\bin\ocx-windows-x64.exe help
           .\packages\cli\dist\bin\ocx-windows-x64.exe
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
+      - name: Exercise Windows baseline binary in cmd.exe
+        run: |
+          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
+          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
       - name: Assert Windows binary smoke output
         run: bun test tests/binary-smoke.test.ts
         working-directory: packages/cli
         env:
           OCX_DIST_TESTS: "1"
-          OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe
+          OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe;${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64-baseline.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,28 +97,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
-      - name: Build Windows binaries
+      - name: Build Windows binary
         run: |
           bun run scripts/build-binary.ts --target=windows-x64
-          bun run scripts/build-binary.ts --target=windows-x64-baseline
         working-directory: packages/cli
-      - name: Exercise Windows binaries in PowerShell
+      - name: Exercise Windows binary in PowerShell
         run: |
           .\packages\cli\dist\bin\ocx-windows-x64.exe --version
           .\packages\cli\dist\bin\ocx-windows-x64.exe --help
           .\packages\cli\dist\bin\ocx-windows-x64.exe help
           .\packages\cli\dist\bin\ocx-windows-x64.exe
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
-      - name: Exercise Windows baseline binary in cmd.exe
-        run: |
-          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
-          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
       - name: Assert Windows binary smoke output
         run: bun test tests/binary-smoke.test.ts
         working-directory: packages/cli
         env:
           OCX_DIST_TESTS: "1"
-          OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe;${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
+          OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,47 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/cli/junit.xml
           report_type: test_results
+
+  windows-binary-smoke:
+    name: Windows Binary Smoke
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            .turbo
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - name: Build Windows binaries
+        run: |
+          bun run scripts/build-binary.ts --target=windows-x64
+          bun run scripts/build-binary.ts --target=windows-x64-baseline
+        working-directory: packages/cli
+      - name: Exercise Windows binaries in PowerShell
+        run: |
+          .\packages\cli\dist\bin\ocx-windows-x64.exe --version
+          .\packages\cli\dist\bin\ocx-windows-x64.exe --help
+          .\packages\cli\dist\bin\ocx-windows-x64.exe help
+          .\packages\cli\dist\bin\ocx-windows-x64.exe
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
+      - name: Exercise Windows baseline binary in cmd.exe
+        run: |
+          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
+          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
+      - name: Assert Windows binary smoke output
+        run: bun test tests/binary-smoke.test.ts
+        working-directory: packages/cli
+        env:
+          OCX_DIST_TESTS: "1"
+          OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe;${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64-baseline.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: packages/cli
 
       - name: Build binaries
-        run: bun run scripts/build-binary.ts --all
+        run: bun run build:binary:all
         working-directory: packages/cli
 
       - name: Upload binary artifacts
@@ -63,27 +63,10 @@ jobs:
           name: ocx-binaries
           path: packages/cli/dist/bin
 
-      - name: Exercise release Windows binaries in PowerShell
-        run: |
-          .\packages\cli\dist\bin\ocx-windows-x64.exe --version
-          .\packages\cli\dist\bin\ocx-windows-x64.exe --help
-          .\packages\cli\dist\bin\ocx-windows-x64.exe help
-          .\packages\cli\dist\bin\ocx-windows-x64.exe
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
-          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
-
-      - name: Exercise release Windows baseline binary in cmd.exe
-        run: |
-          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
-          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
-
-      - name: Assert release Windows binary smoke output
-        run: bun test tests/binary-smoke.test.ts
+      - name: Run release Windows binary smoke tests
+        run: bun run test:binary-smoke
         working-directory: packages/cli
         env:
-          OCX_DIST_TESTS: "1"
           OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe;${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,83 @@ permissions:
   pull-requests: read  # Required for git-cliff PR metadata/avatars
 
 jobs:
-  release:
+  build-artifacts:
     runs-on: ubuntu-latest
     # Guards: only run on main repo, skip prereleases (v1.4.0-rc.1)
     if: github.repository == 'kdcokenny/ocx' && !contains(github.ref_name, '-')
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate
+        run: bun run check && bun run test
+
+      - name: Build CLI
+        run: bun run build
+        working-directory: packages/cli
+
+      - name: Build binaries
+        run: bun run scripts/build-binary.ts --all
+        working-directory: packages/cli
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ocx-binaries
+          path: packages/cli/dist/bin/ocx-*
+          if-no-files-found: error
+
+  smoke-windows-artifacts:
+    runs-on: windows-latest
+    needs: build-artifacts
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: ocx-binaries
+          path: packages/cli/dist/bin
+
+      - name: Exercise release Windows binaries in PowerShell
+        run: |
+          .\packages\cli\dist\bin\ocx-windows-x64.exe --version
+          .\packages\cli\dist\bin\ocx-windows-x64.exe --help
+          .\packages\cli\dist\bin\ocx-windows-x64.exe help
+          .\packages\cli\dist\bin\ocx-windows-x64.exe
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
+          .\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
+
+      - name: Exercise release Windows baseline binary in cmd.exe
+        run: |
+          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
+          cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
+
+      - name: Assert release Windows binary smoke output
+        run: bun test tests/binary-smoke.test.ts
+        working-directory: packages/cli
+        env:
+          OCX_DIST_TESTS: "1"
+          OCX_BINARY_SMOKE_TARGETS: ${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64.exe;${{ github.workspace }}\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
+
+  release:
+    runs-on: ubuntu-latest
+    needs: smoke-windows-artifacts
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,9 +123,11 @@ jobs:
         run: bun run build
         working-directory: packages/cli
 
-      - name: Build binaries
-        run: bun run scripts/build-binary.ts --all
-        working-directory: packages/cli
+      - name: Download smoke-tested binary artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: ocx-binaries
+          path: packages/cli/dist/bin
 
       - name: Generate checksums
         run: |

--- a/docs/MANUAL_TESTING.md
+++ b/docs/MANUAL_TESTING.md
@@ -47,7 +47,7 @@ This document provides a complete testing checklist for OCX. Use it to verify fu
 
 - **Performance benchmarking** - Not covered by manual testing
 - **Load testing** - Not applicable to CLI tool
-- **Windows-specific testing** - Focus on macOS (primary platform)
+- **Full Windows feature testing** - Focus on macOS (primary platform), with release-critical standalone Windows smoke checks covered below
 - **Automated integration tests** - See `packages/cli/tests/`
 
 ---
@@ -176,6 +176,31 @@ continuing registry-dependent tests.
 
 > **REMINDER:** If a registry server died during testing, restart it with `bun run dev`
 > (port 8787 for KDCO, port 8788 for Kit) before resuming tests.
+
+### Windows Standalone Binary Validation
+
+Before publishing a release, validate the exact Windows standalone artifacts from
+`packages/cli/dist/bin` on Windows:
+
+```powershell
+.\packages\cli\dist\bin\ocx-windows-x64.exe --version
+.\packages\cli\dist\bin\ocx-windows-x64.exe --help
+.\packages\cli\dist\bin\ocx-windows-x64.exe help
+.\packages\cli\dist\bin\ocx-windows-x64.exe
+.\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version
+.\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --help
+.\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help
+.\packages\cli\dist\bin\ocx-windows-x64-baseline.exe
+cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe --version"
+cmd.exe /c ".\packages\cli\dist\bin\ocx-windows-x64-baseline.exe help"
+```
+
+Expected: each command exits `0`; `--version` prints the package semver without
+required-argument errors; `--help` and `help` print `Usage:` and `ocx`; no-arg
+execution prints non-empty help/usage text; stderr has no unhandled exception or
+stack trace. If Bun standalone compilation regresses, do not publish the
+binaries; publish npm only if needed and document Windows users should install
+via npm until compiled artifacts pass the smoke checks.
 
 ### Verify Dev Build
 

--- a/docs/MANUAL_TESTING.md
+++ b/docs/MANUAL_TESTING.md
@@ -182,6 +182,29 @@ continuing registry-dependent tests.
 Before publishing a release, validate the exact Windows standalone artifacts from
 `packages/cli/dist/bin` on Windows:
 
+```bash
+cd "$OCX_REPO/packages/cli"
+bun run build:binary:windows
+bun run test:binary-smoke
+```
+
+For full release artifact validation, build every target before running the same
+smoke command:
+
+```bash
+cd "$OCX_REPO/packages/cli"
+bun run build:binary:all
+bun run test:binary-smoke
+```
+
+The Windows smoke suite validates both standalone artifact names:
+
+- `ocx-windows-x64.exe`
+- `ocx-windows-x64-baseline.exe`
+
+On Windows, the automated smoke command executes both `.exe` artifacts. The
+equivalent manual commands are:
+
 ```powershell
 .\packages\cli\dist\bin\ocx-windows-x64.exe --version
 .\packages\cli\dist\bin\ocx-windows-x64.exe --help

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,13 +39,16 @@
 	"scripts": {
 		"build": "bun run scripts/build.ts",
 		"build:binary": "bun run scripts/build-binary.ts",
+		"build:binary:all": "bun run scripts/build-binary.ts --all",
+		"build:binary:windows": "bun run scripts/build-binary.ts --target=windows-x64 && bun run scripts/build-binary.ts --target=windows-x64-baseline",
 		"release:tag": "bun run scripts/release-tag.ts",
 		"check": "bun check:biome && bun check:types",
 		"check:biome": "biome check .",
 		"check:types": "tsc --noEmit",
 		"dev": "bun run src/index.ts",
 		"prepublishOnly": "bun run build",
-		"test": "bun test"
+		"test": "bun test",
+		"test:binary-smoke": "OCX_DIST_TESTS=1 bun test tests/binary-smoke.test.ts"
 	},
 	"dependencies": {
 		"commander": "^14.0.3",

--- a/packages/cli/scripts/build-binary.ts
+++ b/packages/cli/scripts/build-binary.ts
@@ -36,7 +36,7 @@ async function buildBinary(build: { name: string; target: Bun.Build.Target }) {
 	console.log(`Building ${build.target}...`)
 
 	const result = await Bun.build({
-		entrypoints: ["./src/index.ts"],
+		entrypoints: ["./src/cli/launcher.ts"],
 		compile: {
 			target: build.target,
 			outfile: outfile,

--- a/packages/cli/src/cli/bootstrap.ts
+++ b/packages/cli/src/cli/bootstrap.ts
@@ -50,7 +50,7 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
 	registerUpdateCheckHook(program)
 
 	if (argv.length <= 2) {
-		program.outputHelp()
+		process.stdout.write(program.helpInformation())
 		return
 	}
 

--- a/packages/cli/src/cli/bootstrap.ts
+++ b/packages/cli/src/cli/bootstrap.ts
@@ -49,5 +49,10 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
 	// Register update check hook (runs after each command)
 	registerUpdateCheckHook(program)
 
+	if (argv.length <= 2) {
+		program.outputHelp()
+		return
+	}
+
 	await program.parseAsync(argv)
 }

--- a/packages/cli/src/cli/entrypoint.ts
+++ b/packages/cli/src/cli/entrypoint.ts
@@ -1,0 +1,10 @@
+import { handleError } from "../utils/handle-error"
+import { runCli } from "./bootstrap"
+
+export async function runCliEntryPoint(argv: string[] = process.argv): Promise<void> {
+	try {
+		await runCli(argv)
+	} catch (error) {
+		handleError(error)
+	}
+}

--- a/packages/cli/src/cli/launcher.ts
+++ b/packages/cli/src/cli/launcher.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S bun --no-env-file
+
+import { handleError } from "../utils/handle-error"
+import { runCli } from "./bootstrap"
+
+try {
+	await runCli(process.argv)
+} catch (error) {
+	handleError(error)
+}

--- a/packages/cli/src/cli/launcher.ts
+++ b/packages/cli/src/cli/launcher.ts
@@ -1,10 +1,5 @@
 #!/usr/bin/env -S bun --no-env-file
 
-import { handleError } from "../utils/handle-error"
-import { runCli } from "./bootstrap"
+import { runCliEntryPoint } from "./entrypoint"
 
-try {
-	await runCli(process.argv)
-} catch (error) {
-	handleError(error)
-}
+await runCliEntryPoint()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,13 +5,8 @@ if (import.meta.main) {
 }
 
 async function runCliEntryPoint(): Promise<void> {
-	try {
-		const { runCli } = await import("./cli/bootstrap")
-		await runCli()
-	} catch (error) {
-		const { handleError } = await import("./utils/handle-error")
-		handleError(error)
-	}
+	const { runCliEntryPoint: runCli } = await import("./cli/entrypoint")
+	await runCli()
 }
 
 export {

--- a/packages/cli/tests/binary-smoke.test.ts
+++ b/packages/cli/tests/binary-smoke.test.ts
@@ -1,13 +1,13 @@
 /**
  * Smoke tests against compiled standalone binaries.
  *
- * Prerequisites: Run `bun run scripts/build-binary.ts` first, or pass explicit
- * targets with OCX_BINARY_SMOKE_TARGETS separated by path.delimiter.
- * To run: OCX_DIST_TESTS=1 bun test tests/binary-smoke.test.ts
+ * Prerequisites: Run `bun run build:binary:all` first, or pass explicit targets
+ * with OCX_BINARY_SMOKE_TARGETS separated by path.delimiter.
+ * To run: bun run test:binary-smoke
  */
 import { describe, expect, it } from "bun:test"
 import { existsSync, readFileSync } from "node:fs"
-import { delimiter, join } from "node:path"
+import { basename, delimiter, join } from "node:path"
 
 interface SmokeTarget {
 	label: string
@@ -21,34 +21,45 @@ const REQUIRED_ERROR_TEXT = /required|missing required/i
 const UNHANDLED_ERROR_TEXT = /(?:unhandled|uncaught|exception|\n\s*at\s+)/i
 
 const packageVersion = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")).version as string
+const WINDOWS_BINARY_NAMES = ["ocx-windows-x64.exe", "ocx-windows-x64-baseline.exe"] as const
 
 function getDefaultBinaryName(): string {
-	if (process.platform === "win32") return "ocx-windows-x64-baseline.exe"
 	if (process.platform === "darwin" && process.arch === "arm64") return "ocx-darwin-arm64"
 	if (process.platform === "darwin") return "ocx-darwin-x64"
 	if (process.platform === "linux" && process.arch === "arm64") return "ocx-linux-arm64"
 	return "ocx-linux-x64"
 }
 
+function getWindowsSmokeTargets(): SmokeTarget[] {
+	return WINDOWS_BINARY_NAMES.map((name) => ({
+		label: name,
+		path: join(DIST_BIN_DIR, name),
+	}))
+}
+
 function getSmokeTargets(): SmokeTarget[] {
 	const explicitTargets = process.env.OCX_BINARY_SMOKE_TARGETS
 	if (explicitTargets) {
-		return explicitTargets.split(delimiter).map((targetPath) => ({
-			label: targetPath,
-			path: targetPath,
-		}))
+		return explicitTargets
+			.split(delimiter)
+			.filter(Boolean)
+			.map((targetPath) => ({
+				label: basename(targetPath),
+				path: targetPath,
+			}))
+	}
+
+	if (process.platform === "win32") {
+		return getWindowsSmokeTargets()
 	}
 
 	const defaultPath = join(DIST_BIN_DIR, getDefaultBinaryName())
-	if (existsSync(defaultPath)) {
-		return [{ label: defaultPath, path: defaultPath }]
-	}
+	const defaultTargets = existsSync(defaultPath)
+		? [{ label: basename(defaultPath), path: defaultPath }]
+		: []
+	const windowsTargets = getWindowsSmokeTargets().filter((target) => existsSync(target.path))
 
-	const windowsTargets = ["ocx-windows-x64.exe", "ocx-windows-x64-baseline.exe"]
-		.map((name) => join(DIST_BIN_DIR, name))
-		.filter((targetPath) => existsSync(targetPath))
-
-	return windowsTargets.map((targetPath) => ({ label: targetPath, path: targetPath }))
+	return [...defaultTargets, ...windowsTargets]
 }
 
 function runBinary(binaryPath: string, args: string[] = []) {
@@ -75,6 +86,20 @@ function expectHelpOutput(result: ReturnType<typeof runBinary>): void {
 	expect(stderr).not.toMatch(UNHANDLED_ERROR_TEXT)
 }
 
+function assertBinaryExists(target: SmokeTarget): void {
+	if (existsSync(target.path)) return
+
+	throw new Error(
+		`Missing compiled binary for smoke target ${target.label} at ${target.path}. Run bun run build:binary:all or bun run build:binary:windows before bun run test:binary-smoke.`,
+	)
+}
+
+function canExecuteSmokeTarget(target: SmokeTarget): boolean {
+	if (process.platform === "win32") return true
+
+	return !target.path.toLowerCase().endsWith(".exe")
+}
+
 ;(SKIP ? describe.skip : describe)("compiled binary smoke", () => {
 	const smokeTargets = getSmokeTargets()
 
@@ -84,8 +109,20 @@ function expectHelpOutput(result: ReturnType<typeof runBinary>): void {
 
 	for (const target of smokeTargets) {
 		describe(target.label, () => {
-			it("prints version", () => {
-				expect(existsSync(target.path)).toBe(true)
+			const runExecutableTest = canExecuteSmokeTarget(target) ? it : it.skip
+
+			it("exists before smoke execution", () => {
+				assertBinaryExists(target)
+			})
+
+			if (!canExecuteSmokeTarget(target)) {
+				it.skip(
+					`${target.label} execution requires a Windows runner; CI release smoke executes this .exe on windows-latest`,
+				)
+			}
+
+			runExecutableTest("prints version", () => {
+				assertBinaryExists(target)
 
 				const result = runBinary(target.path, ["--version"])
 				const stdout = outputText(result.stdout)
@@ -98,17 +135,17 @@ function expectHelpOutput(result: ReturnType<typeof runBinary>): void {
 				expect(stderr).not.toMatch(UNHANDLED_ERROR_TEXT)
 			})
 
-			it("prints help", () => {
+			runExecutableTest("prints help", () => {
 				const result = runBinary(target.path, ["--help"])
 				expectHelpOutput(result)
 			})
 
-			it("prints help subcommand", () => {
+			runExecutableTest("prints help subcommand", () => {
 				const result = runBinary(target.path, ["help"])
 				expectHelpOutput(result)
 			})
 
-			it("prints no-argument help", () => {
+			runExecutableTest("prints no-argument help", () => {
 				const result = runBinary(target.path)
 				const stdout = outputText(result.stdout)
 				const stderr = outputText(result.stderr)

--- a/packages/cli/tests/binary-smoke.test.ts
+++ b/packages/cli/tests/binary-smoke.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Smoke tests against compiled standalone binaries.
+ *
+ * Prerequisites: Run `bun run scripts/build-binary.ts` first, or pass explicit
+ * targets with OCX_BINARY_SMOKE_TARGETS separated by path.delimiter.
+ * To run: OCX_DIST_TESTS=1 bun test tests/binary-smoke.test.ts
+ */
+import { describe, expect, it } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import { delimiter, join } from "node:path"
+
+interface SmokeTarget {
+	label: string
+	path: string
+}
+
+const DIST_BIN_DIR = join(import.meta.dir, "../dist/bin")
+const PACKAGE_JSON = join(import.meta.dir, "../package.json")
+const SKIP = process.env.OCX_DIST_TESTS !== "1"
+const REQUIRED_ERROR_TEXT = /required|missing required/i
+const UNHANDLED_ERROR_TEXT = /(?:unhandled|uncaught|exception|\n\s*at\s+)/i
+
+const packageVersion = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")).version as string
+
+function getDefaultBinaryName(): string {
+	if (process.platform === "win32") return "ocx-windows-x64-baseline.exe"
+	if (process.platform === "darwin" && process.arch === "arm64") return "ocx-darwin-arm64"
+	if (process.platform === "darwin") return "ocx-darwin-x64"
+	if (process.platform === "linux" && process.arch === "arm64") return "ocx-linux-arm64"
+	return "ocx-linux-x64"
+}
+
+function getSmokeTargets(): SmokeTarget[] {
+	const explicitTargets = process.env.OCX_BINARY_SMOKE_TARGETS
+	if (explicitTargets) {
+		return explicitTargets.split(delimiter).map((targetPath) => ({
+			label: targetPath,
+			path: targetPath,
+		}))
+	}
+
+	const defaultPath = join(DIST_BIN_DIR, getDefaultBinaryName())
+	if (existsSync(defaultPath)) {
+		return [{ label: defaultPath, path: defaultPath }]
+	}
+
+	const windowsTargets = ["ocx-windows-x64.exe", "ocx-windows-x64-baseline.exe"]
+		.map((name) => join(DIST_BIN_DIR, name))
+		.filter((targetPath) => existsSync(targetPath))
+
+	return windowsTargets.map((targetPath) => ({ label: targetPath, path: targetPath }))
+}
+
+function runBinary(binaryPath: string, args: string[] = []) {
+	return Bun.spawnSync([binaryPath, ...args], {
+		cwd: DIST_BIN_DIR,
+		stderr: "pipe",
+		stdout: "pipe",
+	})
+}
+
+function outputText(output: Buffer | Uint8Array | null): string {
+	if (!output) return ""
+	return new TextDecoder().decode(output)
+}
+
+function expectHelpOutput(result: ReturnType<typeof runBinary>): void {
+	const stdout = outputText(result.stdout)
+	const stderr = outputText(result.stderr)
+
+	expect(result.exitCode).toBe(0)
+	expect(stdout.length).toBeGreaterThan(0)
+	expect(stdout).toContain("Usage:")
+	expect(stdout).toContain("ocx")
+	expect(stderr).not.toMatch(UNHANDLED_ERROR_TEXT)
+}
+
+;(SKIP ? describe.skip : describe)("compiled binary smoke", () => {
+	const smokeTargets = getSmokeTargets()
+
+	it("finds at least one compiled binary target", () => {
+		expect(smokeTargets.length).toBeGreaterThan(0)
+	})
+
+	for (const target of smokeTargets) {
+		describe(target.label, () => {
+			it("prints version", () => {
+				expect(existsSync(target.path)).toBe(true)
+
+				const result = runBinary(target.path, ["--version"])
+				const stdout = outputText(result.stdout)
+				const stderr = outputText(result.stderr)
+
+				expect(result.exitCode).toBe(0)
+				expect(stdout).toContain(packageVersion)
+				expect(stdout).toMatch(/\d+\.\d+\.\d+/)
+				expect(stdout).not.toMatch(REQUIRED_ERROR_TEXT)
+				expect(stderr).not.toMatch(UNHANDLED_ERROR_TEXT)
+			})
+
+			it("prints help", () => {
+				const result = runBinary(target.path, ["--help"])
+				expectHelpOutput(result)
+			})
+
+			it("prints help subcommand", () => {
+				const result = runBinary(target.path, ["help"])
+				expectHelpOutput(result)
+			})
+
+			it("prints no-argument help", () => {
+				const result = runBinary(target.path)
+				const stdout = outputText(result.stdout)
+				const stderr = outputText(result.stderr)
+
+				expect(result.exitCode).toBe(0)
+				expect(stdout.length).toBeGreaterThan(0)
+				expect(stdout).toMatch(/Usage:|help/i)
+				expect(stderr).not.toMatch(UNHANDLED_ERROR_TEXT)
+			})
+		})
+	}
+})


### PR DESCRIPTION
## Summary
- Add a dedicated compiled-binary launcher that awaits `runCli(process.argv)` and routes failures through existing error handling.
- Update CLI no-arg behavior to print help and exit successfully, with artifact-level smoke coverage for `--version`, `--help`, `help`, and no-arg invocation.
- Gate CI and releases on Windows standalone executable smoke checks, and publish the same smoke-tested binary artifact set.

## Fixes
Fixes #194

## Validation
- Root `bun run check`: PASS
- Root `bun run build`: PASS
- Root `bun run test`: PASS (`1349 pass`, `11 skip`, `0 fail`)
- CLI `bun run check`: PASS
- CLI `bun run build`: PASS
- CLI `bun run scripts/build-binary.ts --all`: PASS
- CLI `OCX_DIST_TESTS=1 bun test tests/binary-smoke.test.ts`: PASS (`5 pass`, `0 fail`)

## Notes
- Windows `.exe` runtime proof is expected from PR CI `windows-latest` smoke job.
- Unrelated local `.opencode/` and `workers/kdco-registry/*` changes were excluded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Windows standalone CLI binaries with a compiled launcher and correct no-arg behavior (prints help, exits 0). CI and release now smoke-test the exact Windows artifacts and publish the same smoke-tested binaries. Fixes #194.

- **Bug Fixes**
  - Add compiled launcher `src/cli/launcher.ts` and entrypoint `src/cli/entrypoint.ts` that await `runCli(process.argv)` and route errors via `handleError`.
  - Show help and exit 0 with no args in `runCli`.
  - Build from `src/cli/launcher.ts`; Windows `ocx-windows-x64.exe` and `ocx-windows-x64-baseline.exe` pass `--version`, `--help`, `help`, and no-arg checks.

- **New Features**
  - Add artifact-level binary smoke tests (`packages/cli/tests/binary-smoke.test.ts`) and Windows validation steps in docs.
  - CI: build Windows binaries on `ubuntu-latest`, upload them, then smoke-test on `windows-latest` via `bun run test:binary-smoke` using `OCX_BINARY_SMOKE_TARGETS`.
  - Release: split build and Windows smoke jobs; publish by downloading the same smoke-tested artifacts.

<sup>Written for commit 32b90b88ee7374ce6fba426486eddcc75c5ba52b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

