### PR TITLE
fix(registry): Support standalone notify cmux

### DIFF
--- a/facades/opencode-notify/README.md
+++ b/facades/opencode-notify/README.md
@@ -141,8 +141,8 @@ If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` an
 - `.opencode/plugins/notify/cmux.ts`
 - `.opencode/plugins/notify/status.ts`
 - `.opencode/plugins/notify/title.ts`
-- `.opencode/plugins/worktree/terminal.ts`
 - `.opencode/plugins/kdco-primitives/index.ts`
+- `.opencode/plugins/kdco-primitives/cmux.ts`
 - `.opencode/plugins/kdco-primitives/get-project-id.ts`
 - `.opencode/plugins/kdco-primitives/log-warn.ts`
 - `.opencode/plugins/kdco-primitives/mutex.ts`
@@ -153,7 +153,7 @@ If you prefer not to use OCX, copy the plugin files into `.opencode/plugins/` an
 - `.opencode/plugins/kdco-primitives/with-timeout.ts`
 
 **Caveats:**
-- Manually install dependencies (`node-notifier`, `detect-terminal`, `zod`)
+- Manually install dependencies (`node-notifier`, `detect-terminal`)
 - On macOS 13+, install [`vjeantet/alerter`](https://github.com/vjeantet/alerter) and ensure `alerter` is on `PATH` (Homebrew: `brew install vjeantet/tap/alerter`; MacPorts and GitHub Releases/manual zip are also supported)
 - Install [cmux](https://www.cmux.dev/) if you want the additional [cmux](https://www.cmux.dev/)-native notification path
 - Updates require manual re-copying

--- a/workers/kdco-registry/files/plugins/kdco-primitives/cmux.ts
+++ b/workers/kdco-registry/files/plugins/kdco-primitives/cmux.ts
@@ -1,0 +1,41 @@
+export type ResolveExecutable = (command: string) => string | null | undefined
+export type CmuxEnvironment = Record<string, string | undefined>
+
+export interface CmuxContext {
+	workspaceID?: string
+	surfaceID?: string
+	socketPath?: string
+	socketMode?: string
+}
+
+function normalizeCmuxValue(value?: string): string | undefined {
+	const trimmed = value?.trim()
+	return trimmed ? trimmed : undefined
+}
+
+export function detectCmuxContext(env: CmuxEnvironment = process.env): CmuxContext {
+	return {
+		workspaceID: normalizeCmuxValue(env.CMUX_WORKSPACE_ID),
+		surfaceID: normalizeCmuxValue(env.CMUX_SURFACE_ID),
+		socketPath: normalizeCmuxValue(env.CMUX_SOCKET_PATH),
+		socketMode: normalizeCmuxValue(env.CMUX_SOCKET_MODE),
+	}
+}
+
+export function canUseCmuxWorkflow(
+	env: CmuxEnvironment = process.env,
+	resolveExecutable: ResolveExecutable = (command) => Bun.which(command),
+	cmuxExecutable: string = "cmux",
+): boolean {
+	if (!resolveExecutable(cmuxExecutable)) {
+		return false
+	}
+
+	const context = detectCmuxContext(env)
+	if (context.workspaceID) {
+		return true
+	}
+
+	const socketModeAllowsExternalControl = context.socketMode?.toLowerCase() === "allowall"
+	return Boolean(context.socketPath && socketModeAllowsExternalControl)
+}

--- a/workers/kdco-registry/files/plugins/kdco-primitives/index.ts
+++ b/workers/kdco-registry/files/plugins/kdco-primitives/index.ts
@@ -19,6 +19,13 @@ export { assertShellSafe, escapeAppleScript, escapeBash, escapeBatch } from "./s
 // Temp directory
 export { getTempDir } from "./temp"
 // Terminal detection
+export {
+	canUseCmuxWorkflow,
+	detectCmuxContext,
+	type CmuxContext,
+	type CmuxEnvironment,
+	type ResolveExecutable,
+} from "./cmux"
 export { isInsideTmux } from "./terminal-detect"
 // Types
 export type { OpencodeClient } from "./types"

--- a/workers/kdco-registry/files/plugins/notify/cmux.ts
+++ b/workers/kdco-registry/files/plugins/notify/cmux.ts
@@ -1,5 +1,5 @@
 import { TimeoutError, withTimeout } from "../kdco-primitives/with-timeout"
-import { canUseCmuxWorkflow } from "../worktree/terminal"
+import { canUseCmuxWorkflow } from "../kdco-primitives/cmux"
 
 interface CmuxNotificationPayload {
 	title: string

--- a/workers/kdco-registry/files/plugins/worktree/terminal.ts
+++ b/workers/kdco-registry/files/plugins/worktree/terminal.ts
@@ -12,8 +12,10 @@ import * as fs from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
 import { z } from "zod"
-import type { OpencodeClient } from "../kdco-primitives"
+import type { CmuxContext, CmuxEnvironment, OpencodeClient, ResolveExecutable } from "../kdco-primitives"
 import {
+	canUseCmuxWorkflow,
+	detectCmuxContext,
 	escapeAppleScript,
 	escapeBash,
 	escapeBatch,
@@ -23,6 +25,14 @@ import {
 	Mutex,
 	TimeoutError,
 	withTimeout,
+} from "../kdco-primitives"
+
+export {
+	canUseCmuxWorkflow,
+	detectCmuxContext,
+	type CmuxContext,
+	type CmuxEnvironment,
+	type ResolveExecutable,
 } from "../kdco-primitives"
 
 // =============================================================================
@@ -160,8 +170,6 @@ export function buildBatchCommandFromArgv(argv?: string[]): string | undefined {
 	return normalizedArgv.map((arg) => `"${escapeBatch(arg).replace(/"/g, '""')}"`).join(" ")
 }
 
