### PR TITLE
docs: Remove obsolete migration docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Profiles control what OpenCode sees through `exclude`/`include` patterns. Each p
 | `ocx oc -p <name>` | Launch OpenCode with a profile |
 | `ocx profile list --global` | List your profiles |
 | `ocx config edit --global` | Edit your global config |
-| `ocx migrate` | Dry-run preview of v1.4.6 → v2 migration (shows what would change, no writes) |
-| `ocx migrate --apply` | Apply migration to receipt format |
-| `ocx migrate --global` | Dry-run preview of global root + all profiles migration |
-| `ocx migrate --global --apply` | Apply migration across global root and profiles |
 
 **[Full CLI Reference →](https://ocx.kdco.dev/docs/cli/commands)**
 
@@ -90,23 +86,6 @@ ocx add kdco/workspace
 ```
 
 See [Components & Registries](https://ocx.kdco.dev/docs/registries/create) for more.
-
-### Upgrading from v1.4.6
-
-If you have an existing v1.4.6 project, migrate to the receipt format (`.ocx/receipt.jsonc`):
-
-```bash
-ocx migrate          # Dry-run: shows what would be migrated (no files written)
-ocx migrate --apply  # Apply migration
-ocx verify           # Confirm integrity post-migration
-```
-
-For global config migration (migrates global root and all profiles):
-
-```bash
-ocx migrate --global          # Preview migration across global root + all profiles
-ocx migrate --global --apply  # Apply migration to global root and every profile
-```
 
 ### Creating Registries
 


### PR DESCRIPTION
## Summary
- remove obsolete v1 migration commands from the README common commands table
- remove the old v1.4.6 upgrade section from the README

## Verification
- git diff -- README.md
- README grep for migrate/v1.4.6/v2 migration returned no matches
- bunx biome check README.md (README ignored by Biome)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed obsolete v1.4.6 → v2 migration docs from the README to avoid confusion and reflect the current release. Dropped `ocx migrate` commands from the common commands table and deleted the v1.4.6 upgrade section.

<sup>Written for commit a3c2c181b2741529ccc6f245f2917a3e1936b185. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/215?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

