### PR TITLE
fix(profile): Exclude project tools from profile overlays

### DIFF
--- a/packages/cli/src/commands/opencode-overlay.ts
+++ b/packages/cli/src/commands/opencode-overlay.ts
@@ -29,8 +29,6 @@ export const OPENCODE_OVERLAY_SOURCE_SCOPES = [
 	"commands",
 	"skill",
 	"skills",
-	"tool",
-	"tools",
 ] as const
 export const OPENCODE_MERGED_DIR_PREFIX = "ocx-oc-merged-"
 export const OVERLAY_TRANSACTION_MANIFEST_VERSION = 1

--- a/packages/cli/tests/opencode-overlay.test.ts
+++ b/packages/cli/tests/opencode-overlay.test.ts
@@ -16,6 +16,7 @@ import {
 	applyOverlayCopyOperations,
 	loadProjectOverlayPolicy,
 	OPENCODE_MERGED_DIR_PREFIX,
+	OPENCODE_OVERLAY_SOURCE_SCOPES,
 	planOverlayCopyOperations,
 	prepareMergedConfigDirForProfile,
 } from "../src/commands/opencode-overlay"
@@ -203,6 +204,13 @@ async function listMergedDirs(tmpRoot: string): Promise<string[]> {
 }
 
 describe("opencode overlay planner", () => {
+	it("does not discover executable tool scopes for project profile overlays", () => {
+		expect(OPENCODE_OVERLAY_SOURCE_SCOPES).toContain("command")
+		expect(OPENCODE_OVERLAY_SOURCE_SCOPES).toContain("commands")
+		expect(OPENCODE_OVERLAY_SOURCE_SCOPES).not.toContain("tool")
+		expect(OPENCODE_OVERLAY_SOURCE_SCOPES).not.toContain("tools")
+	})
+
 	it("uses TypeScript-style include/exclude matrix with include-wins overlap", () => {
 		const candidates = [
 			{ sourcePath: "/tmp/agents/alpha.md", overlayRelativePath: "agents/alpha.md" },
@@ -922,7 +930,7 @@ describe("ocx oc profile overlay integration", () => {
 		}
 	})
 
-	it("merges project command and tool scopes over profile config", async () => {
+	it("merges project command scopes over profile config but excludes tool scopes", async () => {
 		const testDir = await createTempDir("oc-overlay-commands-tools")
 		try {
 			await createProfile(testDir, "work")
@@ -947,12 +955,40 @@ describe("ocx oc profile overlay integration", () => {
 			const payload = await readCapturePayload(payloadPath)
 			expect(payload.files).toContain("command/singular-command.md")
 			expect(payload.files).toContain("commands/plural-command.md")
-			expect(payload.files).toContain("tool/singular-tool.ts")
-			expect(payload.files).toContain("tools/plural-tool.ts")
+			expect(payload.files).not.toContain("tool/singular-tool.ts")
+			expect(payload.files).not.toContain("tools/plural-tool.ts")
 			expect(payload.fileContents["command/singular-command.md"]).toBe("singular command")
 			expect(payload.fileContents["commands/plural-command.md"]).toBe("plural command")
-			expect(payload.fileContents["tool/singular-tool.ts"]).toBe("singular tool")
-			expect(payload.fileContents["tools/plural-tool.ts"]).toBe("plural tool")
+			expect(payload.fileContents["tool/singular-tool.ts"]).toBeUndefined()
+			expect(payload.fileContents["tools/plural-tool.ts"]).toBeUndefined()
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("does not allow project policy includes to re-enable tool scopes", async () => {
+		const testDir = await createTempDir("oc-overlay-tools-policy-bypass")
+		try {
+			await createProfile(testDir, "work")
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(join(localConfigDir, "tool"), { recursive: true })
+			await mkdir(join(localConfigDir, "tools"), { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "ocx.jsonc"),
+				JSON.stringify({ profile: "work", include: ["tool/**", "tools/**"] }, null, 2),
+			)
+			await Bun.write(join(localConfigDir, "tool", "singular-tool.ts"), "singular tool")
+			await Bun.write(join(localConfigDir, "tools", "plural-tool.ts"), "plural tool")
+
+			const { result, payloadPath } = await runOcCapture({ testDir, profileName: "work" })
+			expect(result.exitCode).toBe(0)
+
+			const payload = await readCapturePayload(payloadPath)
+			expect(payload.files).not.toContain("tool/singular-tool.ts")
+			expect(payload.files).not.toContain("tools/plural-tool.ts")
+			expect(payload.fileContents["tool/singular-tool.ts"]).toBeUndefined()
+			expect(payload.fileContents["tools/plural-tool.ts"]).toBeUndefined()
 		} finally {
 			await cleanupTempDir(testDir)
 		}


### PR DESCRIPTION
## Summary

Fixes the profile/project isolation bypass where project-controlled `.opencode/tool` and `.opencode/tools` files were copied into the temporary merged OpenCode config directory for profile launches.

The profile launch path still copies trusted profile-owned files into the merged config directory, and project command overlays continue to work. The change only removes executable project tool scopes from project overlay discovery.

## Root cause

`OPENCODE_OVERLAY_SOURCE_SCOPES` included `tool` and `tools`. Because project overlay policy defaults to include-all, and profile launches pass the merged directory through `OPENCODE_CONFIG_DIR` while setting `OPENCODE_DISABLE_PROJECT_CONFIG=true`, project custom tool modules could cross the intended isolation boundary.

## Changes

- Removed `tool` and `tools` from project profile overlay source scopes.
- Updated the command/tool overlay integration test so `command` and `commands` are still copied while `tool` and `tools` are excluded.
- Added a direct regression guard on `OPENCODE_OVERLAY_SOURCE_SCOPES`.
- Added a policy-bypass regression test proving `include: ["tool/**", "tools/**"]` cannot re-enable tool discovery.

## Verification

- `bun test packages/cli/tests/opencode-overlay.test.ts --test-name-pattern "does not discover executable tool scopes|merges project command scopes|does not allow project policy"`
  - `3 pass, 0 fail`
- `bun test packages/cli/tests/opencode-overlay.test.ts`
  - `39 pass, 0 fail`
- `bun run --cwd packages/cli check`
  - Biome and `tsc --noEmit` passed.
- `git diff --check`
  - Passed.
- `bun test` from `packages/cli`
  - `1360 pass, 7 skip, 0 fail`

## Manual security verification

Ran a disposable-project PoC against the real `prepareMergedConfigDirForProfile()` and `buildOpenCodeEnv()` implementation with project policy explicitly including `tool/**`, `tools/**`, and `command/**`.

Observed:

- `OPENCODE_DISABLE_PROJECT_CONFIG` was `true`.
- `OPENCODE_CONFIG_DIR` pointed at the temporary merged config directory.
- `command/ok.md` was copied.
- `tool/evil.ts` was not copied.
- `tools/evil2.ts` was not copied.
- No copied tool import was possible, and the tool side-effect marker was not created.

Independent QA also verified through the real `oc --profile work` launch path that project tools are absent even under explicit include policy while profile-owned `tool` / `tools` files remain present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents project tools from bypassing profile isolation by excluding `tool` and `tools` scopes from project profile overlay discovery. Project command overlays still work, and trusted profile-owned tools remain available.

- **Bug Fixes**
  - Removed `tool` and `tools` from `OPENCODE_OVERLAY_SOURCE_SCOPES` to avoid copying project tools into the merged config during profile launches.
  - Updated integration test: `command`/`commands` are copied; `tool`/`tools` are excluded.
  - Added regression checks for `OPENCODE_OVERLAY_SOURCE_SCOPES` and a policy-bypass test ensuring `include: ["tool/**", "tools/**"]` cannot re-enable tool discovery.

<sup>Written for commit c404836c460cdc50c41c594a1cf4d915ea7365e4. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

