### PR TITLE
fix: Migrate macOS notifications to alerter

### DIFF
--- a/docs/integrations/notify.mdx
+++ b/docs/integrations/notify.mdx
@@ -12,7 +12,7 @@ A plugin for OpenCode that delivers Native OS notifications when tasks complete,
 You delegate a task and switch to another window. Now you're checking back every 30 seconds. This plugin solves that:
 
 - **Stay focused** — Work in other apps. A notification arrives when the AI needs you.
-- **Native OS notifications first** — Uses macOS Notification Center, Windows Toast, or Linux notify-send via `node-notifier`.
+- **Native OS notifications first** — Uses macOS Notification Center via `alerter`, plus Windows Toast and Linux notify-send via `node-notifier`.
 - **Smart defaults** — Only notifies for meaningful events, with parent-session filtering and quiet-hours support.
 - **Additional [cmux](https://www.cmux.dev/)-native path** — When running in [cmux](https://www.cmux.dev/), can route through `cmux notify` and still falls back safely to desktop notifications.
 
@@ -49,9 +49,11 @@ Question notifications intentionally bypass macOS focus suppression so direct pr
 
 By default, notifications go through the native OS desktop notification path:
 
-- **macOS:** Notification Center (`terminal-notifier` backend)
+- **macOS:** Notification Center via [`vjeantet/alerter`](https://github.com/vjeantet/alerter) (`alerter` must be on `PATH`, macOS 13+)
 - **Windows:** Toast notifications (`SnoreToast` backend)
 - **Linux:** `notify-send`
+
+macOS desktop fallback requires installing `alerter` separately. Supported install paths include Homebrew (`brew install vjeantet/tap/alerter`), MacPorts, or downloading the release zip from GitHub Releases and placing the binary on `PATH`.
 
 ### Additional [cmux](https://www.cmux.dev/)-native path
 
@@ -61,7 +63,7 @@ When OpenCode runs inside [cmux](https://www.cmux.dev/) (with `CMUX_WORKSPACE_ID
 cmux notify --title "..." --subtitle "..." --body "..."
 ```
 
-If [cmux](https://www.cmux.dev/) is unavailable or notification delivery fails, the plugin automatically falls back to the existing `node-notifier` desktop path.
+If [cmux](https://www.cmux.dev/) is unavailable or notification delivery fails, the plugin automatically falls back to the desktop path: `alerter` on macOS, and the existing `node-notifier`-backed path on Windows/Linux.
 
 ## Platform Support
 

--- a/facades/opencode-notify/README.md
+++ b/facades/opencode-notify/README.md
@@ -11,7 +11,7 @@ You delegate a task and switch to another window. Now you're checking back every
 This plugin solves that:
 
 - **Stay focused** - Work in other apps. A notification arrives when the AI needs you.
-- **Native OS notifications first** - Uses macOS Notification Center, Windows Toast, or Linux notify-send via `node-notifier`.
+- **Native OS notifications first** - Uses macOS Notification Center via `alerter`, plus Windows Toast and Linux notify-send via `node-notifier`.
 - **Smart defaults** - Won't spam you. Only notifies for meaningful events, with parent-session filtering and quiet-hours support.
 - **Additional [cmux](https://www.cmux.dev/)-native path** - When running in [cmux](https://www.cmux.dev/), can route through `cmux notify` and still falls back safely to desktop notifications.
 
@@ -52,9 +52,11 @@ Question notifications intentionally bypass macOS focus suppression so direct pr
 
 By default, notifications go through the native OS desktop notification path:
 
-- **macOS:** Notification Center (`terminal-notifier` backend)
+- **macOS:** Notification Center via [`vjeantet/alerter`](https://github.com/vjeantet/alerter) (`alerter` must be on `PATH`, macOS 13+)
 - **Windows:** Toast notifications (`SnoreToast` backend)
 - **Linux:** `notify-send`
+
+macOS desktop fallback requires installing `alerter` separately. Supported install paths include Homebrew (`brew install vjeantet/tap/alerter`), MacPorts, or downloading the release zip from GitHub Releases and placing the binary on `PATH`.
 
 ### Additional [cmux](https://www.cmux.dev/)-native path
 
@@ -64,7 +66,7 @@ When running inside [cmux](https://www.cmux.dev/) (with `CMUX_WORKSPACE_ID` set)
 cmux notify --title "..." --subtitle "..." --body "..."
 ```
 
-If [cmux](https://www.cmux.dev/) is unavailable or invocation fails, notifications automatically fall back to the existing `node-notifier` desktop behavior.
+If [cmux](https://www.cmux.dev/) is unavailable or invocation fails, notifications automatically fall back to the desktop path: `alerter` on macOS, and the existing `node-notifier`-backed path on Windows/Linux.
 
 ## Platform Support
 
@@ -152,6 +154,7 @@ If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` an
 
 **Caveats:**
 - Manually install dependencies (`node-notifier`, `detect-terminal`, `zod`)
+- On macOS 13+, install [`vjeantet/alerter`](https://github.com/vjeantet/alerter) and ensure `alerter` is on `PATH` (Homebrew: `brew install vjeantet/tap/alerter`; MacPorts and GitHub Releases/manual zip are also supported)
 - Install [cmux](https://www.cmux.dev/) if you want the additional [cmux](https://www.cmux.dev/)-native notification path
 - Updates require manual re-copying
 

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -11,10 +11,10 @@
  * - Click notification to focus terminal
  * - Parent session only by default (no spam from sub-tasks)
  *
- * Uses cmux CLI first (if available), then node-notifier fallback:
+ * Uses cmux CLI first (if available), then desktop notification fallback:
  * - cmux: `cmux notify --title ... --subtitle ... --body ...`
  * - cmux status: `cmux set-status <key> <value>` / `cmux clear-status <key>`
- * - macOS: terminal-notifier (native NSUserNotificationCenter)
+ * - macOS: alerter (native Notification Center, requires alerter on PATH)
  * - Windows: SnoreToast (native toast notifications)
  * - Linux: notify-send (native desktop notifications)
  */
@@ -29,7 +29,7 @@ import detectTerminal from "detect-terminal"
 // @ts-expect-error - installed at runtime by OCX
 import notifier from "node-notifier"
 import type { OpencodeClient } from "./kdco-primitives/types"
-import { sendNotificationWithFallback } from "./notify/backend"
+import { sendDesktopNotificationByPlatform, sendNotificationWithFallback } from "./notify/backend"
 import {
 	canUseCmuxNotification,
 	clearCmuxStatus,
@@ -384,7 +384,7 @@ function buildPermissionEventDedupeKey(properties: unknown): string | null {
 	return `permission:request:${normalizedRequestID}`
 }
 
-function sendNodeNotification(options: NotificationOptions): void {
+async function sendDesktopNotification(options: NotificationOptions): Promise<void> {
 	const { title, message, sound, terminalInfo } = options
 
 	// Base notification options
@@ -394,12 +394,15 @@ function sendNodeNotification(options: NotificationOptions): void {
 		sound,
 	}
 
-	// macOS-specific: click notification to focus terminal
-	if (process.platform === "darwin" && terminalInfo.bundleId) {
-		notifyOptions.activate = terminalInfo.bundleId
-	}
-
-	notifier.notify(notifyOptions)
+	await sendDesktopNotificationByPlatform({
+		platform: process.platform,
+		title,
+		message,
+		subtitle: options.subtitle,
+		sound,
+		senderBundleId: terminalInfo.bundleId,
+		sendNodeNotifierNotification: () => notifier.notify(notifyOptions),
+	})
 }
 
 async function sendNotification(
@@ -414,7 +417,7 @@ async function sendNotification(
 				subtitle: options.subtitle,
 				body: options.cmuxBody ?? options.message,
 			}),
-		sendNodeNotify: () => sendNodeNotification(options),
+		sendDesktopNotification: () => sendDesktopNotification(options),
 	})
 }
 

--- a/workers/kdco-registry/files/plugins/notify/backend.ts
+++ b/workers/kdco-registry/files/plugins/notify/backend.ts
@@ -1,12 +1,100 @@
 interface NotifyBackendOptions {
 	preferCmux: boolean
 	tryCmuxNotify: () => Promise<boolean>
-	sendNodeNotify: () => void
+	sendDesktopNotification: () => void | Promise<void>
+}
+
+export interface DesktopNotificationOptions {
+	title: string
+	message: string
+	subtitle?: string
+	sound?: string
+	senderBundleId?: string | null
+}
+
+interface DesktopNotificationRouterOptions extends DesktopNotificationOptions {
+	platform: NodeJS.Platform | string
+	sendNodeNotifierNotification: () => void
+	sendMacOSNotification?: (options: DesktopNotificationOptions) => Promise<boolean>
+}
+
+interface AlerterProcess {
+	exited: Promise<number>
+}
+
+interface AlerterRuntime {
+	which?: (command: string) => string | null | Promise<string | null>
+	spawnProcess?: (argv: string[]) => AlerterProcess
+	warn?: (message: string) => void
+}
+
+const ALERTER_INSTALL_HINT =
+	"install vjeantet/alerter (brew install vjeantet/tap/alerter) and ensure it is on PATH"
+
+export function buildAlerterArguments(options: DesktopNotificationOptions): string[] {
+	const argv = ["alerter", "--message", options.message, "--title", options.title]
+
+	if (options.subtitle) {
+		argv.push("--subtitle", options.subtitle)
+	}
+
+	if (options.sound) {
+		argv.push("--sound", options.sound)
+	}
+
+	if (options.senderBundleId) {
+		argv.push("--sender", options.senderBundleId)
+	}
+
+	return argv
+}
+
+export async function sendMacOSAlerterNotification(
+	options: DesktopNotificationOptions,
+	runtime: AlerterRuntime = {},
+): Promise<boolean> {
+	const which = runtime.which ?? Bun.which
+	const warn = runtime.warn ?? console.warn
+
+	try {
+		const alerterPath = await which("alerter")
+		if (!alerterPath) {
+			warn(`notify: macOS desktop notification skipped; alerter not found on PATH (${ALERTER_INSTALL_HINT}).`)
+			return false
+		}
+
+		const alerterArguments = buildAlerterArguments(options)
+		const spawnProcess = runtime.spawnProcess ?? ((argv: string[]) => Bun.spawn(argv, { stdout: "ignore", stderr: "pipe" }))
+		const process = spawnProcess([alerterPath, ...alerterArguments.slice(1)])
+		const exitCode = await process.exited
+
+		if (exitCode === 0) return true
+
+		warn(`notify: macOS desktop notification skipped; alerter exited with code ${exitCode}.`)
+		return false
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		warn(`notify: macOS desktop notification skipped; alerter failed (${message}).`)
+		return false
+	}
+}
+
+export async function sendDesktopNotificationByPlatform(
+	options: DesktopNotificationRouterOptions,
+): Promise<void> {
+	const { platform, sendNodeNotifierNotification, sendMacOSNotification, ...notificationOptions } = options
+
+	if (platform === "darwin") {
+		await (sendMacOSNotification ?? sendMacOSAlerterNotification)(notificationOptions)
+		return
+	}
+
+	sendNodeNotifierNotification()
 }
 
 export async function sendNotificationWithFallback(options: NotifyBackendOptions): Promise<void> {
 	if (!options.preferCmux) {
-		options.sendNodeNotify()
+		await options.sendDesktopNotification()
 		return
 	}
 
@@ -14,8 +102,8 @@ export async function sendNotificationWithFallback(options: NotifyBackendOptions
 		const sentViaCmux = await options.tryCmuxNotify()
 		if (sentViaCmux) return
 	} catch {
-		// Fall through to node-notifier fallback
+		// Fall through to desktop notification fallback
 	}
 
-	options.sendNodeNotify()
+	await options.sendDesktopNotification()
 }

--- a/workers/kdco-registry/tests/notify-backend.test.ts
+++ b/workers/kdco-registry/tests/notify-backend.test.ts
@@ -1,68 +1,73 @@
 import { describe, expect, it, mock } from "bun:test"
-import { sendNotificationWithFallback } from "../files/plugins/notify/backend"
+import {
+	buildAlerterArguments,
+	sendDesktopNotificationByPlatform,
+	sendMacOSAlerterNotification,
+	sendNotificationWithFallback,
+} from "../files/plugins/notify/backend"
 import { sendCmuxNotification } from "../files/plugins/notify/cmux"
 
 describe("notify backend fallback behavior", () => {
-	it("uses node notifier directly when cmux is not preferred", async () => {
+	it("uses desktop notifications directly when cmux is not preferred", async () => {
 		const tryCmuxNotify = mock(async () => true)
-		const sendNodeNotify = mock(() => {})
+		const sendDesktopNotification = mock(() => {})
 
 		await sendNotificationWithFallback({
 			preferCmux: false,
 			tryCmuxNotify,
-			sendNodeNotify,
+			sendDesktopNotification,
 		})
 
 		expect(tryCmuxNotify).not.toHaveBeenCalled()
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(sendDesktopNotification).toHaveBeenCalledTimes(1)
 	})
 
 	it("prefers cmux when cmux delivery succeeds", async () => {
 		const tryCmuxNotify = mock(async () => true)
-		const sendNodeNotify = mock(() => {})
+		const sendDesktopNotification = mock(() => {})
 
 		await sendNotificationWithFallback({
 			preferCmux: true,
 			tryCmuxNotify,
-			sendNodeNotify,
+			sendDesktopNotification,
 		})
 
 		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
-		expect(sendNodeNotify).not.toHaveBeenCalled()
+		expect(sendDesktopNotification).not.toHaveBeenCalled()
 	})
 
-	it("falls back to node notifier when cmux returns false", async () => {
+	it("falls back to desktop notifications when cmux returns false", async () => {
 		const tryCmuxNotify = mock(async () => false)
-		const sendNodeNotify = mock(() => {})
+		const sendDesktopNotification = mock(() => {})
 
 		await sendNotificationWithFallback({
 			preferCmux: true,
 			tryCmuxNotify,
-			sendNodeNotify,
+			sendDesktopNotification,
 		})
 
 		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(sendDesktopNotification).toHaveBeenCalledTimes(1)
 	})
 
-	it("falls back to node notifier when cmux throws", async () => {
+	it("falls back to desktop notifications when cmux throws", async () => {
 		const tryCmuxNotify = mock(async () => {
 			throw new Error("cmux unavailable")
 		})
-		const sendNodeNotify = mock(() => {})
+		const sendDesktopNotification = mock(() => {})
 
 		await sendNotificationWithFallback({
 			preferCmux: true,
 			tryCmuxNotify,
-			sendNodeNotify,
+			sendDesktopNotification,
 		})
 
 		expect(tryCmuxNotify).toHaveBeenCalledTimes(1)
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(sendDesktopNotification).toHaveBeenCalledTimes(1)
 	})
 
-	it("falls back to node notifier when cmux exits non-zero", async () => {
-		const sendNodeNotify = mock(() => {})
+	it("falls back to desktop notifications when cmux exits non-zero", async () => {
+		const sendDesktopNotification = mock(() => {})
 
 		await sendNotificationWithFallback({
 			preferCmux: true,
@@ -78,14 +83,14 @@ describe("notify backend fallback behavior", () => {
 						}),
 					},
 				),
-			sendNodeNotify,
+			sendDesktopNotification,
 		})
 
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(sendDesktopNotification).toHaveBeenCalledTimes(1)
 	})
 
-	it("falls back to node notifier when cmux times out", async () => {
-		const sendNodeNotify = mock(() => {})
+	it("falls back to desktop notifications when cmux times out", async () => {
+		const sendDesktopNotification = mock(() => {})
 
 		await sendNotificationWithFallback({
 			preferCmux: true,
@@ -104,9 +109,187 @@ describe("notify backend fallback behavior", () => {
 						}),
 					},
 				),
-			sendNodeNotify,
+			sendDesktopNotification,
 		})
 
-		expect(sendNodeNotify).toHaveBeenCalledTimes(1)
+		expect(sendDesktopNotification).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe("macOS alerter desktop notifications", () => {
+	it("routes darwin desktop notifications to alerter without calling node-notifier", async () => {
+		const sendMacOSNotification = mock(async () => true)
+		const nodeNotifierNotify = mock(() => {})
+
+		await sendDesktopNotificationByPlatform({
+			platform: "darwin",
+			title: "Waiting for you",
+			message: "Permission needed",
+			subtitle: "Session A",
+			sound: "Submarine",
+			senderBundleId: "com.mitchellh.ghostty",
+			sendMacOSNotification,
+			sendNodeNotifierNotification: nodeNotifierNotify,
+		})
+
+		expect(sendMacOSNotification).toHaveBeenCalledWith({
+			title: "Waiting for you",
+			message: "Permission needed",
+			subtitle: "Session A",
+			sound: "Submarine",
+			senderBundleId: "com.mitchellh.ghostty",
+		})
+		expect(nodeNotifierNotify).not.toHaveBeenCalled()
+	})
+
+	it("routes non-macOS desktop notifications to node-notifier without resolving or spawning alerter", async () => {
+		const sendMacOSNotification = mock(async () => {
+			throw new Error("alerter should not be used on non-macOS")
+		})
+		const nodeNotifierNotify = mock(() => {})
+
+		await sendDesktopNotificationByPlatform({
+			platform: "linux",
+			title: "Ready",
+			message: "Task complete",
+			sound: "Glass",
+			senderBundleId: "com.example.Terminal",
+			sendMacOSNotification,
+			sendNodeNotifierNotification: nodeNotifierNotify,
+		})
+
+		expect(nodeNotifierNotify).toHaveBeenCalledTimes(1)
+		expect(sendMacOSNotification).not.toHaveBeenCalled()
+	})
+
+	it("maps notification options to alerter argv", () => {
+		expect(
+			buildAlerterArguments({
+				title: "Waiting for you",
+				message: "Permission needed",
+				subtitle: "Session A",
+				sound: "Submarine",
+				senderBundleId: "com.mitchellh.ghostty",
+			}),
+		).toEqual([
+			"alerter",
+			"--message",
+			"Permission needed",
+			"--title",
+			"Waiting for you",
+			"--subtitle",
+			"Session A",
+			"--sound",
+			"Submarine",
+			"--sender",
+			"com.mitchellh.ghostty",
+		])
+	})
+
+	it("omits optional alerter flags when not configured", () => {
+		expect(
+			buildAlerterArguments({
+				title: "Ready",
+				message: "Task complete",
+			}),
+		).toEqual(["alerter", "--message", "Task complete", "--title", "Ready"])
+	})
+
+	it("spawns the resolved alerter binary without shell interpolation", async () => {
+		const spawnProcess = mock((argv: string[]) => ({
+			exited: Promise.resolve(0),
+		}))
+		const warn = mock(() => {})
+
+		const sent = await sendMacOSAlerterNotification(
+			{
+				title: "Question for you",
+				message: "Please answer",
+				sound: "Submarine",
+				senderBundleId: "com.googlecode.iterm2",
+			},
+			{
+				which: async () => "/opt/homebrew/bin/alerter",
+				spawnProcess,
+				warn,
+			},
+		)
+
+		expect(sent).toBe(true)
+		expect(spawnProcess).toHaveBeenCalledWith([
+			"/opt/homebrew/bin/alerter",
+			"--message",
+			"Please answer",
+			"--title",
+			"Question for you",
+			"--sound",
+			"Submarine",
+			"--sender",
+			"com.googlecode.iterm2",
+		])
+		expect(warn).not.toHaveBeenCalled()
+	})
+
+	it("warns and reports false when alerter is missing", async () => {
+		const spawnProcess = mock((argv: string[]) => ({
+			exited: Promise.resolve(0),
+		}))
+		const warn = mock(() => {})
+
+		const sent = await sendMacOSAlerterNotification(
+			{
+				title: "Ready",
+				message: "Task complete",
+			},
+			{
+				which: async () => null,
+				spawnProcess,
+				warn,
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(spawnProcess).not.toHaveBeenCalled()
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("alerter not found on PATH"))
+	})
+
+	it("warns and reports false when alerter exits non-zero", async () => {
+		const warn = mock(() => {})
+
+		const sent = await sendMacOSAlerterNotification(
+			{
+				title: "Ready",
+				message: "Task complete",
+			},
+			{
+				which: async () => "/usr/local/bin/alerter",
+				spawnProcess: () => ({ exited: Promise.resolve(2) }),
+				warn,
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(warn).toHaveBeenCalledWith("notify: macOS desktop notification skipped; alerter exited with code 2.")
+	})
+
+	it("warns and reports false when spawning alerter throws", async () => {
+		const warn = mock(() => {})
+
+		const sent = await sendMacOSAlerterNotification(
+			{
+				title: "Ready",
+				message: "Task complete",
+			},
+			{
+				which: async () => "/usr/local/bin/alerter",
+				spawnProcess: () => {
+					throw new Error("spawn failed")
+				},
+				warn,
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(warn).toHaveBeenCalledWith("notify: macOS desktop notification skipped; alerter failed (spawn failed).")
 	})
 })

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -19,6 +19,25 @@ const notifyMock = mock((payload: Record<string, unknown>) => {
 })
 const readActualFile = fsPromises.readFile
 
+function pushAlerterNotificationPayload(command: string[]): void {
+	if (!command[0]?.includes("alerter")) return
+
+	const payload: Record<string, unknown> = {}
+	for (let index = 1; index < command.length; index += 2) {
+		const flag = command[index]
+		const value = command[index + 1]
+		if (!flag || value === undefined) continue
+
+		if (flag === "--title") payload.title = value
+		if (flag === "--message") payload.message = value
+		if (flag === "--subtitle") payload.subtitle = value
+		if (flag === "--sound") payload.sound = value
+		if (flag === "--sender") payload.sender = value
+	}
+
+	notificationPayloads.push(payload)
+}
+
 mock.module("node:fs/promises", () => ({
 	...fsPromises,
 	readFile: async (filePath: Parameters<typeof fsPromises.readFile>[0], options?: Parameters<typeof fsPromises.readFile>[1]) => {
@@ -55,6 +74,24 @@ beforeEach(() => {
 	mockedTerminalName = null
 	notificationPayloads.length = 0
 	notifyMock.mockClear()
+	spyOn(Bun, "which").mockImplementation((command: string) =>
+		command === "alerter" ? "/usr/local/bin/alerter" : null,
+	)
+	spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+		const command = args[0]
+		if (Array.isArray(command) && typeof command[0] === "string" && command[0].includes("alerter")) {
+			pushAlerterNotificationPayload(command.map(String))
+			return {
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		}
+
+		return {
+			stdout: new Blob([""]).stream(),
+			stderr: new Blob([""]).stream(),
+			exited: Promise.resolve(0),
+		} as ReturnType<typeof Bun.spawn>
+	})
 	delete process.env.CMUX_WORKSPACE_ID
 	delete process.env.CMUX_SOCKET_PATH
 	delete process.env.CMUX_SOCKET_MODE
@@ -88,6 +125,13 @@ function mockFocusedTerminal(): void {
 
 	spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 		const command = args[0]
+		if (Array.isArray(command) && typeof command[0] === "string" && command[0].includes("alerter")) {
+			pushAlerterNotificationPayload(command.map(String))
+			return {
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		}
+
 		const script = Array.isArray(command) && typeof command[2] === "string" ? command[2] : ""
 		const output = script.includes("frontmost") ? "Ghostty\n" : "com.mitchellh.ghostty\n"
 


### PR DESCRIPTION
## Summary
- Migrate macOS desktop notification fallback to `vjeantet/alerter` using argv-array spawning and `--sender` for terminal identity.
- Preserve Windows/Linux desktop notifications through the existing `node-notifier` path and keep cmux-first routing with desktop fallback.
- Update notify docs and facade README with macOS 13+, PATH, Homebrew, MacPorts, and GitHub Releases/manual zip install requirements.

## Verification
- `bun test workers/kdco-registry/tests/notify-*.test.ts` — PASS (57 pass, 0 fail)
- `cd workers/kdco-registry && bun run check` — PASS (`tsc --noEmit`)
- `cd workers/kdco-registry && bun run build` — PASS (built 17 components and copied schemas)
- `bun run check` — PASS (4/4 turbo tasks successful)
- `bun run build` — PASS (3/3 turbo tasks successful)
- `bun run test` — PASS (1353 pass, 24 skip, 0 fail)

## Risk
- macOS desktop fallback now requires users to install `alerter` and keep it on `PATH`; missing or failing `alerter` is handled non-disruptively with a concise warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate macOS desktop notifications to `vjeantet/alerter` while keeping cmux-first routing and `node-notifier` on Windows/Linux. Adds a platform-aware backend with `--sender` to identify the active terminal.

- **New Features**
  - Added `sendDesktopNotificationByPlatform` to route macOS to `alerter`; Windows/Linux stay on `node-notifier`.
  - macOS spawns `alerter` via argv (no shell) and passes `--sender` when available.
  - Updated notify docs and facade README; added tests for routing and `alerter` behavior.

- **Migration**
  - macOS users must install `vjeantet/alerter` and ensure `alerter` is on `PATH`.
  - Example: Homebrew `brew install vjeantet/tap/alerter` (MacPorts or GitHub Releases also work).
  - If `alerter` is missing or fails, we warn and continue without breaking.

<sup>Written for commit fbc3d7e45017686ce6dba948a942fdd6358a0e77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

