### PR TITLE
fix(profile): Include commands and tools in profile merge overlays

### DIFF
--- a/packages/cli/src/commands/opencode-overlay.ts
+++ b/packages/cli/src/commands/opencode-overlay.ts
@@ -21,7 +21,16 @@ import { findLocalConfigDir, OCX_CONFIG_FILE } from "../profile/paths"
 import { ConfigError } from "../utils/errors"
 import { validatePath } from "../utils/path-security"
 
-export const OPENCODE_OVERLAY_SOURCE_SCOPES = ["agent", "agents", "skill", "skills"] as const
+export const OPENCODE_OVERLAY_SOURCE_SCOPES = [
+	"agent",
+	"agents",
+	"command",
+	"commands",
+	"skill",
+	"skills",
+	"tool",
+	"tools",
+] as const
 export const OPENCODE_MERGED_DIR_PREFIX = "ocx-oc-merged-"
 export const OVERLAY_TRANSACTION_MANIFEST_VERSION = 1
 

--- a/packages/cli/tests/opencode-overlay.test.ts
+++ b/packages/cli/tests/opencode-overlay.test.ts
@@ -922,6 +922,42 @@ describe("ocx oc profile overlay integration", () => {
 		}
 	})
 
+	it("merges project command and tool scopes over profile config", async () => {
+		const testDir = await createTempDir("oc-overlay-commands-tools")
+		try {
+			await createProfile(testDir, "work")
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(join(localConfigDir, "command"), { recursive: true })
+			await mkdir(join(localConfigDir, "commands"), { recursive: true })
+			await mkdir(join(localConfigDir, "tool"), { recursive: true })
+			await mkdir(join(localConfigDir, "tools"), { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "ocx.jsonc"),
+				JSON.stringify({ profile: "work" }, null, 2),
+			)
+			await Bun.write(join(localConfigDir, "command", "singular-command.md"), "singular command")
+			await Bun.write(join(localConfigDir, "commands", "plural-command.md"), "plural command")
+			await Bun.write(join(localConfigDir, "tool", "singular-tool.ts"), "singular tool")
+			await Bun.write(join(localConfigDir, "tools", "plural-tool.ts"), "plural tool")
+
+			const { result, payloadPath } = await runOcCapture({ testDir, profileName: "work" })
+			expect(result.exitCode).toBe(0)
+
+			const payload = await readCapturePayload(payloadPath)
+			expect(payload.files).toContain("command/singular-command.md")
+			expect(payload.files).toContain("commands/plural-command.md")
+			expect(payload.files).toContain("tool/singular-tool.ts")
+			expect(payload.files).toContain("tools/plural-tool.ts")
+			expect(payload.fileContents["command/singular-command.md"]).toBe("singular command")
+			expect(payload.fileContents["commands/plural-command.md"]).toBe("plural command")
+			expect(payload.fileContents["tool/singular-tool.ts"]).toBe("singular tool")
+			expect(payload.fileContents["tools/plural-tool.ts"]).toBe("plural tool")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
 	it("uses project .opencode/ocx.jsonc include/exclude policy with include-wins overlap", async () => {
 		const testDir = await createTempDir("oc-overlay-policy")
 		try {


### PR DESCRIPTION
Closes #209.

## Summary
- Include project \`.opencode/command\` and \`.opencode/commands\` in profile merge overlays
- Include project \`.opencode/tool\` and \`.opencode/tools\` in profile merge overlays
- Add regression coverage for all four command/tool overlay scopes

## Verification
- \`bun test packages/cli/tests/opencode-overlay.test.ts\` — 37 pass, 0 fail
- \`bun run --cwd packages/cli check\` — pass
- \`bun run --cwd packages/cli build\` — pass (\`✓ Build complete: ./dist/index.js (v2.0.9)\`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project command and tool scopes to profile merge overlays so `.opencode/command(s)` and `.opencode/tool(s)` correctly override profile config. Addresses #209.

- **Bug Fixes**
  - Expanded `OPENCODE_OVERLAY_SOURCE_SCOPES` to include `command`, `commands`, `tool`, `tools`.
  - Ensured files from these project dirs merge over profile config during overlay.
  - Added regression tests in `packages/cli` for all four scopes.

<sup>Written for commit f5b8486b46266342fdc3769759991eb52f738da6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

