### PR TITLE
fix(cli): Clarify Bun runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ npm install -g ocx
 
 The install script handles PATH configuration automatically or prints instructions if manual setup is needed.
 
+The npm package runs with Bun at runtime. Make sure `bun` is available on your `PATH` before using `npm install -g ocx`; Node.js alone is not sufficient. If you do not have Bun, use the standalone binaries from the install script or GitHub Releases when available.
+
 ## Quick Start
 
 Work in any repo without modifying it. Your config, their code.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -27,6 +27,8 @@ Use npm if you prefer a package-manager-based install or are on Windows:
 npm install -g ocx
 ```
 
+The npm-installed CLI requires Bun on your `PATH` at runtime. Node.js alone is not sufficient. If you do not have Bun installed, use the standalone binaries from the install script or GitHub Releases when available.
+
 ## Verify Your Installation
 
 After installing, confirm OCX is available:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
 		"registry"
 	],
 	"engines": {
-		"node": ">=18"
+		"bun": ">=1.2.0"
 	},
 	"scripts": {
 		"build": "bun run scripts/build.ts",


### PR DESCRIPTION
### Summary
Align package metadata and docs with the actual runtime requirement for the npm-installed CLI. The CLI now declares Bun as the runtime engine, and the README plus installation guide clarify that Bun must be available on `PATH` when installing via npm. Node.js alone is not sufficient; standalone binaries remain the alternative for users who do not want Bun installed.

### Fixes
Fixes #193

### Validation
- `bun install --frozen-lockfile`
- `bun run check`
- `bun run build`

### Notes
- Scope is metadata/docs only; no Node compatibility shim is added.
- Reviewed and approved before PR creation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare `bun` as the required runtime for the npm-installed CLI and update docs to state Bun must be on PATH; Node.js alone is not enough. Updates `engines` in `packages/cli/package.json` to `bun >=1.2.0` and points users without Bun to standalone binaries.

<sup>Written for commit 9ea3e55d9068cd751e346f59657830b24a5ce8a1. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

