### PR TITLE
fix(cli): Handle opencode shutdown signals

### DIFF
--- a/docs/cli/opencode.mdx
+++ b/docs/cli/opencode.mdx
@@ -19,10 +19,11 @@ Launch OpenCode with resolved configuration and profile support. OCX merges prof
 | Flag | Shorthand | Default | Description |
 |------|-----------|---------|-------------|
 | `--profile <name>` | `-p` | | Use specific global profile |
+| `--verbose` | `-v` | `false` | Enable verbose OCX output |
 | `--no-rename` | | `false` | Skip automatic window/terminal renaming |
 
 <Note>
-Only `-p`/`--profile` and `--no-rename` are OCX flags. All other arguments and flags pass through to OpenCode. Use `--` to pass flags that conflict with OCX (e.g., `ocx oc -- --help` forwards help to OpenCode).
+`-p`/`--profile`, `-v`/`--verbose`, and `--no-rename` are OCX-owned flags. Other arguments and flags pass through to OpenCode. Use `--` to pass OpenCode flags that conflict with OCX (e.g., `ocx oc -- --help` forwards help to OpenCode).
 </Note>
 
 ## Examples

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -45,6 +45,8 @@ interface OpencodeOptions {
 
 type OpenCodeShutdownSignal = "SIGINT" | "SIGTERM"
 
+// Give OpenCode 2.5s to handle SIGINT/SIGTERM itself before escalating to SIGKILL.
+// Keeps shutdown deterministic and avoids hanging if the child ignores the signal.
 const OPENCODE_SIGNAL_GRACE_MS = 2500
 const OPENCODE_SIGNAL_EXIT_CODES: Record<OpenCodeShutdownSignal, number> = {
 	SIGINT: 130,

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -23,6 +23,7 @@ import { getGitInfo } from "../utils/git-context"
 import { handleError } from "../utils/handle-error"
 import { logger } from "../utils/logger"
 import { getGlobalConfigPath } from "../utils/paths"
+import { addVerboseOption } from "../utils/shared-options"
 import {
 	canWriteOscTerminalTitle,
 	formatTerminalName,
@@ -39,6 +40,15 @@ import {
 interface OpencodeOptions {
 	profile?: string
 	rename?: boolean
+	verbose?: boolean
+}
+
+type OpenCodeShutdownSignal = "SIGINT" | "SIGTERM"
+
+const OPENCODE_SIGNAL_GRACE_MS = 2500
+const OPENCODE_SIGNAL_EXIT_CODES: Record<OpenCodeShutdownSignal, number> = {
+	SIGINT: 130,
+	SIGTERM: 143,
 }
 
 type OpencodeLeafOrigin = "profile" | "local"
@@ -578,7 +588,7 @@ export function buildOpenCodeEnv(opts: {
 }
 
 export function registerOpencodeCommand(program: Command): void {
-	program
+	const command = program
 		.command("oc")
 		.alias("opencode")
 		.description("Launch OpenCode with resolved configuration")
@@ -586,13 +596,86 @@ export function registerOpencodeCommand(program: Command): void {
 		.option("--no-rename", "Disable terminal/tmux window renaming")
 		.allowUnknownOption()
 		.allowExcessArguments(true)
-		.action(async (options: OpencodeOptions, command: Command) => {
-			try {
-				await runOpencode(command.args, options)
-			} catch (error) {
-				handleError(error)
-			}
-		})
+
+	addVerboseOption(command)
+	command.action(async (options: OpencodeOptions, command: Command) => {
+		try {
+			await runOpencode(command.args, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+}
+
+function createOpenCodeShutdownSupervisor() {
+	let childProcess: ReturnType<typeof Bun.spawn> | null = null
+	let graceTimer: ReturnType<typeof setTimeout> | null = null
+	let rememberedSignalExitCode: number | null = null
+	let hasEscalatedToKill = false
+
+	const clearGraceTimer = () => {
+		if (!graceTimer) {
+			return
+		}
+
+		clearTimeout(graceTimer)
+		graceTimer = null
+	}
+
+	const killChildImmediately = () => {
+		if (!childProcess) {
+			return
+		}
+
+		if (hasEscalatedToKill) {
+			return
+		}
+
+		hasEscalatedToKill = true
+		childProcess.kill("SIGKILL")
+	}
+
+	const startSignalGraceTimer = () => {
+		if (graceTimer) {
+			return
+		}
+
+		graceTimer = setTimeout(() => {
+			killChildImmediately()
+		}, OPENCODE_SIGNAL_GRACE_MS)
+	}
+
+	const requestShutdown = (signal: OpenCodeShutdownSignal) => {
+		rememberedSignalExitCode ??= OPENCODE_SIGNAL_EXIT_CODES[signal]
+
+		if (!childProcess) {
+			return
+		}
+
+		if (graceTimer || hasEscalatedToKill) {
+			killChildImmediately()
+			return
+		}
+
+		childProcess.kill(signal)
+		startSignalGraceTimer()
+	}
+
+	return {
+		attachChild(processToSupervise: ReturnType<typeof Bun.spawn>) {
+			childProcess = processToSupervise
+		},
+		clearGraceTimer,
+		getRememberedSignalExitCode() {
+			return rememberedSignalExitCode
+		},
+		handleSigint() {
+			requestShutdown("SIGINT")
+		},
+		handleSigterm() {
+			requestShutdown("SIGTERM")
+		},
+	}
 }
 
 async function runOpencode(args: string[], options: OpencodeOptions): Promise<void> {
@@ -659,23 +742,10 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 	let mergedConfig: PreparedMergedConfigDir | null = null
 	let primaryFailure: Error | null = null
 	let childExitCode: number | null = null
-	let preSpawnSignalExitCode: number | null = null
+	const shutdownSupervisor = createOpenCodeShutdownSupervisor()
 
-	const sigintHandler = () => {
-		if (proc) {
-			proc.kill("SIGINT")
-		} else {
-			preSpawnSignalExitCode = 130
-		}
-	}
-
-	const sigtermHandler = () => {
-		if (proc) {
-			proc.kill("SIGTERM")
-		} else {
-			preSpawnSignalExitCode = 143
-		}
-	}
+	const sigintHandler = () => shutdownSupervisor.handleSigint()
+	const sigtermHandler = () => shutdownSupervisor.handleSigterm()
 
 	const exitHandler = () => {
 		if (shouldRename) {
@@ -688,8 +758,8 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 		process.on("SIGTERM", sigtermHandler)
 		process.on("exit", exitHandler)
 
-		if (preSpawnSignalExitCode !== null) {
-			childExitCode = preSpawnSignalExitCode
+		if (shutdownSupervisor.getRememberedSignalExitCode() !== null) {
+			childExitCode = shutdownSupervisor.getRememberedSignalExitCode()
 			return
 		}
 
@@ -700,14 +770,14 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 			})
 		}
 
-		if (preSpawnSignalExitCode !== null) {
-			childExitCode = preSpawnSignalExitCode
+		if (shutdownSupervisor.getRememberedSignalExitCode() !== null) {
+			childExitCode = shutdownSupervisor.getRememberedSignalExitCode()
 			return
 		}
 
 		const gitInfo = shouldRename ? await getGitInfo(projectDir) : { repoName: null, branch: null }
-		if (preSpawnSignalExitCode !== null) {
-			childExitCode = preSpawnSignalExitCode
+		if (shutdownSupervisor.getRememberedSignalExitCode() !== null) {
+			childExitCode = shutdownSupervisor.getRememberedSignalExitCode()
 			return
 		}
 
@@ -723,8 +793,8 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 			setTerminalName(baseTitle)
 		}
 
-		if (preSpawnSignalExitCode !== null) {
-			childExitCode = preSpawnSignalExitCode
+		if (shutdownSupervisor.getRememberedSignalExitCode() !== null) {
+			childExitCode = shutdownSupervisor.getRememberedSignalExitCode()
 			return
 		}
 
@@ -774,6 +844,7 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 				`Failed to launch OpenCode binary "${configuredBin}": ${error instanceof Error ? error.message : String(error)}`,
 			)
 		}
+		shutdownSupervisor.attachChild(proc)
 
 		// Wait for child to exit
 		childExitCode = await proc.exited
@@ -783,6 +854,8 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 				? error
 				: createOpencodeOcError("spawn", `OpenCode process failed: ${String(error)}`)
 	} finally {
+		shutdownSupervisor.clearGraceTimer()
+
 		// Cleanup signal handlers
 		process.off("SIGINT", sigintHandler)
 		process.off("SIGTERM", sigtermHandler)
@@ -798,7 +871,7 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 			} catch (cleanupError: unknown) {
 				const hasPrimaryFailure =
 					primaryFailure !== null ||
-					preSpawnSignalExitCode !== null ||
+					shutdownSupervisor.getRememberedSignalExitCode() !== null ||
 					(childExitCode !== null && childExitCode !== 0)
 
 				if (hasPrimaryFailure) {
@@ -821,6 +894,11 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 
 	if (primaryFailure) {
 		throw primaryFailure
+	}
+
+	const rememberedSignalExitCode = shutdownSupervisor.getRememberedSignalExitCode()
+	if (rememberedSignalExitCode !== null) {
+		process.exit(rememberedSignalExitCode)
 	}
 
 	if (childExitCode !== null) {

--- a/packages/cli/tests/opencode.test.ts
+++ b/packages/cli/tests/opencode.test.ts
@@ -9,7 +9,7 @@ import {
 	resolveStableOpenCodeLauncherPath,
 } from "../src/commands/opencode"
 import { EXIT_CODES } from "../src/utils/errors"
-import { cleanupTempDir, createTempDir, runCLI, runCLIIsolated } from "./helpers"
+import { cleanupTempDir, createIsolatedEnv, createTempDir, runCLI, runCLIIsolated } from "./helpers"
 
 async function createProfile(testDir: string, name: string): Promise<void> {
 	const profileDir = join(testDir, "opencode", "profiles", name)
@@ -40,6 +40,128 @@ async function createConfigContentCaptureScript(testDir: string): Promise<{
 	)
 
 	return { scriptPath, outputPath }
+}
+
+async function waitForFile(filePath: string, timeoutMs = 3000): Promise<void> {
+	const startedAt = Date.now()
+
+	while (Date.now() - startedAt < timeoutMs) {
+		if (await Bun.file(filePath).exists()) {
+			return
+		}
+
+		await Bun.sleep(25)
+	}
+
+	throw new Error(`Timed out waiting for file: ${filePath}`)
+}
+
+async function createArgCaptureOpenCodeScript(testDir: string): Promise<{
+	scriptPath: string
+	outputPath: string
+}> {
+	const scriptPath = join(testDir, "capture-opencode-args.ts")
+	const outputPath = join(testDir, "captured-opencode-args.json")
+
+	await Bun.write(
+		scriptPath,
+		[
+			"const outputPath = process.argv[2]",
+			"if (!outputPath) {",
+			'  throw new Error("missing output path")',
+			"}",
+			"await Bun.write(outputPath, JSON.stringify({ args: process.argv.slice(3) }, null, 2))",
+		].join("\n"),
+	)
+
+	return { scriptPath, outputPath }
+}
+
+async function createSignalAwareOpenCodeScript(testDir: string): Promise<{
+	scriptPath: string
+	signalPath: string
+	readyPath: string
+}> {
+	const scriptPath = join(testDir, "signal-aware-opencode.ts")
+	const signalPath = join(testDir, "captured-signals.json")
+	const readyPath = join(testDir, "signal-aware-opencode-ready")
+
+	await Bun.write(
+		scriptPath,
+		[
+			"const signalPath = process.argv[2]",
+			"const readyPath = process.argv[3]",
+			"const mode = process.argv[4] ?? 'ignore'",
+			"if (!signalPath || !readyPath) {",
+			'  throw new Error("missing signal or ready path")',
+			"}",
+			"const receivedSignals = []",
+			"async function recordSignal(signal) {",
+			"  receivedSignals.push(signal)",
+			"  await Bun.write(signalPath, JSON.stringify(receivedSignals, null, 2))",
+			"}",
+			"process.on('SIGINT', async () => {",
+			"  await recordSignal('SIGINT')",
+			"  if (mode === 'cooperative') process.exit(130)",
+			"})",
+			"process.on('SIGTERM', async () => {",
+			"  await recordSignal('SIGTERM')",
+			"  if (mode === 'cooperative') process.exit(143)",
+			"})",
+			"await Bun.write(readyPath, 'ready')",
+			"setInterval(() => {}, 1000)",
+		].join("\n"),
+	)
+
+	return { scriptPath, signalPath, readyPath }
+}
+
+async function runOcUntilReadyThenSignal(args: {
+	testDir: string
+	readyPath: string
+	signal: "SIGINT" | "SIGTERM"
+	cliArgs: string[]
+}): Promise<{ exitCode: number; output: string }> {
+	const indexPath = join(import.meta.dir, "..", "src/index.ts")
+	const proc = Bun.spawn(["bun", "run", indexPath, ...args.cliArgs], {
+		cwd: args.testDir,
+		env: createIsolatedEnv(args.testDir, {
+			XDG_CONFIG_HOME: args.testDir,
+			OPENCODE_BIN: "bun",
+		}),
+		stdout: "pipe",
+		stderr: "pipe",
+	})
+	const outputPromise = Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	])
+
+	await waitForFile(args.readyPath)
+	proc.kill(args.signal)
+
+	let timedOut = false
+	let timeoutId: ReturnType<typeof setTimeout> | null = null
+	const exitCode = await Promise.race([
+		proc.exited,
+		new Promise<number>(
+			(resolve) =>
+				(timeoutId = setTimeout(() => {
+					timedOut = true
+					proc.kill("SIGKILL")
+					resolve(124)
+				}, 6000)),
+		),
+	])
+	if (timeoutId) {
+		clearTimeout(timeoutId)
+	}
+	const [stdout, stderr] = await outputPromise.catch(() => ["", ""])
+
+	return {
+		exitCode,
+		output: `${stdout}${stderr}${timedOut ? "\n[TIMEOUT after 6000ms]" : ""}`,
+	}
 }
 
 describe("dedupeLastWins", () => {
@@ -446,7 +568,88 @@ describe("oc command CLI contract", () => {
 		const result = await runCLI(["oc", "--help"], process.cwd())
 		expect(result.stdout).toContain("--profile")
 		expect(result.stdout).toContain("--no-rename")
+		expect(result.stdout).toContain("--verbose")
 		expect(result.stdout).not.toContain("[path]")
+	})
+
+	it("consumes OCX verbose flag before forwarding OpenCode args", async () => {
+		const testDir = await createTempDir("oc-contract-verbose-consumed")
+		try {
+			const { scriptPath, outputPath } = await createArgCaptureOpenCodeScript(testDir)
+
+			const result = await runCLIIsolated(
+				["oc", "--no-rename", "--verbose", "run", scriptPath, outputPath, "--model", "test-model"],
+				testDir,
+				{ OPENCODE_BIN: "bun" },
+			)
+
+			expect(result.exitCode).toBe(0)
+			const captured = JSON.parse(await Bun.file(outputPath).text()) as { args: string[] }
+			expect(captured.args).toEqual(["--model", "test-model"])
+			expect(captured.args).not.toContain("--verbose")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("forwards SIGINT then escalates and exits with interrupt code", async () => {
+		const testDir = await createTempDir("oc-signal-sigint-escalates")
+		try {
+			const { scriptPath, signalPath, readyPath } = await createSignalAwareOpenCodeScript(testDir)
+
+			const result = await runOcUntilReadyThenSignal({
+				testDir,
+				readyPath,
+				signal: "SIGINT",
+				cliArgs: ["oc", "--no-rename", "run", scriptPath, signalPath, readyPath, "ignore"],
+			})
+
+			expect(result.exitCode).toBe(130)
+			expect(result.output).not.toContain("[TIMEOUT")
+			expect(JSON.parse(await Bun.file(signalPath).text())).toEqual(["SIGINT"])
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("forwards SIGTERM then escalates and exits with termination code", async () => {
+		const testDir = await createTempDir("oc-signal-sigterm-escalates")
+		try {
+			const { scriptPath, signalPath, readyPath } = await createSignalAwareOpenCodeScript(testDir)
+
+			const result = await runOcUntilReadyThenSignal({
+				testDir,
+				readyPath,
+				signal: "SIGTERM",
+				cliArgs: ["oc", "--no-rename", "run", scriptPath, signalPath, readyPath, "ignore"],
+			})
+
+			expect(result.exitCode).toBe(143)
+			expect(result.output).not.toContain("[TIMEOUT")
+			expect(JSON.parse(await Bun.file(signalPath).text())).toEqual(["SIGTERM"])
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("allows cooperative child SIGINT shutdown to exit cleanly", async () => {
+		const testDir = await createTempDir("oc-signal-sigint-cooperative")
+		try {
+			const { scriptPath, signalPath, readyPath } = await createSignalAwareOpenCodeScript(testDir)
+
+			const result = await runOcUntilReadyThenSignal({
+				testDir,
+				readyPath,
+				signal: "SIGINT",
+				cliArgs: ["oc", "--no-rename", "run", scriptPath, signalPath, readyPath, "cooperative"],
+			})
+
+			expect(result.exitCode).toBe(130)
+			expect(result.output).not.toContain("[TIMEOUT")
+			expect(JSON.parse(await Bun.file(signalPath).text())).toEqual(["SIGINT"])
+		} finally {
+			await cleanupTempDir(testDir)
+		}
 	})
 
 	it("does not interpret positional args as path (regression #112)", async () => {


### PR DESCRIPTION
## Summary
- Fixes #198 by forwarding SIGINT/SIGTERM to the OpenCode child and escalating with SIGKILL after a deterministic 2500ms grace period when ignored.
- Consumes OCX-owned `-v/--verbose` before forwarding remaining arguments to OpenCode.
- Updates opencode CLI docs and adds fake-child regression tests for signal forwarding/escalation and verbose passthrough.

## Verification
- `git diff --check` — PASS
- `bun test packages/cli/tests/opencode.test.ts` — PASS (67 tests)
- `bun run --cwd packages/cli check` — PASS

Fixes #198

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward SIGINT/SIGTERM from the `oc` command to the OpenCode child with a 2.5s grace before SIGKILL, and exit with the correct codes (130/143). Adds an OCX-owned `-v/--verbose` flag that `oc` consumes (not forwarded) and updates help/docs to clarify OCX flags and the 2.5s grace (fixes #198).

- **Bug Fixes**
  - Forward SIGINT/SIGTERM to the child; escalate with SIGKILL after 2500ms if ignored.
  - Preserve 130/143 exit codes, including when signals arrive before spawn or the child exits cooperatively.

- **New Features**
  - Add `-v/--verbose` as an OCX flag; update help/docs and add tests for signal handling (2.5s grace) and verbose passthrough.

<sup>Written for commit b71b870b688321516e7b52231d2ee1e119cd99db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

