### PR TITLE
fix(cli): Enforce profile exclusions for project overlays

### DIFF
--- a/packages/cli/src/commands/opencode-overlay.ts
+++ b/packages/cli/src/commands/opencode-overlay.ts
@@ -440,6 +440,15 @@ export function planOverlayCopyOperations(
 		}))
 }
 
+function filterCandidatesByProfileVisibilityPolicy(
+	candidates: readonly OverlayCandidate[],
+	profileVisibilityPolicy: ProjectOverlayPolicy,
+): OverlayCandidate[] {
+	return candidates.filter((candidate) =>
+		shouldIncludeOverlayPath(`.opencode/${candidate.overlayRelativePath}`, profileVisibilityPolicy),
+	)
+}
+
 async function rejectSymlinkEntry(
 	projectConfigRealPath: string,
 	absolutePath: string,
@@ -984,6 +993,7 @@ export interface OverlayPrepareSeams {
 interface PrepareMergedConfigDirOptions {
 	projectDir: string
 	profileDir: string
+	profileVisibilityPolicy: ProjectOverlayPolicy
 	hardeningMode?: OverlayHardeningMode
 	seams?: OverlayPrepareSeams
 }
@@ -1055,9 +1065,13 @@ export async function prepareMergedConfigDirForProfile(
 		if (localConfigDir) {
 			const projectOverlayConfigDir = await resolveProjectOverlayConfigDir(localConfigDir)
 			const policy = await loadProjectOverlayPolicy(projectOverlayConfigDir)
-			const candidates = await collectOverlayCandidates(
+			const rawCandidates = await collectOverlayCandidates(
 				projectOverlayConfigDir,
 				options.seams?.collection,
+			)
+			const candidates = filterCandidatesByProfileVisibilityPolicy(
+				rawCandidates,
+				options.profileVisibilityPolicy,
 			)
 			const copyPlan = planOverlayCopyOperations(candidates, policy)
 			const manifest = buildOverlayTransactionManifest(projectOverlayConfigDir, copyPlan)

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -751,9 +751,20 @@ async function runOpencode(args: string[], options: OpencodeOptions): Promise<vo
 		}
 
 		if (config.profileName) {
+			if (!profile) {
+				throw createOpencodeOcError(
+					"validate",
+					`Resolved profile ${config.profileName} is missing during profile launch`,
+				)
+			}
+
 			mergedConfig = await prepareMergedConfigDirForProfile({
 				projectDir,
 				profileDir: getProfileDir(config.profileName),
+				profileVisibilityPolicy: {
+					include: profile.ocx.include,
+					exclude: profile.ocx.exclude,
+				},
 			})
 		}
 

--- a/packages/cli/tests/opencode-overlay.test.ts
+++ b/packages/cli/tests/opencode-overlay.test.ts
@@ -35,6 +35,8 @@ interface PromptCapturePayload {
 	promptContent: string | null
 }
 
+const ALLOW_ALL_PROFILE_VISIBILITY_POLICY = { include: [], exclude: [] }
+
 async function createProfile(testDir: string, name: string): Promise<string> {
 	const profileDir = join(testDir, "opencode", "profiles", name)
 	await mkdir(profileDir, { recursive: true })
@@ -43,6 +45,16 @@ async function createProfile(testDir: string, name: string): Promise<string> {
 		JSON.stringify({ registries: {}, profileMarker: "profile" }, null, 2),
 	)
 	return profileDir
+}
+
+async function writeProfileVisibilityPolicy(
+	profileDir: string,
+	policy: { include: string[]; exclude: string[] },
+): Promise<void> {
+	await Bun.write(
+		join(profileDir, "ocx.jsonc"),
+		JSON.stringify({ registries: {}, profileMarker: "profile", ...policy }, null, 2),
+	)
 }
 
 async function createCaptureScript(testDir: string): Promise<string> {
@@ -529,6 +541,7 @@ describe("opencode overlay planner", () => {
 				prepareMergedConfigDirForProfile({
 					projectDir: testDir,
 					profileDir,
+					profileVisibilityPolicy: ALLOW_ALL_PROFILE_VISIBILITY_POLICY,
 					hardeningMode: "native-fd-required",
 				}),
 			).rejects.toThrow(/Native fd helper required for overlay merge/i)
@@ -552,6 +565,7 @@ describe("opencode overlay planner", () => {
 			prepared = await prepareMergedConfigDirForProfile({
 				projectDir: testDir,
 				profileDir,
+				profileVisibilityPolicy: ALLOW_ALL_PROFILE_VISIBILITY_POLICY,
 				hardeningMode: "native-fd-required",
 			})
 
@@ -582,6 +596,7 @@ describe("opencode overlay planner", () => {
 			const prepared = await prepareMergedConfigDirForProfile({
 				projectDir: testDir,
 				profileDir,
+				profileVisibilityPolicy: ALLOW_ALL_PROFILE_VISIBILITY_POLICY,
 				seams: {
 					nativeHelper: {
 						name: "test-native-helper",
@@ -644,6 +659,7 @@ describe("opencode overlay planner", () => {
 				prepareMergedConfigDirForProfile({
 					projectDir: testDir,
 					profileDir,
+					profileVisibilityPolicy: ALLOW_ALL_PROFILE_VISIBILITY_POLICY,
 					seams: {
 						collection: {
 							beforeScopeInspect: async () => {
@@ -689,6 +705,7 @@ describe("opencode overlay planner", () => {
 				prepareMergedConfigDirForProfile({
 					projectDir: testDir,
 					profileDir,
+					profileVisibilityPolicy: ALLOW_ALL_PROFILE_VISIBILITY_POLICY,
 					seams: {
 						collection: {
 							beforeDirectoryRead: async (context: {
@@ -736,6 +753,7 @@ describe("opencode overlay planner", () => {
 				prepareMergedConfigDirForProfile({
 					projectDir: testDir,
 					profileDir,
+					profileVisibilityPolicy: ALLOW_ALL_PROFILE_VISIBILITY_POLICY,
 					seams: {
 						copy: {
 							beforeSourceVerification: async (operation: {
@@ -876,10 +894,83 @@ describe("opencode overlay planner", () => {
 			await cleanupTempDir(testDir)
 		}
 	})
+
+	it("applies active profile exclusions before project overlay policy defaults", async () => {
+		const testDir = await createTempDir("oc-overlay-profile-exclude")
+		let prepared: Awaited<ReturnType<typeof prepareMergedConfigDirForProfile>> | null = null
+		try {
+			const profileDir = await createProfile(testDir, "work")
+			await mkdir(join(profileDir, "agents"), { recursive: true })
+			await mkdir(join(profileDir, "skills"), { recursive: true })
+			await writeFile(join(profileDir, "agents", "shared.md"), "profile-agent")
+			await writeFile(join(profileDir, "skills", "profile-skill.md"), "profile-skill")
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(join(localConfigDir, "agents"), { recursive: true })
+			await mkdir(join(localConfigDir, "skills"), { recursive: true })
+			await writeFile(join(localConfigDir, "agents", "evil.md"), "project-agent")
+			await writeFile(join(localConfigDir, "skills", "evil-skill.md"), "project-skill")
+			await writeFile(join(localConfigDir, "agents", "shared.md"), "project-agent")
+
+			prepared = await prepareMergedConfigDirForProfile({
+				projectDir: testDir,
+				profileDir,
+				profileVisibilityPolicy: {
+					include: [],
+					exclude: ["**/.opencode/**"],
+				},
+			})
+
+			await expect(readFile(join(prepared.path, "agents", "evil.md"), "utf8")).rejects.toThrow()
+			await expect(
+				readFile(join(prepared.path, "skills", "evil-skill.md"), "utf8"),
+			).rejects.toThrow()
+			expect(await readFile(join(prepared.path, "agents", "shared.md"), "utf8")).toBe(
+				"profile-agent",
+			)
+		} finally {
+			if (prepared) {
+				await prepared.cleanup()
+			}
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("lets profile include rules opt project overlay files back in", async () => {
+		const testDir = await createTempDir("oc-overlay-profile-include")
+		let prepared: Awaited<ReturnType<typeof prepareMergedConfigDirForProfile>> | null = null
+		try {
+			const profileDir = await createProfile(testDir, "work")
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(join(localConfigDir, "agents"), { recursive: true })
+			await mkdir(join(localConfigDir, "skills"), { recursive: true })
+			await writeFile(join(localConfigDir, "agents", "keep.md"), "keep")
+			await writeFile(join(localConfigDir, "agents", "drop.md"), "drop")
+			await writeFile(join(localConfigDir, "skills", "drop.md"), "drop")
+
+			prepared = await prepareMergedConfigDirForProfile({
+				projectDir: testDir,
+				profileDir,
+				profileVisibilityPolicy: {
+					include: ["**/.opencode/agents/keep.md"],
+					exclude: ["**/.opencode/**"],
+				},
+			})
+
+			expect(await readFile(join(prepared.path, "agents", "keep.md"), "utf8")).toBe("keep")
+			await expect(readFile(join(prepared.path, "agents", "drop.md"), "utf8")).rejects.toThrow()
+			await expect(readFile(join(prepared.path, "skills", "drop.md"), "utf8")).rejects.toThrow()
+		} finally {
+			if (prepared) {
+				await prepared.cleanup()
+			}
+			await cleanupTempDir(testDir)
+		}
+	})
 })
 
 describe("ocx oc profile overlay integration", () => {
-	it("merges project agents/skills over profile with no leakage beyond overlay scope", async () => {
+	it("does not merge project agents/skills when the active profile excludes .opencode", async () => {
 		const testDir = await createTempDir("oc-overlay-visibility")
 		try {
 			const profileDir = await createProfile(testDir, "work")
@@ -912,8 +1003,8 @@ describe("ocx oc profile overlay integration", () => {
 			expect(payload.configDir).not.toBe(profileDir)
 			expect(payload.files).toContain("agents/profile-agent.md")
 			expect(payload.files).toContain("skills/profile-skill.md")
-			expect(payload.files).toContain("agents/project-agent.md")
-			expect(payload.files).toContain("skills/project-skill.md")
+			expect(payload.files).not.toContain("agents/project-agent.md")
+			expect(payload.files).not.toContain("skills/project-skill.md")
 			expect(payload.files).not.toContain("notes/should-not-leak.md")
 			expect(payload.fileContents["ocx.jsonc"] ?? "").toContain("profileMarker")
 			expect(payload.fileContents["ocx.jsonc"] ?? "").not.toContain("projectMarker")
@@ -922,7 +1013,7 @@ describe("ocx oc profile overlay integration", () => {
 		}
 	})
 
-	it("merges project command and tool scopes over profile config", async () => {
+	it("does not merge project command and tool scopes when the active profile excludes .opencode", async () => {
 		const testDir = await createTempDir("oc-overlay-commands-tools")
 		try {
 			await createProfile(testDir, "work")
@@ -945,13 +1036,47 @@ describe("ocx oc profile overlay integration", () => {
 			expect(result.exitCode).toBe(0)
 
 			const payload = await readCapturePayload(payloadPath)
+			expect(payload.files).not.toContain("command/singular-command.md")
+			expect(payload.files).not.toContain("commands/plural-command.md")
+			expect(payload.files).not.toContain("tool/singular-tool.ts")
+			expect(payload.files).not.toContain("tools/plural-tool.ts")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("merges project command and tool scopes when the active profile explicitly includes them", async () => {
+		const testDir = await createTempDir("oc-overlay-commands-tools-included")
+		try {
+			const profileDir = await createProfile(testDir, "work")
+			await writeProfileVisibilityPolicy(profileDir, {
+				include: ["**/.opencode/command/**", "**/.opencode/tools/**"],
+				exclude: ["**/.opencode/**"],
+			})
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(join(localConfigDir, "command"), { recursive: true })
+			await mkdir(join(localConfigDir, "commands"), { recursive: true })
+			await mkdir(join(localConfigDir, "tool"), { recursive: true })
+			await mkdir(join(localConfigDir, "tools"), { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "ocx.jsonc"),
+				JSON.stringify({ profile: "work" }, null, 2),
+			)
+			await Bun.write(join(localConfigDir, "command", "singular-command.md"), "singular command")
+			await Bun.write(join(localConfigDir, "commands", "plural-command.md"), "plural command")
+			await Bun.write(join(localConfigDir, "tool", "singular-tool.ts"), "singular tool")
+			await Bun.write(join(localConfigDir, "tools", "plural-tool.ts"), "plural tool")
+
+			const { result, payloadPath } = await runOcCapture({ testDir, profileName: "work" })
+			expect(result.exitCode).toBe(0)
+
+			const payload = await readCapturePayload(payloadPath)
 			expect(payload.files).toContain("command/singular-command.md")
-			expect(payload.files).toContain("commands/plural-command.md")
-			expect(payload.files).toContain("tool/singular-tool.ts")
+			expect(payload.files).not.toContain("commands/plural-command.md")
+			expect(payload.files).not.toContain("tool/singular-tool.ts")
 			expect(payload.files).toContain("tools/plural-tool.ts")
 			expect(payload.fileContents["command/singular-command.md"]).toBe("singular command")
-			expect(payload.fileContents["commands/plural-command.md"]).toBe("plural command")
-			expect(payload.fileContents["tool/singular-tool.ts"]).toBe("singular tool")
 			expect(payload.fileContents["tools/plural-tool.ts"]).toBe("plural tool")
 		} finally {
 			await cleanupTempDir(testDir)
@@ -961,7 +1086,11 @@ describe("ocx oc profile overlay integration", () => {
 	it("uses project .opencode/ocx.jsonc include/exclude policy with include-wins overlap", async () => {
 		const testDir = await createTempDir("oc-overlay-policy")
 		try {
-			await createProfile(testDir, "work")
+			const profileDir = await createProfile(testDir, "work")
+			await writeProfileVisibilityPolicy(profileDir, {
+				include: ["**/.opencode/**"],
+				exclude: ["**/.opencode/**"],
+			})
 
 			const localConfigDir = join(testDir, ".opencode")
 			await mkdir(join(localConfigDir, "agents"), { recursive: true })
@@ -998,6 +1127,10 @@ describe("ocx oc profile overlay integration", () => {
 		const testDir = await createTempDir("oc-overlay-collision")
 		try {
 			const profileDir = await createProfile(testDir, "work")
+			await writeProfileVisibilityPolicy(profileDir, {
+				include: ["**/.opencode/agents/shared.md"],
+				exclude: ["**/.opencode/**"],
+			})
 			await mkdir(join(profileDir, "agents"), { recursive: true })
 			await Bun.write(join(profileDir, "agents", "shared.md"), "from-profile")
 
@@ -1014,6 +1147,31 @@ describe("ocx oc profile overlay integration", () => {
 
 			const payload = await readCapturePayload(payloadPath)
 			expect(payload.fileContents["agents/shared.md"]).toBe("from-project")
+		} finally {
+			await cleanupTempDir(testDir)
+		}
+	})
+
+	it("keeps profile file on collisions when .opencode is excluded", async () => {
+		const testDir = await createTempDir("oc-overlay-collision-profile-wins")
+		try {
+			const profileDir = await createProfile(testDir, "work")
+			await mkdir(join(profileDir, "agents"), { recursive: true })
+			await Bun.write(join(profileDir, "agents", "shared.md"), "from-profile")
+
+			const localConfigDir = join(testDir, ".opencode")
+			await mkdir(join(localConfigDir, "agents"), { recursive: true })
+			await Bun.write(
+				join(localConfigDir, "ocx.jsonc"),
+				JSON.stringify({ profile: "work" }, null, 2),
+			)
+			await Bun.write(join(localConfigDir, "agents", "shared.md"), "from-project")
+
+			const { result, payloadPath } = await runOcCapture({ testDir, profileName: "work" })
+			expect(result.exitCode).toBe(0)
+
+			const payload = await readCapturePayload(payloadPath)
+			expect(payload.fileContents["agents/shared.md"]).toBe("from-profile")
 		} finally {
 			await cleanupTempDir(testDir)
 		}
@@ -1284,7 +1442,11 @@ describe("ocx oc profile overlay integration", () => {
 	it("cleans merged temp dir when copy fails before spawn", async () => {
 		const testDir = await createTempDir("oc-overlay-copy-cleanup")
 		try {
-			await createProfile(testDir, "work")
+			const profileDir = await createProfile(testDir, "work")
+			await writeProfileVisibilityPolicy(profileDir, {
+				include: ["**/.opencode/agents/unreadable.md"],
+				exclude: ["**/.opencode/**"],
+			})
 
 			const tmpRoot = join(testDir, "tmp")
 			await mkdir(tmpRoot, { recursive: true })
@@ -1321,6 +1483,10 @@ describe("ocx oc profile overlay integration", () => {
 		const testDir = await createTempDir("oc-overlay-destination-symlink-cleanup")
 		try {
 			const profileDir = await createProfile(testDir, "work")
+			await writeProfileVisibilityPolicy(profileDir, {
+				include: ["**/.opencode/agents/agent.md"],
+				exclude: ["**/.opencode/**"],
+			})
 
 			const outsideDir = join(testDir, "outside")
 			await mkdir(outsideDir, { recursive: true })


### PR DESCRIPTION
## Summary
- Filter project `.opencode` overlay candidates through the active profile's include/exclude policy before copying them into the merged OpenCode config directory.
- Fail closed if a profile launch somehow resolves a profile name without a parsed profile object.
- Update overlay regression coverage for default `.opencode` exclusion, explicit include opt-ins, project policy layering, and collision behavior.

## Root Cause
Profile launches set `OPENCODE_DISABLE_PROJECT_CONFIG=true`, but the merged `OPENCODE_CONFIG_DIR` path still copied project `.opencode/{agent,agents,command,commands,skill,skills,tool,tools}` files using only project-owned overlay policy. Missing project policy defaulted to include-all, so a repository could inject or override profile agents/skills despite the active profile's default `**/.opencode/**` exclusion.

## Manual Verification
Recreated the original PoC locally after the fix with:
- active profile policy: `exclude: ["**/.opencode/**"]`
- no project `.opencode/ocx.jsonc`
- project `.opencode/agents/evil.md`
- project `.opencode/skills/evil-skill.md`
- colliding project `.opencode/agents/shared.md`

Observed patched output:
```json
{
  "projectPolicyExists": false,
  "loadedProjectPolicy": { "include": [], "exclude": [] },
  "profileExclude": ["**/.opencode/**"],
  "injectedAgentPresent": false,
  "injectedSkillPresent": false,
  "collisionWinner": "PROFILE TRUSTED AGENT",
  "files": ["agents/shared.md", "ocx.jsonc", "skills/profile-skill.md"]
}
```

## Checks
- `bun test packages/cli/tests/opencode-overlay.test.ts --timeout 60000`
- `bun test packages/cli/tests/opencode.test.ts --timeout 60000`
- `bun run --cwd packages/cli check`
- `git diff --check`

## Flow Gates
- Plan review requested changes around command/tool semantics and fail-closed behavior; incorporated those changes.
- QA review approved the final diff after independently running the focused overlay suite and package check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce active profile include/exclude rules when merging project `.opencode` overlays so projects can’t inject or override profile files. Also fail closed if a profile launch resolves a missing profile.

- **Bug Fixes**
  - Filter overlay candidates by the active profile’s visibility policy before applying project policy.
  - Pass profile `ocx.include`/`ocx.exclude` to the merge step; honor profile-wide `**/.opencode/**` excludes with explicit include opt-ins.
  - Throw a validation error when a profile name resolves without a parsed profile object.
  - Expand tests to cover default exclusions, include opt-ins, command/tool scopes, and collision behavior.

<sup>Written for commit 21e87def610be3a72672f52ac6e38f48153b74c5. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/218?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

