### PR TITLE
docs: Fix opencode-notify manual install list

### DIFF
--- a/facades/opencode-notify/README.md
+++ b/facades/opencode-notify/README.md
@@ -132,16 +132,26 @@ Ghostty, Kitty, iTerm2, WezTerm, Alacritty, Hyper, Terminal.app, Windows Termina
 
 ## Manual Installation
 
-If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` and preserve the multi-file layout:
+If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` and preserve the exact multi-file layout shown below:
 
 - `.opencode/plugins/notify.ts`
 - `.opencode/plugins/notify/backend.ts`
 - `.opencode/plugins/notify/cmux.ts`
+- `.opencode/plugins/notify/status.ts`
+- `.opencode/plugins/notify/title.ts`
+- `.opencode/plugins/worktree/terminal.ts`
+- `.opencode/plugins/kdco-primitives/index.ts`
+- `.opencode/plugins/kdco-primitives/get-project-id.ts`
+- `.opencode/plugins/kdco-primitives/log-warn.ts`
+- `.opencode/plugins/kdco-primitives/mutex.ts`
+- `.opencode/plugins/kdco-primitives/shell.ts`
+- `.opencode/plugins/kdco-primitives/temp.ts`
+- `.opencode/plugins/kdco-primitives/terminal-detect.ts`
 - `.opencode/plugins/kdco-primitives/types.ts`
 - `.opencode/plugins/kdco-primitives/with-timeout.ts`
 
 **Caveats:**
-- Manually install dependencies (`node-notifier`, `detect-terminal`)
+- Manually install dependencies (`node-notifier`, `detect-terminal`, `zod`)
 - Install [cmux](https://www.cmux.dev/) if you want the additional [cmux](https://www.cmux.dev/)-native notification path
 - Updates require manual re-copying
 


### PR DESCRIPTION
## Summary
- Updates the opencode-notify manual installation list to include the required plugin and primitive files.
- Adds `zod` to the manual dependency caveat.

## Verification
- `git diff --check`

Closes #200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the opencode-notify manual install docs by listing all required plugin and `kdco-primitives` files and adding `zod` to the manual dependencies. Prevents missing file errors during manual setup.

<sup>Written for commit 38e23eb6890a7926c0a305e6227893ad3bb8e8f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

