### PR TITLE
fix(cli): List symlinked profile directories

### DIFF
--- a/packages/cli/src/profile/manager.ts
+++ b/packages/cli/src/profile/manager.ts
@@ -197,10 +197,31 @@ export class ProfileManager {
 		await this.ensureInitialized()
 
 		const entries = await readdir(this.profilesDir, { withFileTypes: true, encoding: "utf8" })
-		return entries
-			.filter((e) => e.isDirectory() && !e.name.startsWith("."))
-			.map((e) => e.name)
-			.sort()
+		const profiles: string[] = []
+
+		for (const entry of entries) {
+			if (entry.name.startsWith(".") || entry.name === "current") {
+				continue
+			}
+
+			if (entry.isDirectory()) {
+				profiles.push(entry.name)
+				continue
+			}
+
+			if (entry.isSymbolicLink()) {
+				try {
+					const stats = await stat(getProfileDir(entry.name))
+					if (stats.isDirectory()) {
+						profiles.push(entry.name)
+					}
+				} catch {
+					// Broken symlinks and inaccessible targets are not profile directories.
+				}
+			}
+		}
+
+		return profiles.sort()
 	}
 
 	/**

--- a/packages/cli/tests/profile-commands.test.ts
+++ b/packages/cli/tests/profile-commands.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdir } from "node:fs/promises"
+import { mkdir, symlink } from "node:fs/promises"
 import { join } from "node:path"
 import { cleanupTempDir, createTempDir, runCLI } from "./helpers"
 
@@ -237,6 +237,28 @@ describe("ocx profile list", () => {
 		expect(payload.initialized).toBe(true)
 		expect(payload.profiles).toContain(GLOBAL_ONLY_PROFILE)
 		expect(payload.profiles).not.toContain(LOCAL_ONLY_PROFILE)
+	})
+
+	it("should list and show symlinked global profiles", async () => {
+		const configDir = join(testDir, "opencode")
+		const targetDir = join(testDir, "external-profiles", "symlinked-profile-target")
+		await mkdir(targetDir, { recursive: true })
+		await Bun.write(
+			join(targetDir, "ocx.jsonc"),
+			JSON.stringify({ componentPath: "components/symlinked-profile-999" }, null, 2),
+		)
+		await symlink(targetDir, join(configDir, "profiles", "symlinked-profile"))
+
+		const listResult = await runCLI(["profile", "list", "--global"], testDir)
+
+		expect(listResult.exitCode).toBe(0)
+		expect(listResult.stdout).toContain("symlinked-profile")
+
+		const showResult = await runCLI(["profile", "show", "symlinked-profile", "--global"], testDir)
+
+		expect(showResult.exitCode).toBe(0)
+		expect(showResult.stdout).toContain("symlinked-profile")
+		expect(showResult.stdout).toContain("components/symlinked-profile-999")
 	})
 })
 

--- a/packages/cli/tests/profile/manager.test.ts
+++ b/packages/cli/tests/profile/manager.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdir, rm, stat } from "node:fs/promises"
+import { mkdir, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { ProfileManager } from "../../src/profile/manager"
 import { getProfileDir, getProfilesDir } from "../../src/profile/paths"
@@ -178,6 +178,44 @@ describe("ProfileManager.list", () => {
 		const profiles = await manager.list()
 
 		expect(profiles).not.toContain(".hidden")
+	})
+
+	it("should include symlinks that resolve to directories", async () => {
+		const manager = ProfileManager.create()
+		await manager.initialize()
+		await manager.add("zebra")
+
+		const targetDir = join(testDir, "external-profiles", "alpha-link-target")
+		await mkdir(targetDir, { recursive: true })
+		await symlink(targetDir, join(getProfilesDir(), "alpha-link"))
+
+		const profiles = await manager.list()
+
+		expect(profiles).toEqual(["alpha-link", "default", "zebra"])
+	})
+
+	it("should exclude broken symlinks", async () => {
+		const manager = ProfileManager.create()
+		await manager.initialize()
+
+		await symlink(join(testDir, "missing-profile-target"), join(getProfilesDir(), "broken-link"))
+
+		const profiles = await manager.list()
+
+		expect(profiles).not.toContain("broken-link")
+	})
+
+	it("should exclude symlinks that resolve to regular files", async () => {
+		const manager = ProfileManager.create()
+		await manager.initialize()
+
+		const targetFile = join(testDir, "not-a-profile")
+		await writeFile(targetFile, "not a directory")
+		await symlink(targetFile, join(getProfilesDir(), "file-link"))
+
+		const profiles = await manager.list()
+
+		expect(profiles).not.toContain("file-link")
 	})
 
 	it("should not include current symlink in list", async () => {


### PR DESCRIPTION
## Summary
- Update profile listing to include symlinked profile entries whose targets resolve to directories.
- Keep hidden entries, current, broken symlinks, and symlinks to non-directories excluded from profile lists.
- Add manager and CLI regression coverage for symlinked profile list/show behavior.

## Tests
- bun test packages/cli/tests/profile/manager.test.ts
- bun test packages/cli/tests/profile-commands.test.ts
- bun run --cwd packages/cli check

Fixes #213

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Includes symlinked profiles in profile lists and CLI when their targets are directories. Hidden entries, current, broken symlinks, and non-directory links remain excluded.

- Bug Fixes
  - Updated `ProfileManager.list` to resolve symlinks and include directory targets only.
  - Ensured CLI `profile list`/`show` handle symlinked global profiles.
  - Added regression tests for manager and CLI covering symlink cases.
  - Fixes #213.

<sup>Written for commit 718cb8a37dc84a9d5f8f4c66cce762287013d443. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