-type ResolveExecutable = (command: string) => string | null | undefined
-type CmuxEnvironment = Record<string, string | undefined>
 type CmuxCommandResult = {
 	exitCode: number
 	stderr: string
@@ -189,14 +197,6 @@ const STABILIZATION_DELAY_MS = 150
 const wslEnvSchema = z.object({
 	WSL_DISTRO_NAME: z.string().optional(),
 	WSLENV: z.string().optional(),
-})
-
-/** Validates cmux environment detection */
-const cmuxEnvSchema = z.object({
-	CMUX_WORKSPACE_ID: z.string().optional(),
-	CMUX_SURFACE_ID: z.string().optional(),
-	CMUX_SOCKET_PATH: z.string().optional(),
-	CMUX_SOCKET_MODE: z.string().optional(),
 })
 
 /** Validates Linux terminal environment detection */
@@ -256,47 +256,6 @@ function isInsideWSL(): boolean {
 	} catch {
 		return false
 	}
-}
-
-export interface CmuxContext {
-	workspaceID?: string
-	surfaceID?: string
-	socketPath?: string
-	socketMode?: string
-}
-
-function normalizeCmuxValue(value?: string): string | undefined {
-	const trimmed = value?.trim()
-	return trimmed ? trimmed : undefined
-}
-
-export function detectCmuxContext(env: CmuxEnvironment = process.env): CmuxContext {
-	const parsed = cmuxEnvSchema.parse(env)
-
-	return {
-		workspaceID: normalizeCmuxValue(parsed.CMUX_WORKSPACE_ID),
-		surfaceID: normalizeCmuxValue(parsed.CMUX_SURFACE_ID),
-		socketPath: normalizeCmuxValue(parsed.CMUX_SOCKET_PATH),
-		socketMode: normalizeCmuxValue(parsed.CMUX_SOCKET_MODE),
-	}
-}
-
-export function canUseCmuxWorkflow(
-	env: CmuxEnvironment = process.env,
-	resolveExecutable: ResolveExecutable = (command) => Bun.which(command),
-	cmuxExecutable: string = "cmux",
-): boolean {
-	if (!resolveExecutable(cmuxExecutable)) {
-		return false
-	}
-
-	const context = detectCmuxContext(env)
-	if (context.workspaceID) {
-		return true
-	}
-
-	const socketModeAllowsExternalControl = context.socketMode?.toLowerCase() === "allowall"
-	return Boolean(context.socketPath && socketModeAllowsExternalControl)
 }
 
 type PlatformTerminalType = Exclude<TerminalType, "tmux" | "cmux">

--- a/workers/kdco-registry/registry.jsonc
+++ b/workers/kdco-registry/registry.jsonc
@@ -27,6 +27,7 @@
 				"plugins/kdco-primitives/mutex.ts",
 				"plugins/kdco-primitives/shell.ts",
 				"plugins/kdco-primitives/temp.ts",
+				"plugins/kdco-primitives/cmux.ts",
 				"plugins/kdco-primitives/terminal-detect.ts",
 				"plugins/kdco-primitives/index.ts"
 			],

