### PR TITLE
feat(registry): Add Termux notifications

### DIFF
--- a/facades/opencode-notify/README.md
+++ b/facades/opencode-notify/README.md
@@ -2,7 +2,7 @@
 
 > Native OS notifications for OpenCode.
 
-A plugin for [OpenCode](https://github.com/sst/opencode) that delivers Native OS notifications when tasks complete, errors occur, or the AI needs your input. It uses native OS notification delivery on macOS, Windows, and Linux, with an additional [cmux](https://www.cmux.dev/)-native path when available.
+A plugin for [OpenCode](https://github.com/sst/opencode) that delivers Native OS notifications when tasks complete, errors occur, or the AI needs your input. It uses native OS notification delivery on macOS, Windows, Linux, and Android Termux, with an additional [cmux](https://www.cmux.dev/)-native path when available.
 
 ## Why This Exists
 
@@ -12,6 +12,7 @@ This plugin solves that:
 
 - **Stay focused** - Work in other apps. A notification arrives when the AI needs you.
 - **Native OS notifications first** - Uses macOS Notification Center, Windows Toast, or Linux notify-send via `node-notifier`.
+- **Android Termux support** - Detects Termux and sends through `termux-notification` when available.
 - **Smart defaults** - Won't spam you. Only notifies for meaningful events, with parent-session filtering and quiet-hours support.
 - **Additional [cmux](https://www.cmux.dev/)-native path** - When running in [cmux](https://www.cmux.dev/), can route through `cmux notify` and still falls back safely to desktop notifications.
 
@@ -55,6 +56,23 @@ By default, notifications go through the native OS desktop notification path:
 - **macOS:** Notification Center (`terminal-notifier` backend)
 - **Windows:** Toast notifications (`SnoreToast` backend)
 - **Linux:** `notify-send`
+- **Android Termux:** `termux-notification` from Termux:API
+
+### Android Termux
+
+When running under Termux (`TERMUX_VERSION` plus a Termux `PREFIX`), notifications are sent via:
+
+```bash
+termux-notification --title "..." --content "..." --action "am start -n com.termux/com.termux.app.TermuxActivity"
+```
+
+Install the Termux:API app and package first:
+
+```bash
+pkg install termux-api
+```
+
+If `termux-notification` is unavailable, exits non-zero, or times out, the plugin falls back to the existing cmux/desktop notification paths.
 
 ### Additional [cmux](https://www.cmux.dev/)-native path
 
@@ -68,13 +86,13 @@ If [cmux](https://www.cmux.dev/) is unavailable or invocation fails, notificatio
 
 ## Platform Support
 
-| Feature | macOS | Windows | Linux |
-|---------|-------|---------|-------|
-| Native OS notifications | Yes | Yes | Yes |
-| Custom sounds | Yes | No | No |
-| Focus detection | Yes | No | No |
-| Click-to-focus | Yes | No | No |
-| Terminal detection | Yes | Yes | Yes |
+| Feature | macOS | Windows | Linux | Android Termux |
+|---------|-------|---------|-------|----------------|
+| Native OS notifications | Yes | Yes | Yes | Yes, via Termux:API |
+| Custom sounds | Yes | No | No | No |
+| Focus detection | Yes | No | No | No |
+| Click-to-focus | Yes | No | No | Yes, opens Termux activity |
+| Terminal detection | Yes | Yes | Yes | Yes |
 
 ## Configuration (Optional)
 
@@ -94,6 +112,13 @@ Works out of the box. To customize, create `~/.config/opencode/kdco-notify.json`
     "enabled": false,
     "start": "22:00",
     "end": "08:00"
+  },
+  "termux": {
+    "enabled": true,
+    "notificationCommand": "termux-notification",
+    "launchCommand": "am",
+    "launchActivity": "com.termux/com.termux.app.TermuxActivity",
+    "timeoutMs": 1500
   }
 }
 ```
@@ -104,6 +129,11 @@ Configuration keys:
 - `terminal` (optional): override terminal auto-detection.
 - `sounds`: per-event sounds (`idle`, `error`, `permission`, optional `question`).
 - `quietHours`: scheduled suppression window.
+- `termux.enabled` (default `true`): enable Termux delivery when the environment is detected.
+- `termux.notificationCommand` (default `termux-notification`): command used for Termux notifications.
+- `termux.launchCommand` (default `am`): Android activity-manager command used for notification tap actions.
+- `termux.launchActivity` (default `com.termux/com.termux.app.TermuxActivity`): activity opened when a Termux notification is tapped.
+- `termux.timeoutMs` (default `1500`): timeout before falling back to cmux/desktop notification paths.
 
 **Available macOS sounds:** Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink
 
@@ -138,6 +168,7 @@ If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` an
 - `.opencode/plugins/notify/backend.ts`
 - `.opencode/plugins/notify/cmux.ts`
 - `.opencode/plugins/notify/status.ts`
+- `.opencode/plugins/notify/termux.ts`
 - `.opencode/plugins/notify/title.ts`
 - `.opencode/plugins/worktree/terminal.ts`
 - `.opencode/plugins/kdco-primitives/index.ts`
@@ -153,6 +184,7 @@ If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` an
 **Caveats:**
 - Manually install dependencies (`node-notifier`, `detect-terminal`, `zod`)
 - Install [cmux](https://www.cmux.dev/) if you want the additional [cmux](https://www.cmux.dev/)-native notification path
+- On Android Termux, install Termux:API and `pkg install termux-api`; no extra npm dependency is required for Termux notifications
 - Updates require manual re-copying
 
 ## Part of the OCX Ecosystem

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -26,8 +26,6 @@ import type { Plugin } from "@opencode-ai/plugin"
 import type { Event } from "@opencode-ai/sdk"
 // @ts-expect-error - installed at runtime by OCX
 import detectTerminal from "detect-terminal"
-// @ts-expect-error - installed at runtime by OCX
-import notifier from "node-notifier"
 import type { OpencodeClient } from "./kdco-primitives/types"
 import { sendNotificationWithFallback } from "./notify/backend"
 import {
@@ -42,6 +40,11 @@ import {
 	getCmuxSessionStatusText,
 	type CmuxSessionStatusTransition,
 } from "./notify/status"
+import {
+	isTermuxEnvironment,
+	sendTermuxNotification,
+	type TermuxNotificationConfig,
+} from "./notify/termux"
 import { parseOscTitleContext, writeOscTitleBestEffort } from "./notify/title"
 
 interface NotifyConfig {
@@ -62,6 +65,8 @@ interface NotifyConfig {
 	}
 	/** Override terminal detection (optional) */
 	terminal?: string
+	/** Android Termux notification integration */
+	termux: TermuxNotificationConfig
 }
 
 interface TerminalInfo {
@@ -81,6 +86,13 @@ const DEFAULT_CONFIG: NotifyConfig = {
 		enabled: false,
 		start: "22:00",
 		end: "08:00",
+	},
+	termux: {
+		enabled: true,
+		notificationCommand: "termux-notification",
+		launchCommand: "am",
+		launchActivity: "com.termux/com.termux.app.TermuxActivity",
+		timeoutMs: 1500,
 	},
 }
 
@@ -122,6 +134,10 @@ async function loadConfig(): Promise<NotifyConfig> {
 			quietHours: {
 				...DEFAULT_CONFIG.quietHours,
 				...userConfig.quietHours,
+			},
+			termux: {
+				...DEFAULT_CONFIG.termux,
+				...userConfig.termux,
 			},
 		}
 	} catch {
@@ -245,7 +261,14 @@ interface NotificationOptions {
 
 interface NotificationRuntime {
 	preferCmux: boolean
+	preferTermux: boolean
 }
+
+type NodeNotifier = {
+	notify: (options: Record<string, unknown>) => void
+}
+
+let nodeNotifierPromise: Promise<NodeNotifier | null> | null = null
 
 const QUESTION_DEDUPE_WINDOW_MS = 1500
 const READY_DEDUPE_WINDOW_MS = 1500
@@ -384,8 +407,30 @@ function buildPermissionEventDedupeKey(properties: unknown): string | null {
 	return `permission:request:${normalizedRequestID}`
 }
 
-function sendNodeNotification(options: NotificationOptions): void {
+async function loadNodeNotifier(): Promise<NodeNotifier | null> {
+	if (nodeNotifierPromise) return nodeNotifierPromise
+
+	nodeNotifierPromise = (async () => {
+		try {
+			// @ts-expect-error - installed at runtime by OCX; lazy-loaded so Termux/manual installs do not fail at plugin import time
+			const module = await import("node-notifier")
+			const candidate = module.default ?? module
+
+			if (!candidate || typeof candidate.notify !== "function") return null
+
+			return candidate as NodeNotifier
+		} catch {
+			return null
+		}
+	})()
+
+	return nodeNotifierPromise
+}
+
+async function sendNodeNotification(options: NotificationOptions): Promise<void> {
 	const { title, message, sound, terminalInfo } = options
+	const nodeNotifier = await loadNodeNotifier()
+	if (!nodeNotifier) return
 
 	// Base notification options
 	const notifyOptions: Record<string, unknown> = {
@@ -399,15 +444,29 @@ function sendNodeNotification(options: NotificationOptions): void {
 		notifyOptions.activate = terminalInfo.bundleId
 	}
 
-	notifier.notify(notifyOptions)
+	try {
+		nodeNotifier.notify(notifyOptions)
+	} catch {
+		// Notification delivery is best-effort; event handling must remain stable.
+	}
 }
 
 async function sendNotification(
 	options: NotificationOptions,
+	config: NotifyConfig,
 	runtime: NotificationRuntime,
 ): Promise<void> {
 	await sendNotificationWithFallback({
+		preferTermux: runtime.preferTermux,
 		preferCmux: runtime.preferCmux,
+		tryTermuxNotify: () =>
+			sendTermuxNotification(
+				{
+					title: options.title,
+					body: options.message,
+				},
+				config.termux,
+			),
 		tryCmuxNotify: () =>
 			sendCmuxNotification({
 				title: options.title,
@@ -461,6 +520,7 @@ async function handleSessionIdle(
 			sound: config.sounds.idle,
 			terminalInfo,
 		},
+		config,
 		notificationRuntime,
 	)
 }
@@ -494,6 +554,7 @@ async function handleSessionError(
 			sound: config.sounds.error,
 			terminalInfo,
 		},
+		config,
 		notificationRuntime,
 	)
 }
@@ -519,6 +580,7 @@ async function handlePermissionUpdated(
 			sound: config.sounds.permission,
 			terminalInfo,
 		},
+		config,
 		notificationRuntime,
 	)
 }
@@ -540,6 +602,7 @@ async function handleQuestionAsked(
 			sound,
 			terminalInfo,
 		},
+		config,
 		notificationRuntime,
 	)
 }
@@ -558,6 +621,7 @@ export const NotifyPlugin: Plugin = async (ctx) => {
 	const terminalInfo = await detectTerminalInfo(config)
 	const notificationRuntime: NotificationRuntime = {
 		preferCmux: canUseCmuxNotification(),
+		preferTermux: isTermuxEnvironment(),
 	}
 	const oscTitleContext = parseOscTitleContext()
 	const shouldSuppressCmuxSessionStatusWrites = oscTitleContext?.mayWriteOscTitle === true

--- a/workers/kdco-registry/files/plugins/notify/backend.ts
+++ b/workers/kdco-registry/files/plugins/notify/backend.ts
@@ -1,12 +1,23 @@
 interface NotifyBackendOptions {
+	preferTermux?: boolean
 	preferCmux: boolean
+	tryTermuxNotify?: () => Promise<boolean>
 	tryCmuxNotify: () => Promise<boolean>
-	sendNodeNotify: () => void
+	sendNodeNotify: () => Promise<void> | void
 }
 
 export async function sendNotificationWithFallback(options: NotifyBackendOptions): Promise<void> {
+	if (options.preferTermux && options.tryTermuxNotify) {
+		try {
+			const sentViaTermux = await options.tryTermuxNotify()
+			if (sentViaTermux) return
+		} catch {
+			// Fall through to cmux/node-notifier fallback
+		}
+	}
+
 	if (!options.preferCmux) {
-		options.sendNodeNotify()
+		await options.sendNodeNotify()
 		return
 	}
 
@@ -17,5 +28,5 @@ export async function sendNotificationWithFallback(options: NotifyBackendOptions
 		// Fall through to node-notifier fallback
 	}
 
-	options.sendNodeNotify()
+	await options.sendNodeNotify()
 }

--- a/workers/kdco-registry/files/plugins/notify/termux.ts
+++ b/workers/kdco-registry/files/plugins/notify/termux.ts
@@ -1,0 +1,102 @@
+import { TimeoutError, withTimeout } from "../kdco-primitives/with-timeout"
+
+export interface TermuxNotificationPayload {
+	title: string
+	body: string
+}
+
+export interface TermuxNotificationConfig {
+	enabled: boolean
+	notificationCommand: string
+	launchCommand: string
+	launchActivity: string
+	timeoutMs: number
+}
+
+type EnvironmentVariables = Record<string, string | undefined>
+type TermuxProcess = {
+	exited: Promise<number>
+	kill?: () => void
+}
+type SpawnTermuxProcess = (command: string[]) => TermuxProcess
+
+type TermuxExecutionOptions = {
+	env?: EnvironmentVariables
+	spawnProcess?: SpawnTermuxProcess
+}
+
+const TERMUX_PREFIX_MARKER = "/com.termux/"
+
+const spawnTermuxWithBun: SpawnTermuxProcess = (command) =>
+	Bun.spawn(command, {
+		stdout: "ignore",
+		stderr: "ignore",
+	})
+
+function hasNonEmptyEnvValue(value: string | undefined): boolean {
+	return typeof value === "string" && value.trim().length > 0
+}
+
+export function isTermuxEnvironment(env: EnvironmentVariables = process.env): boolean {
+	if (!hasNonEmptyEnvValue(env.TERMUX_VERSION)) return false
+	if (!hasNonEmptyEnvValue(env.PREFIX)) return false
+
+	return `/${env.PREFIX?.trim()}/`.includes(TERMUX_PREFIX_MARKER)
+}
+
+export function buildTermuxLaunchAction(config: TermuxNotificationConfig): string {
+	return `${config.launchCommand} start -n ${config.launchActivity}`
+}
+
+export function buildTermuxNotificationArgs(
+	payload: TermuxNotificationPayload,
+	config: TermuxNotificationConfig,
+): string[] {
+	return [
+		"--title",
+		payload.title,
+		"--content",
+		payload.body,
+		"--action",
+		buildTermuxLaunchAction(config),
+	]
+}
+
+export async function sendTermuxNotification(
+	payload: TermuxNotificationPayload,
+	config: TermuxNotificationConfig,
+	options?: TermuxExecutionOptions,
+): Promise<boolean> {
+	if (!config.enabled) return false
+	if (!isTermuxEnvironment(options?.env)) return false
+
+	const spawnProcess = options?.spawnProcess ?? spawnTermuxWithBun
+
+	try {
+		const proc = spawnProcess([
+			config.notificationCommand,
+			...buildTermuxNotificationArgs(payload, config),
+		])
+
+		try {
+			const exitCode = await withTimeout(
+				proc.exited,
+				config.timeoutMs,
+				"termux-notification timed out",
+			)
+			return exitCode === 0
+		} catch (error) {
+			if (error instanceof TimeoutError) {
+				try {
+					proc.kill?.()
+				} catch {
+					// best effort cleanup
+				}
+			}
+
+			return false
+		}
+	} catch {
+		return false
+	}
+}

--- a/workers/kdco-registry/registry.jsonc
+++ b/workers/kdco-registry/registry.jsonc
@@ -63,6 +63,7 @@
 				"plugins/notify/backend.ts",
 				"plugins/notify/cmux.ts",
 				"plugins/notify/status.ts",
+				"plugins/notify/termux.ts",
 				"plugins/notify/title.ts"
 			],
 			"dependencies": ["kdco-primitives"],

--- a/workers/kdco-registry/tests/notify-backend.test.ts
+++ b/workers/kdco-registry/tests/notify-backend.test.ts
@@ -3,6 +3,42 @@ import { sendNotificationWithFallback } from "../files/plugins/notify/backend"
 import { sendCmuxNotification } from "../files/plugins/notify/cmux"
 
 describe("notify backend fallback behavior", () => {
+	it("prefers Termux before cmux and node notifier when Termux delivery succeeds", async () => {
+		const tryTermuxNotify = mock(async () => true)
+		const tryCmuxNotify = mock(async () => true)
+		const sendNodeNotify = mock(() => {})
+
+		await sendNotificationWithFallback({
+			preferTermux: true,
+			preferCmux: true,
+			tryTermuxNotify,
+			tryCmuxNotify,
+			sendNodeNotify,
+		})
+
+		expect(tryTermuxNotify).toHaveBeenCalledTimes(1)
+		expect(tryCmuxNotify).not.toHaveBeenCalled()
+		expect(sendNodeNotify).not.toHaveBeenCalled()
+	})
+
+	it("falls back to cmux when Termux delivery fails", async () => {
+		const tryTermuxNotify = mock(async () => false)
+		const tryCmuxNotify = mock(async () => true)
+		const sendNodeNotify = mock(() => {})
+
+		await sendNotificationWithFallback({
+			preferTermux: true,
+			preferCmux: true,
+			tryTermuxNotify,
+			tryCmuxNotify,
+			sendNodeNotify,
+		})
+
+		expect(tryTermuxNotify).toHaveBeenCalledTimes(1)
+		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
+		expect(sendNodeNotify).not.toHaveBeenCalled()
+	})
+
 	it("uses node notifier directly when cmux is not preferred", async () => {
 		const tryCmuxNotify = mock(async () => true)
 		const sendNodeNotify = mock(() => {})

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -54,6 +54,8 @@ beforeEach(() => {
 	delete process.env.CMUX_SOCKET_PATH
 	delete process.env.CMUX_SOCKET_MODE
 	delete process.env.OCX_TITLE_CONTEXT
+	delete process.env.TERMUX_VERSION
+	delete process.env.PREFIX
 })
 
 afterEach(() => {
@@ -152,6 +154,74 @@ function decodeOscTitleWrite(chunk: unknown): string | null {
 }
 
 describe("notify plugin event compatibility and dedupe", () => {
+	it("routes notifications through termux-notification before desktop notifier in Termux", async () => {
+		process.env.TERMUX_VERSION = "0.118.1"
+		process.env.PREFIX = "/data/data/com.termux/files/usr"
+
+		const commands: string[][] = []
+		spyOn(Bun, "spawn").mockImplementation((command: string[]) => {
+			commands.push(command)
+			return {
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin()
+
+		await emitEvent(hooks, {
+			type: "permission.asked",
+			properties: {
+				id: "perm-termux",
+				sessionID: "session-a",
+				permission: "bash",
+				patterns: [],
+				metadata: {},
+				always: [],
+			},
+		})
+
+		expect(commands).toEqual([
+			[
+				"termux-notification",
+				"--title",
+				"Waiting for you",
+				"--content",
+				"OpenCode needs your input",
+				"--action",
+				"am start -n com.termux/com.termux.app.TermuxActivity",
+			],
+		])
+		expect(notificationPayloads).toHaveLength(0)
+	})
+
+	it("falls back to desktop notifier when termux-notification fails", async () => {
+		process.env.TERMUX_VERSION = "0.118.1"
+		process.env.PREFIX = "/data/data/com.termux/files/usr"
+
+		spyOn(Bun, "spawn").mockImplementation(() =>
+			({
+				exited: Promise.resolve(1),
+			}) as ReturnType<typeof Bun.spawn>
+		)
+
+		const { hooks } = await createPlugin()
+
+		await emitEvent(hooks, {
+			type: "permission.asked",
+			properties: {
+				id: "perm-termux-fallback",
+				sessionID: "session-a",
+				permission: "bash",
+				patterns: [],
+				metadata: {},
+				always: [],
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(1)
+		expect(notificationPayloads[0]?.title).toBe("Waiting for you")
+	})
+
 	it("dedupes permission notification when permission.asked and permission.updated describe same request", async () => {
 		const { hooks } = await createPlugin()
 

--- a/workers/kdco-registry/tests/notify-termux.test.ts
+++ b/workers/kdco-registry/tests/notify-termux.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test"
+import {
+	buildTermuxLaunchAction,
+	buildTermuxNotificationArgs,
+	isTermuxEnvironment,
+	sendTermuxNotification,
+	type TermuxNotificationConfig,
+} from "../files/plugins/notify/termux"
+
+const DEFAULT_TERMUX_CONFIG: TermuxNotificationConfig = {
+	enabled: true,
+	notificationCommand: "termux-notification",
+	launchCommand: "am",
+	launchActivity: "com.termux/com.termux.app.TermuxActivity",
+	timeoutMs: 1500,
+}
+
+describe("notify termux integration", () => {
+	it("detects Termux only when TERMUX_VERSION and PREFIX identify Termux", () => {
+		expect(
+			isTermuxEnvironment({
+				TERMUX_VERSION: "0.118.1",
+				PREFIX: "/data/data/com.termux/files/usr",
+			}),
+		).toBe(true)
+
+		expect(isTermuxEnvironment({ TERMUX_VERSION: "0.118.1" })).toBe(false)
+		expect(isTermuxEnvironment({ PREFIX: "/data/data/com.termux/files/usr" })).toBe(false)
+		expect(
+			isTermuxEnvironment({
+				TERMUX_VERSION: "0.118.1",
+				PREFIX: "/usr/local",
+			}),
+		).toBe(false)
+	})
+
+	it("builds a Termux launch action for the configured activity", () => {
+		expect(buildTermuxLaunchAction(DEFAULT_TERMUX_CONFIG)).toBe(
+			"am start -n com.termux/com.termux.app.TermuxActivity",
+		)
+	})
+
+	it("builds termux-notification args with title, content, and click action", () => {
+		expect(
+			buildTermuxNotificationArgs(
+				{
+					title: "Waiting for you",
+					body: "OpenCode needs your input",
+				},
+				DEFAULT_TERMUX_CONFIG,
+			),
+		).toEqual([
+			"--title",
+			"Waiting for you",
+			"--content",
+			"OpenCode needs your input",
+			"--action",
+			"am start -n com.termux/com.termux.app.TermuxActivity",
+		])
+	})
+
+	it("sends termux-notification when running in Termux", async () => {
+		const commands: string[][] = []
+
+		const sent = await sendTermuxNotification(
+			{
+				title: "Ready for review",
+				body: "Task complete",
+			},
+			DEFAULT_TERMUX_CONFIG,
+			{
+				env: {
+					TERMUX_VERSION: "0.118.1",
+					PREFIX: "/data/data/com.termux/files/usr",
+				},
+				spawnProcess: (command) => {
+					commands.push(command)
+					return {
+						exited: Promise.resolve(0),
+					}
+				},
+			},
+		)
+
+		expect(sent).toBe(true)
+		expect(commands).toEqual([
+			[
+				"termux-notification",
+				"--title",
+				"Ready for review",
+				"--content",
+				"Task complete",
+				"--action",
+				"am start -n com.termux/com.termux.app.TermuxActivity",
+			],
+		])
+	})
+
+	it("returns false without spawning outside Termux", async () => {
+		const commands: string[][] = []
+
+		const sent = await sendTermuxNotification(
+			{
+				title: "Ready",
+				body: "Task complete",
+			},
+			DEFAULT_TERMUX_CONFIG,
+			{
+				env: { TERMUX_VERSION: "0.118.1", PREFIX: "/usr/local" },
+				spawnProcess: (command) => {
+					commands.push(command)
+					return { exited: Promise.resolve(0) }
+				},
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(commands).toEqual([])
+	})
+
+	it("returns false and kills the process when termux-notification times out", async () => {
+		let killed = false
+
+		const sent = await sendTermuxNotification(
+			{
+				title: "Ready",
+				body: "Task complete",
+			},
+			{
+				...DEFAULT_TERMUX_CONFIG,
+				timeoutMs: 10,
+			},
+			{
+				env: {
+					TERMUX_VERSION: "0.118.1",
+					PREFIX: "/data/data/com.termux/files/usr",
+				},
+				spawnProcess: () => ({
+					exited: new Promise<number>(() => {
+						// Simulate hung termux-notification process
+					}),
+					kill: () => {
+						killed = true
+					},
+				}),
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(killed).toBe(true)
+	})
+})

--- a/workers/kdco-registry/tests/registry-manifest.test.ts
+++ b/workers/kdco-registry/tests/registry-manifest.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { parse as parseJsonc } from "jsonc-parser"
+
+type RegistryComponent = {
+	name: string
+	files?: string[]
+}
+
+type RegistryManifest = {
+	components?: RegistryComponent[]
+}
+
+const registryRoot = path.resolve(import.meta.dir, "..")
+
+async function readRegistryManifest(): Promise<RegistryManifest> {
+	const registryJsonc = await fs.readFile(path.join(registryRoot, "registry.jsonc"), "utf8")
+	return parseJsonc(registryJsonc) as RegistryManifest
+}
+
+function getComponentFiles(manifest: RegistryManifest, componentName: string): string[] {
+	const component = manifest.components?.find((candidate) => candidate.name === componentName)
+	if (!component) throw new Error(`Missing registry component: ${componentName}`)
+
+	return component.files ?? []
+}
+
+function getNotifyLocalImportFiles(source: string): string[] {
+	const importPathPattern = /from\s+["']\.\/notify\/([^"']+)["']/g
+	return Array.from(source.matchAll(importPathPattern), ([, importPath]) => {
+		if (!importPath) throw new Error("Missing notify import path")
+		return `plugins/notify/${importPath}.ts`
+	})
+}
+
+describe("registry component manifests", () => {
+	it("ships local notify helper files imported by the notify plugin", async () => {
+		const manifest = await readRegistryManifest()
+		const notifyFiles = getComponentFiles(manifest, "notify")
+		const notifySource = await fs.readFile(path.join(registryRoot, "files/plugins/notify.ts"), "utf8")
+
+		for (const importedFile of getNotifyLocalImportFiles(notifySource)) {
+			expect(notifyFiles).toContain(importedFile)
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Add Android Termux detection and Termux:API notification delivery before cmux/node fallback.
- Lazy-load node-notifier so missing desktop notification dependencies do not break plugin loading.
- Ship and document the new Termux helper, including registry manifest coverage.

Closes #204

## Tests
- bun test workers/kdco-registry/tests/notify-plugin.test.ts workers/kdco-registry/tests/notify-backend.test.ts workers/kdco-registry/tests/notify-cmux.test.ts workers/kdco-registry/tests/notify-termux.test.ts — 51 pass, 0 fail
- bun test workers/kdco-registry/tests/registry-manifest.test.ts — 1 pass
- bun run --cwd workers/kdco-registry check — PASS
- bun run --cwd workers/kdco-registry build — PASS (Built 17 components to dist)
- bun run check — PASS (4 successful, 4 total)
- bun run build — PASS (3 successful, 3 total)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Android Termux notifications using Termux:API with automatic detection and a new fallback order (Termux → cmux → desktop). Also lazy-loads `node-notifier` so missing desktop deps don’t break plugin load. Implements the Termux support requested in #204.

- **New Features**
  - Detects Termux (TERMUX_VERSION + PREFIX) and sends via termux-notification; tap opens the Termux activity.
  - Adds a `termux` config block (enabled, commands, launch activity, timeout) with safe defaults.
  - Prefers Termux before cmux and desktop; cleanly falls back when Termux fails or times out.
  - Lazy-loads `node-notifier` to avoid import errors when OS notifiers aren’t installed.
  - Ships `plugins/notify/termux.ts`, updates `registry.jsonc`, and documents Termux in README.

- **Migration**
  - On Android Termux, install Termux:API and run `pkg install termux-api`.
  - Optional: override `termux` settings in config if needed.

<sup>Written for commit c7d364548d36beb4944ec1cc3c0625738326cc8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