--- a/workers/kdco-registry/tests/notify-cmux.test.ts
+++ b/workers/kdco-registry/tests/notify-cmux.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { parse as parseJsonc } from "jsonc-parser"
+import { detectCmuxContext } from "../files/plugins/kdco-primitives/cmux"
 import {
 	buildCmuxClearStatusArgs,
 	buildCmuxNotifyArgs,
@@ -9,7 +15,58 @@ import {
 	sendCmuxStatus,
 } from "../files/plugins/notify/cmux"
 
+const registryPath = path.join(import.meta.dir, "..", "registry.jsonc")
+const registryFilesRoot = path.join(import.meta.dir, "..", "files")
+
 describe("notify cmux integration", () => {
+	it("detects cmux context from the shared primitive", () => {
+		const context = detectCmuxContext({
+			CMUX_WORKSPACE_ID: " workspace-123 ",
+			CMUX_SURFACE_ID: " ",
+			CMUX_SOCKET_PATH: " /tmp/cmux.sock ",
+			CMUX_SOCKET_MODE: " allowall ",
+		})
+
+		expect(context).toEqual({
+			workspaceID: "workspace-123",
+			surfaceID: undefined,
+			socketPath: "/tmp/cmux.sock",
+			socketMode: "allowall",
+		})
+	})
+
+	it("imports from a notify plus kdco-primitives install footprint without worktree terminal", async () => {
+		const registry = parseJsonc(fs.readFileSync(registryPath, "utf8")) as {
+			components: Array<{ name: string; files: string[] }>
+		}
+		const componentFiles = ["notify", "kdco-primitives"].flatMap((componentName) => {
+			const component = registry.components.find((entry) => entry.name === componentName)
+			if (!component) {
+				throw new Error(`Missing registry component: ${componentName}`)
+			}
+			return component.files
+		})
+
+		const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "notify-cmux-footprint-"))
+		try {
+			for (const file of componentFiles) {
+				const sourcePath = path.join(registryFilesRoot, file)
+				const targetPath = path.join(tempRoot, file)
+				fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+				fs.copyFileSync(sourcePath, targetPath)
+			}
+
+			expect(fs.existsSync(path.join(tempRoot, "plugins/worktree/terminal.ts"))).toBe(false)
+
+			const moduleUrl = pathToFileURL(path.join(tempRoot, "plugins/notify/cmux.ts")).href
+			const module = await import(`${moduleUrl}?test=${Date.now()}`)
+
+			expect(module.canUseCmuxNotification({ CMUX_WORKSPACE_ID: "workspace-123" }, () => "cmux")).toBe(true)
+		} finally {
+			fs.rmSync(tempRoot, { recursive: true, force: true })
+		}
+	})
+
 	it("returns false when no cmux context is available", () => {
 		const env = { PATH: "/usr/bin" }
 		const canUse = canUseCmuxNotification(env, () => "/usr/local/bin/cmux")


### PR DESCRIPTION
## Summary
- Move shared cmux context/workflow detection into kdco-primitives without a zod dependency.
- Update notify/worktree imports and registry packaging so standalone notify can import cmux primitives without worktree terminal.
- Update opencode-notify manual install docs to remove the worktree/zod requirement.

## Tests
- bun test workers/kdco-registry/tests/notify-cmux.test.ts workers/kdco-registry/tests/worktree-terminal.test.ts
- bun test workers/kdco-registry/tests/notify-plugin.test.ts workers/kdco-registry/tests/notify-backend.test.ts
- bun run --cwd workers/kdco-registry check
- Isolated footprint import command output IMPORT_OK
- git diff --check

Closes #211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes standalone `notify` cmux by moving cmux detection into `kdco-primitives` (no `zod`) and updating packaging so `notify` works without `worktree/terminal`. Closes #211.

- **Bug Fixes**
  - Added `kdco-primitives/cmux.ts` with `detectCmuxContext` and `canUseCmuxWorkflow`, and switched `notify/cmux.ts` to use it.
  - Updated `registry.jsonc` and tests to support a minimal `notify` + `kdco-primitives` footprint (no `worktree/terminal`).
  - Updated `opencode-notify` manual install docs to remove `zod` and reflect the new file list.

- **Migration**
  - Manual installs: copy `plugins/kdco-primitives/cmux.ts`; you no longer need `plugins/worktree/terminal.ts` or `zod`.
  - Dependencies now: `node-notifier`, `detect-terminal` (plus optional `cmux`).

<sup>Written for commit cb50eb35a1ee457a44148538c16c7fd23551430b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

