### PR TITLE
fix(registry): Harden cmux notification execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
     runs-on: windows-latest
     needs: build-windows-binaries
     timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
   smoke-windows-artifacts:
     runs-on: windows-latest
     needs: build-artifacts
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
 
@@ -72,6 +75,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: smoke-windows-artifacts
+    permissions:
+      id-token: write      # Required for npm OIDC publishing
+      contents: write      # Required for GitHub releases
+      pull-requests: read  # Required for git-cliff PR metadata/avatars
+      actions: read        # Required to download smoke-tested artifacts
     steps:
       - uses: actions/checkout@v6
         with:

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -31,16 +31,16 @@ import notifier from "node-notifier"
 import type { OpencodeClient } from "./kdco-primitives/types"
 import { sendDesktopNotificationByPlatform, sendNotificationWithFallback } from "./notify/backend"
 import {
-	canUseCmuxNotification,
 	clearCmuxStatus,
+	resolveCmuxNotificationCommand,
 	sendCmuxNotification,
 	sendCmuxStatus,
 } from "./notify/cmux"
 import {
 	buildCmuxSessionStatusTransitionForEvent,
 	buildCmuxSessionStatusTransitionForQuestionTool,
-	getCmuxSessionStatusText,
 	type CmuxSessionStatusTransition,
+	getCmuxSessionStatusText,
 } from "./notify/status"
 import { parseOscTitleContext, writeOscTitleBestEffort } from "./notify/title"
 
@@ -245,6 +245,7 @@ interface NotificationOptions {
 
 interface NotificationRuntime {
 	preferCmux: boolean
+	cmuxCommand?: string
 }
 
 const QUESTION_DEDUPE_WINDOW_MS = 1500
@@ -256,21 +257,18 @@ const CMUX_BUSY_ANIMATION_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "�
 
 type RecentNotifications = Map<string, number>
 type SessionLogicalState = CmuxSessionStatusTransition["logicalState"]
-type CmuxSessionLogicalStateBySessionID = Map<
-	string,
-	SessionLogicalState
->
+type CmuxSessionLogicalStateBySessionID = Map<string, SessionLogicalState>
 type TitleSessionLogicalStateBySessionID = Map<string, SessionLogicalState>
 type CmuxSessionStatusWriteIntent =
 	| {
-		readonly sessionID: string
-		readonly kind: "set-status"
-		readonly text: string
-	}
+			readonly sessionID: string
+			readonly kind: "set-status"
+			readonly text: string
+	  }
 	| {
-		readonly sessionID: string
-		readonly kind: "clear-status"
-	}
+			readonly sessionID: string
+			readonly kind: "clear-status"
+	  }
 
 function isCmuxSessionStatusWriteIntentEqual(
 	left: CmuxSessionStatusWriteIntent,
@@ -412,11 +410,14 @@ async function sendNotification(
 	await sendNotificationWithFallback({
 		preferCmux: runtime.preferCmux,
 		tryCmuxNotify: () =>
-			sendCmuxNotification({
-				title: options.title,
-				subtitle: options.subtitle,
-				body: options.cmuxBody ?? options.message,
-			}),
+			sendCmuxNotification(
+				{
+					title: options.title,
+					subtitle: options.subtitle,
+					body: options.cmuxBody ?? options.message,
+				},
+				{ cmuxCommand: runtime.cmuxCommand },
+			),
 		sendDesktopNotification: () => sendDesktopNotification(options),
 	})
 }
@@ -559,8 +560,10 @@ const NotifyPlugin: Plugin = async (ctx) => {
 
 	// Detect terminal once at startup (cached for performance)
 	const terminalInfo = await detectTerminalInfo(config)
+	const cmuxCommand = resolveCmuxNotificationCommand()
 	const notificationRuntime: NotificationRuntime = {
-		preferCmux: canUseCmuxNotification(),
+		preferCmux: Boolean(cmuxCommand),
+		cmuxCommand,
 	}
 	const oscTitleContext = parseOscTitleContext()
 	const shouldSuppressCmuxSessionStatusWrites = oscTitleContext?.mayWriteOscTitle === true
@@ -593,7 +596,8 @@ const NotifyPlugin: Plugin = async (ctx) => {
 	const buildBusySpinnerTitle = (): string => {
 		const frame =
 			CMUX_BUSY_ANIMATION_FRAMES[titleBusySpinnerFrameIndex] ?? CMUX_BUSY_ANIMATION_FRAMES[0]
-		titleBusySpinnerFrameIndex = (titleBusySpinnerFrameIndex + 1) % CMUX_BUSY_ANIMATION_FRAMES.length
+		titleBusySpinnerFrameIndex =
+			(titleBusySpinnerFrameIndex + 1) % CMUX_BUSY_ANIMATION_FRAMES.length
 		return `${frame} ${oscTitleContext?.baseTitle ?? ""}`
 	}
 
@@ -731,13 +735,16 @@ const NotifyPlugin: Plugin = async (ctx) => {
 	): Promise<boolean> => {
 		const statusKey = buildCmuxSessionStatusKey(writeIntent.sessionID)
 		if (writeIntent.kind === "clear-status") {
-			return clearCmuxStatus({ key: statusKey })
+			return clearCmuxStatus({ key: statusKey }, { cmuxCommand: notificationRuntime.cmuxCommand })
 		}
 
-		return sendCmuxStatus({
-			key: statusKey,
-			text: writeIntent.text,
-		})
+		return sendCmuxStatus(
+			{
+				key: statusKey,
+				text: writeIntent.text,
+			},
+			{ cmuxCommand: notificationRuntime.cmuxCommand },
+		)
 	}
 
 	const drainCmuxSessionStatusWrites = async (): Promise<void> => {
@@ -784,7 +791,8 @@ const NotifyPlugin: Plugin = async (ctx) => {
 		if (!notificationRuntime.preferCmux || cmuxStatusUpdatesDisabled) return
 
 		const latestWriteIntent = getLatestCmuxSessionStatusWriteForSession(writeIntent.sessionID)
-		if (latestWriteIntent && isCmuxSessionStatusWriteIntentEqual(latestWriteIntent, writeIntent)) return
+		if (latestWriteIntent && isCmuxSessionStatusWriteIntentEqual(latestWriteIntent, writeIntent))
+			return
 
 		pendingCmuxSessionStatusWrites.set(writeIntent.sessionID, writeIntent)
 		void drainCmuxSessionStatusWrites()
@@ -809,7 +817,8 @@ const NotifyPlugin: Plugin = async (ctx) => {
 	}
 
 	const startBusyAnimationTicker = (): void => {
-		if (busyAnimationTicker || cmuxStatusUpdatesDisabled || animatedBusySessionIDs.size === 0) return
+		if (busyAnimationTicker || cmuxStatusUpdatesDisabled || animatedBusySessionIDs.size === 0)
+			return
 
 		const interval = setInterval(() => {
 			if (cmuxStatusUpdatesDisabled) {

--- a/workers/kdco-registry/files/plugins/notify/cmux.ts
+++ b/workers/kdco-registry/files/plugins/notify/cmux.ts
@@ -95,8 +95,12 @@ function isTrustedCmuxCommandPath(
 			realpathBestEffort(directory),
 		]),
 	]
+	const filteredUntrustedRoots = untrustedRoots.filter((root) => {
+		const resolvedRoot = path.resolve(root)
+		return resolvedRoot !== path.parse(resolvedRoot).root
+	})
 
-	return !untrustedRoots.some((root) =>
+	return !filteredUntrustedRoots.some((root) =>
 		[apparentCandidate, realCandidate].some((candidate) => isPathAtOrInside(root, candidate)),
 	)
 }

--- a/workers/kdco-registry/files/plugins/notify/cmux.ts
+++ b/workers/kdco-registry/files/plugins/notify/cmux.ts
@@ -1,5 +1,8 @@
-import { TimeoutError, withTimeout } from "../kdco-primitives/with-timeout"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 import { canUseCmuxWorkflow } from "../kdco-primitives/cmux"
+import { TimeoutError, withTimeout } from "../kdco-primitives/with-timeout"
 
 interface CmuxNotificationPayload {
 	title: string
@@ -40,12 +43,79 @@ type CmuxExecutionOptions = {
 	cmuxCommand?: string
 }
 
+type CmuxCommandTrustOptions = {
+	currentWorkingDirectory?: string
+	tempDirectory?: string
+}
+
 export function canUseCmuxNotification(
 	env: EnvironmentVariables = process.env,
 	resolveExecutable: ResolveExecutable = resolveWithBunWhich,
 	cmuxCommand: string = "cmux",
 ): boolean {
-	return canUseCmuxWorkflow(env, resolveExecutable, cmuxCommand)
+	return Boolean(resolveCmuxNotificationCommand(env, resolveExecutable, cmuxCommand))
+}
+
+function realpathBestEffort(filePath: string): string {
+	try {
+		return fs.realpathSync(filePath)
+	} catch {
+		return path.resolve(filePath)
+	}
+}
+
+function isPathAtOrInside(parentPath: string, candidatePath: string): boolean {
+	const relative = path.relative(parentPath, candidatePath)
+	return (
+		relative === "" ||
+		(Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative))
+	)
+}
+
+function isTrustedCmuxCommandPath(
+	candidatePath: string,
+	options: CmuxCommandTrustOptions = {},
+): boolean {
+	if (!path.isAbsolute(candidatePath)) return false
+
+	const cwd = path.resolve(options.currentWorkingDirectory ?? process.cwd())
+	const realCwd = realpathBestEffort(cwd)
+	const tempDirectory = path.resolve(options.tempDirectory ?? os.tmpdir())
+	const realTempDirectory = realpathBestEffort(tempDirectory)
+	const apparentCandidate = path.resolve(candidatePath)
+	const realCandidate = realpathBestEffort(candidatePath)
+	const commonTempDirectories = ["/tmp", "/private/tmp", "/var/tmp"]
+	const untrustedRoots = [
+		cwd,
+		realCwd,
+		tempDirectory,
+		realTempDirectory,
+		...commonTempDirectories.flatMap((directory) => [
+			path.resolve(directory),
+			realpathBestEffort(directory),
+		]),
+	]
+
+	return !untrustedRoots.some((root) =>
+		[apparentCandidate, realCandidate].some((candidate) => isPathAtOrInside(root, candidate)),
+	)
+}
+
+export function resolveCmuxNotificationCommand(
+	env: EnvironmentVariables = process.env,
+	resolveExecutable: ResolveExecutable = resolveWithBunWhich,
+	cmuxCommand: string = "cmux",
+	options: CmuxCommandTrustOptions = {},
+): string | undefined {
+	const resolvedCommand = resolveExecutable(cmuxCommand)?.trim()
+	if (!resolvedCommand) return undefined
+	if (!isTrustedCmuxCommandPath(resolvedCommand, options)) return undefined
+
+	if (!canUseCmuxWorkflow(env, () => resolvedCommand, resolvedCommand)) {
+		return undefined
+	}
+
+	return realpathBestEffort(resolvedCommand)
 }
 
 export function buildCmuxNotifyArgs(payload: CmuxNotificationPayload): string[] {
@@ -69,10 +139,14 @@ export function buildCmuxClearStatusArgs(payload: CmuxClearStatusPayload): strin
 	return ["clear-status", payload.key]
 }
 
-async function executeCmuxCommand(commandArgs: string[], options?: CmuxExecutionOptions): Promise<boolean> {
+async function executeCmuxCommand(
+	commandArgs: string[],
+	options?: CmuxExecutionOptions,
+): Promise<boolean> {
 	const timeoutMs = options?.timeoutMs ?? CMUX_NOTIFY_TIMEOUT_MS
 	const spawnProcess = options?.spawnProcess ?? spawnCmuxWithBun
-	const cmuxCommand = options?.cmuxCommand ?? "cmux"
+	const cmuxCommand = options?.cmuxCommand
+	if (!cmuxCommand) return false
 
 	try {
 		const proc = spawnProcess([cmuxCommand, ...commandArgs])

--- a/workers/kdco-registry/tests/notify-backend.test.ts
+++ b/workers/kdco-registry/tests/notify-backend.test.ts
@@ -78,6 +78,7 @@ describe("notify backend fallback behavior", () => {
 						body: "Task failed",
 					},
 					{
+						cmuxCommand: "/usr/local/bin/cmux",
 						spawnProcess: () => ({
 							exited: Promise.resolve(1),
 						}),
@@ -101,6 +102,7 @@ describe("notify backend fallback behavior", () => {
 						body: "Task complete",
 					},
 					{
+						cmuxCommand: "/usr/local/bin/cmux",
 						timeoutMs: 10,
 						spawnProcess: () => ({
 							exited: new Promise<number>(() => {
@@ -196,7 +198,7 @@ describe("macOS alerter desktop notifications", () => {
 	})
 
 	it("spawns the resolved alerter binary without shell interpolation", async () => {
-		const spawnProcess = mock((argv: string[]) => ({
+		const spawnProcess = mock((_argv: string[]) => ({
 			exited: Promise.resolve(0),
 		}))
 		const warn = mock(() => {})
@@ -231,7 +233,7 @@ describe("macOS alerter desktop notifications", () => {
 	})
 
 	it("warns and reports false when alerter is missing", async () => {
-		const spawnProcess = mock((argv: string[]) => ({
+		const spawnProcess = mock((_argv: string[]) => ({
 			exited: Promise.resolve(0),
 		}))
 		const warn = mock(() => {})
@@ -269,7 +271,9 @@ describe("macOS alerter desktop notifications", () => {
 		)
 
 		expect(sent).toBe(false)
-		expect(warn).toHaveBeenCalledWith("notify: macOS desktop notification skipped; alerter exited with code 2.")
+		expect(warn).toHaveBeenCalledWith(
+			"notify: macOS desktop notification skipped; alerter exited with code 2.",
+		)
 	})
 
 	it("warns and reports false when spawning alerter throws", async () => {
@@ -290,6 +294,8 @@ describe("macOS alerter desktop notifications", () => {
 		)
 
 		expect(sent).toBe(false)
-		expect(warn).toHaveBeenCalledWith("notify: macOS desktop notification skipped; alerter failed (spawn failed).")
+		expect(warn).toHaveBeenCalledWith(
+			"notify: macOS desktop notification skipped; alerter failed (spawn failed).",
+		)
 	})
 })

--- a/workers/kdco-registry/tests/notify-cmux.test.ts
+++ b/workers/kdco-registry/tests/notify-cmux.test.ts
@@ -11,6 +11,7 @@ import {
 	buildCmuxStatusArgs,
 	canUseCmuxNotification,
 	clearCmuxStatus,
+	resolveCmuxNotificationCommand,
 	sendCmuxNotification,
 	sendCmuxStatus,
 } from "../files/plugins/notify/cmux"
@@ -61,7 +62,12 @@ describe("notify cmux integration", () => {
 			const moduleUrl = pathToFileURL(path.join(tempRoot, "plugins/notify/cmux.ts")).href
 			const module = await import(`${moduleUrl}?test=${Date.now()}`)
 
-			expect(module.canUseCmuxNotification({ CMUX_WORKSPACE_ID: "workspace-123" }, () => "cmux")).toBe(true)
+			expect(
+				module.canUseCmuxNotification(
+					{ CMUX_WORKSPACE_ID: "workspace-123" },
+					() => "/usr/local/bin/cmux",
+				),
+			).toBe(true)
 		} finally {
 			fs.rmSync(tempRoot, { recursive: true, force: true })
 		}
@@ -77,6 +83,13 @@ describe("notify cmux integration", () => {
 	it("returns false when cmux executable is unavailable", () => {
 		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
 		const canUse = canUseCmuxNotification(env, () => undefined)
+
+		expect(canUse).toBe(false)
+	})
+
+	it("returns false when cmux resolves to a bare command", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const canUse = canUseCmuxNotification(env, () => "cmux")
 
 		expect(canUse).toBe(false)
 	})
@@ -106,6 +119,55 @@ describe("notify cmux integration", () => {
 		const canUse = canUseCmuxNotification(env, () => "/usr/local/bin/cmux")
 
 		expect(canUse).toBe(false)
+	})
+
+	it("resolves a trusted absolute cmux command", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const resolved = resolveCmuxNotificationCommand(env, () => "/usr/local/bin/cmux")
+
+		expect(resolved).toBe("/usr/local/bin/cmux")
+	})
+
+	it("rejects cmux commands resolved from the current project", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const currentWorkingDirectory = "/tmp/project"
+		const resolved = resolveCmuxNotificationCommand(
+			env,
+			() => "/tmp/project/node_modules/.bin/cmux",
+			"cmux",
+			{ currentWorkingDirectory, tempDirectory: "/var/tmp" },
+		)
+
+		expect(resolved).toBeUndefined()
+	})
+
+	it("does not confuse sibling project paths with the current project", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const resolved = resolveCmuxNotificationCommand(
+			env,
+			() => "/opt/project-other/bin/cmux",
+			"cmux",
+			{ currentWorkingDirectory: "/opt/project", tempDirectory: "/var/tmp" },
+		)
+
+		expect(resolved).toBe("/opt/project-other/bin/cmux")
+	})
+
+	it("rejects cmux commands resolved from the temp directory", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const resolved = resolveCmuxNotificationCommand(env, () => "/tmp/untrusted-bin/cmux", "cmux", {
+			currentWorkingDirectory: "/workspace/project",
+			tempDirectory: "/tmp",
+		})
+
+		expect(resolved).toBeUndefined()
+	})
+
+	it("rejects cmux commands resolved from common temp directories by default", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const resolved = resolveCmuxNotificationCommand(env, () => "/tmp/untrusted-bin/cmux")
+
+		expect(resolved).toBeUndefined()
 	})
 
 	it("builds cmux notify args with subtitle", () => {
@@ -167,6 +229,7 @@ describe("notify cmux integration", () => {
 				body: "Task complete",
 			},
 			{
+				cmuxCommand: "/usr/local/bin/cmux",
 				spawnProcess: (command) => {
 					commands.push(command)
 					return {
@@ -177,7 +240,31 @@ describe("notify cmux integration", () => {
 		)
 
 		expect(sent).toBe(true)
-		expect(commands).toEqual([["cmux", "notify", "--title", "Ready", "--body", "Task complete"]])
+		expect(commands).toEqual([
+			["/usr/local/bin/cmux", "notify", "--title", "Ready", "--body", "Task complete"],
+		])
+	})
+
+	it("returns false without spawning when no cmux command is provided", async () => {
+		const commands: string[][] = []
+
+		const sent = await sendCmuxNotification(
+			{
+				title: "Ready",
+				body: "Task complete",
+			},
+			{
+				spawnProcess: (command) => {
+					commands.push(command)
+					return {
+						exited: Promise.resolve(0),
+					}
+				},
+			},
+		)
+
+		expect(sent).toBe(false)
+		expect(commands).toEqual([])
 	})
 
 	it("returns false when cmux exits non-zero", async () => {
@@ -187,6 +274,7 @@ describe("notify cmux integration", () => {
 				body: "Task complete",
 			},
 			{
+				cmuxCommand: "/usr/local/bin/cmux",
 				spawnProcess: () => ({
 					exited: Promise.resolve(2),
 				}),
@@ -205,6 +293,7 @@ describe("notify cmux integration", () => {
 				body: "Task complete",
 			},
 			{
+				cmuxCommand: "/usr/local/bin/cmux",
 				timeoutMs: 10,
 				spawnProcess: () => ({
 					exited: new Promise<number>(() => {
@@ -230,6 +319,7 @@ describe("notify cmux integration", () => {
 				text: "Busy",
 			},
 			{
+				cmuxCommand: "/usr/local/bin/cmux",
 				spawnProcess: (command) => {
 					commands.push(command)
 					return {
@@ -241,7 +331,7 @@ describe("notify cmux integration", () => {
 
 		expect(sent).toBe(true)
 		expect(commands).toEqual([
-			["cmux", "set-status", "opencode.session.abc", "Busy"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.abc", "Busy"],
 		])
 	})
 
@@ -253,6 +343,7 @@ describe("notify cmux integration", () => {
 				key: "opencode.session.abc",
 			},
 			{
+				cmuxCommand: "/usr/local/bin/cmux",
 				spawnProcess: (command) => {
 					commands.push(command)
 					return {
@@ -263,9 +354,7 @@ describe("notify cmux integration", () => {
 		)
 
 		expect(sent).toBe(true)
-		expect(commands).toEqual([
-			["cmux", "clear-status", "opencode.session.abc"],
-		])
+		expect(commands).toEqual([["/usr/local/bin/cmux", "clear-status", "opencode.session.abc"]])
 	})
 
 	it("sendCmuxStatus returns false on timeout and kills process", async () => {
@@ -277,6 +366,7 @@ describe("notify cmux integration", () => {
 				text: "Needs input",
 			},
 			{
+				cmuxCommand: "/usr/local/bin/cmux",
 				timeoutMs: 10,
 				spawnProcess: () => ({
 					exited: new Promise<number>(() => {

--- a/workers/kdco-registry/tests/notify-cmux.test.ts
+++ b/workers/kdco-registry/tests/notify-cmux.test.ts
@@ -128,6 +128,16 @@ describe("notify cmux integration", () => {
 		expect(resolved).toBe("/usr/local/bin/cmux")
 	})
 
+	it("does not reject every absolute cmux command when the current project is filesystem root", () => {
+		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
+		const resolved = resolveCmuxNotificationCommand(env, () => "/usr/local/bin/cmux", "cmux", {
+			currentWorkingDirectory: "/",
+			tempDirectory: "/var/tmp",
+		})
+
+		expect(resolved).toBe("/usr/local/bin/cmux")
+	})
+
 	it("rejects cmux commands resolved from the current project", () => {
 		const env = { CMUX_WORKSPACE_ID: "workspace-123" }
 		const currentWorkingDirectory = "/tmp/project"

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -40,7 +40,10 @@ function pushAlerterNotificationPayload(command: string[]): void {
 
 mock.module("node:fs/promises", () => ({
 	...fsPromises,
-	readFile: async (filePath: Parameters<typeof fsPromises.readFile>[0], options?: Parameters<typeof fsPromises.readFile>[1]) => {
+	readFile: async (
+		filePath: Parameters<typeof fsPromises.readFile>[0],
+		options?: Parameters<typeof fsPromises.readFile>[1],
+	) => {
 		if (filePath !== `${process.env.HOME}/.config/opencode/kdco-notify.json`) {
 			return readActualFile(filePath, options)
 		}
@@ -79,7 +82,11 @@ beforeEach(() => {
 	)
 	spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 		const command = args[0]
-		if (Array.isArray(command) && typeof command[0] === "string" && command[0].includes("alerter")) {
+		if (
+			Array.isArray(command) &&
+			typeof command[0] === "string" &&
+			command[0].includes("alerter")
+		) {
 			pushAlerterNotificationPayload(command.map(String))
 			return {
 				exited: Promise.resolve(0),
@@ -125,7 +132,11 @@ function mockFocusedTerminal(): void {
 
 	spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 		const command = args[0]
-		if (Array.isArray(command) && typeof command[0] === "string" && command[0].includes("alerter")) {
+		if (
+			Array.isArray(command) &&
+			typeof command[0] === "string" &&
+			command[0].includes("alerter")
+		) {
 			pushAlerterNotificationPayload(command.map(String))
 			return {
 				exited: Promise.resolve(0),
@@ -194,6 +205,7 @@ async function emitQuestionToolBefore(
 function decodeOscTitleWrite(chunk: unknown): string | null {
 	if (typeof chunk !== "string") return null
 
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC title sequences are encoded as ESC and BEL.
 	const match = /^\u001b\]0;(.*)\u0007$/.exec(chunk)
 	if (!match) return null
 
@@ -526,15 +538,13 @@ describe("notify plugin event compatibility and dedupe", () => {
 			command === "cmux" ? "/usr/local/bin/cmux" : null,
 		)
 
-		spyOn(globalThis, "setInterval").mockImplementation(
-			((() => {
-				return {
-					unref: () => {
-						// no-op
-					},
-				} as ReturnType<typeof setInterval>
-			}) as unknown) as typeof setInterval,
-		)
+		spyOn(globalThis, "setInterval").mockImplementation((() => {
+			return {
+				unref: () => {
+					// no-op
+				},
+			} as ReturnType<typeof setInterval>
+		}) as unknown as typeof setInterval)
 		spyOn(globalThis, "clearInterval").mockImplementation((() => {
 			// no-op
 		}) as typeof clearInterval)
@@ -542,7 +552,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 		const cmuxCommands: string[][] = []
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 				return {
 					exited: Promise.resolve(0),
@@ -621,15 +631,13 @@ describe("notify plugin event compatibility and dedupe", () => {
 			command === "cmux" ? "/usr/local/bin/cmux" : null,
 		)
 
-		spyOn(globalThis, "setInterval").mockImplementation(
-			((() => {
-				return {
-					unref: () => {
-						// no-op
-					},
-				} as ReturnType<typeof setInterval>
-			}) as unknown) as typeof setInterval,
-		)
+		spyOn(globalThis, "setInterval").mockImplementation((() => {
+			return {
+				unref: () => {
+					// no-op
+				},
+			} as ReturnType<typeof setInterval>
+		}) as unknown as typeof setInterval)
 		spyOn(globalThis, "clearInterval").mockImplementation((() => {
 			// no-op
 		}) as typeof clearInterval)
@@ -637,7 +645,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 		const cmuxCommands: string[][] = []
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 				return {
 					exited: Promise.resolve(0),
@@ -691,10 +699,63 @@ describe("notify plugin event compatibility and dedupe", () => {
 		)
 
 		expect(statusCommands).toEqual([
-			["cmux", "set-status", "opencode.session.session-a", "⠋"],
-			["cmux", "clear-status", "opencode.session.session-a"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["/usr/local/bin/cmux", "clear-status", "opencode.session.session-a"],
 		])
 		expect(writtenTitles).toHaveLength(0)
+	})
+
+	it("falls back to desktop notifications when cmux resolves inside the project", async () => {
+		process.env.CMUX_WORKSPACE_ID = "workspace-123"
+		const projectCmux = `${process.cwd()}/node_modules/.bin/cmux`
+
+		spyOn(Bun, "which").mockImplementation((command: string) => {
+			if (command === "cmux") return projectCmux
+			if (command === "alerter") return "/usr/local/bin/alerter"
+			return null
+		})
+
+		const cmuxCommands: string[][] = []
+		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+			const command = args[0]
+			if (Array.isArray(command) && (command[0] === projectCmux || command[0] === "cmux")) {
+				cmuxCommands.push(command.map(String))
+				return {
+					exited: Promise.resolve(0),
+				} as ReturnType<typeof Bun.spawn>
+			}
+
+			if (
+				Array.isArray(command) &&
+				typeof command[0] === "string" &&
+				command[0].includes("alerter")
+			) {
+				pushAlerterNotificationPayload(command.map(String))
+			}
+
+			return {
+				stdout: new Blob([""]).stream(),
+				stderr: new Blob([""]).stream(),
+				exited: Promise.resolve(0),
+			} as ReturnType<typeof Bun.spawn>
+		})
+
+		const { hooks } = await createPlugin({
+			"session-a": { title: "Session A" },
+		})
+
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-1",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+		await Bun.sleep(0)
+
+		expect(cmuxCommands).toEqual([])
+		expect(notificationPayloads.some((payload) => payload.title === "Question for you")).toBe(true)
 	})
 
 	it("keeps OSC spinner active while any tracked session remains busy", async () => {
@@ -705,22 +766,20 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		let tickerCallback: (() => void) | null = null
 		let tickerIntervalMs: number | null = null
-		spyOn(globalThis, "setInterval").mockImplementation(
-			((callback: unknown, ms?: number) => {
-				if (typeof callback !== "function") {
-					throw new Error("Expected title ticker callback to be a function")
-				}
+		spyOn(globalThis, "setInterval").mockImplementation(((callback: unknown, ms?: number) => {
+			if (typeof callback !== "function") {
+				throw new Error("Expected title ticker callback to be a function")
+			}
 
-				tickerCallback = callback as () => void
-				tickerIntervalMs = ms ?? null
+			tickerCallback = callback as () => void
+			tickerIntervalMs = ms ?? null
 
-				return {
-					unref: () => {
-						// no-op
-					},
-				} as ReturnType<typeof setInterval>
-			}) as typeof setInterval,
-		)
+			return {
+				unref: () => {
+					// no-op
+				},
+			} as ReturnType<typeof setInterval>
+		}) as typeof setInterval)
 		spyOn(globalThis, "clearInterval").mockImplementation((() => {
 			// no-op
 		}) as typeof clearInterval)
@@ -798,15 +857,13 @@ describe("notify plugin event compatibility and dedupe", () => {
 			baseTitle: "ocx[default]:repo/main",
 		})
 
-		spyOn(globalThis, "setInterval").mockImplementation(
-			((() => {
-				return {
-					unref: () => {
-						// no-op
-					},
-				} as ReturnType<typeof setInterval>
-			}) as unknown) as typeof setInterval,
-		)
+		spyOn(globalThis, "setInterval").mockImplementation((() => {
+			return {
+				unref: () => {
+					// no-op
+				},
+			} as ReturnType<typeof setInterval>
+		}) as unknown as typeof setInterval)
 		spyOn(globalThis, "clearInterval").mockImplementation((() => {
 			// no-op
 		}) as typeof clearInterval)
@@ -894,15 +951,13 @@ describe("notify plugin event compatibility and dedupe", () => {
 			baseTitle: "ocx[default]:repo/main",
 		})
 
-		spyOn(globalThis, "setInterval").mockImplementation(
-			((() => {
-				return {
-					unref: () => {
-						// no-op
-					},
-				} as ReturnType<typeof setInterval>
-			}) as unknown) as typeof setInterval,
-		)
+		spyOn(globalThis, "setInterval").mockImplementation((() => {
+			return {
+				unref: () => {
+					// no-op
+				},
+			} as ReturnType<typeof setInterval>
+		}) as unknown as typeof setInterval)
 		spyOn(globalThis, "clearInterval").mockImplementation((() => {
 			// no-op
 		}) as typeof clearInterval)
@@ -946,7 +1001,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 		const cmuxCommands: string[][] = []
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 				return {
 					exited: Promise.resolve(0),
@@ -1010,10 +1065,10 @@ describe("notify plugin event compatibility and dedupe", () => {
 		)
 
 		expect(statusCommands).toEqual([
-			["cmux", "set-status", "opencode.session.session-a", "⠋"],
-			["cmux", "set-status", "opencode.session.session-a", "Needs input"],
-			["cmux", "set-status", "opencode.session.session-a", "Error"],
-			["cmux", "clear-status", "opencode.session.session-a"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "Needs input"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "Error"],
+			["/usr/local/bin/cmux", "clear-status", "opencode.session.session-a"],
 		])
 	})
 
@@ -1026,22 +1081,20 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		let tickerCallback: (() => void) | null = null
 		let tickerIntervalMs: number | null = null
-		spyOn(globalThis, "setInterval").mockImplementation(
-			((callback: unknown, ms?: number) => {
-				if (typeof callback !== "function") {
-					throw new Error("Expected notify busy ticker callback to be a function")
-				}
+		spyOn(globalThis, "setInterval").mockImplementation(((callback: unknown, ms?: number) => {
+			if (typeof callback !== "function") {
+				throw new Error("Expected notify busy ticker callback to be a function")
+			}
 
-				tickerCallback = callback as () => void
-				tickerIntervalMs = ms ?? null
+			tickerCallback = callback as () => void
+			tickerIntervalMs = ms ?? null
 
-				return {
-					unref: () => {
-						// no-op
-					},
-				} as ReturnType<typeof setInterval>
-			}) as typeof setInterval,
-		)
+			return {
+				unref: () => {
+					// no-op
+				},
+			} as ReturnType<typeof setInterval>
+		}) as typeof setInterval)
 		spyOn(globalThis, "clearInterval").mockImplementation((() => {
 			// no-op
 		}) as typeof clearInterval)
@@ -1049,7 +1102,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 		const cmuxCommands: string[][] = []
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 				return {
 					exited: Promise.resolve(0),
@@ -1111,7 +1164,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		expect(setStatusTexts.slice(0, 4)).toEqual(CMUX_BUSY_SPINNER_FRAMES.slice(0, 4))
 		expect(statusCommands[statusCommands.length - 1]).toEqual([
-			"cmux",
+			"/usr/local/bin/cmux",
 			"clear-status",
 			"opencode.session.session-a",
 		])
@@ -1130,7 +1183,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 
 				if (command[1] === "set-status" && shouldDelayFirstStatus) {
@@ -1188,7 +1241,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 			(command) => command[1] === "set-status" || command[1] === "clear-status",
 		)
 		expect(statusCommandsWhileFirstWriteIsPending).toEqual([
-			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "⠋"],
 		])
 
 		if (!resolveFirstStatusExit) {
@@ -1203,8 +1256,8 @@ describe("notify plugin event compatibility and dedupe", () => {
 			(command) => command[1] === "set-status" || command[1] === "clear-status",
 		)
 		expect(finalStatusCommands).toEqual([
-			["cmux", "set-status", "opencode.session.session-a", "⠋"],
-			["cmux", "set-status", "opencode.session.session-a", "Error"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "Error"],
 		])
 	})
 
@@ -1221,7 +1274,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 
 				if (command[1] === "set-status" && shouldDelayFirstStatus) {
@@ -1296,7 +1349,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 		)
 
 		expect(statusCommandsWhileFirstIsPending).toEqual([
-			["cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "⠋"],
 		])
 
 		if (!resolveFirstStatusExit) {
@@ -1312,8 +1365,8 @@ describe("notify plugin event compatibility and dedupe", () => {
 		)
 
 		expect(finalStatusCommands).toEqual([
-			["cmux", "set-status", "opencode.session.session-a", "⠋"],
-			["cmux", "clear-status", "opencode.session.session-a"],
+			["/usr/local/bin/cmux", "set-status", "opencode.session.session-a", "⠋"],
+			["/usr/local/bin/cmux", "clear-status", "opencode.session.session-a"],
 		])
 	})
 
@@ -1330,7 +1383,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 
 				if (command[1] === "set-status" && shouldDelayFirstStatus) {
@@ -1441,7 +1494,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 
 		spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
 			const command = args[0]
-			if (Array.isArray(command) && command[0] === "cmux") {
+			if (Array.isArray(command) && command[0] === "/usr/local/bin/cmux") {
 				cmuxCommands.push(command.map(String))
 
 				if (command[1] === "set-status") {


### PR DESCRIPTION
## Summary

- Resolve the cmux notification executable once at notify plugin startup and pass that trusted absolute path into notify/status/clear-status calls.
- Reject bare, relative, project-local, and common temp-directory cmux resolutions so project-controlled PATH entries fail closed.
- Update notify cmux/backend/plugin tests to assert absolute cmux execution and desktop fallback when cmux is untrusted.

## Security validation

Manual replay with fake `cmux` binaries first on `PATH`:

```text
Project-local fake cmux replay:
Bun.which(cmux)=/Users/kenny/.codex/worktrees/ff16/ocx/.ocx-cmux-poc-bin/cmux
resolved=undefined
canUse=false
sendResult=false
markerExists=false

Temp fake cmux replay:
Bun.which(cmux)=/tmp/ocx-cmux-poc.D2D1LX/untrusted-project-bin/cmux
resolved=undefined
canUse=false
sendResult=false
markerExists=false
```

## Checks

- `bunx biome check workers/kdco-registry/files/plugins/notify.ts workers/kdco-registry/files/plugins/notify/cmux.ts workers/kdco-registry/tests/notify-cmux.test.ts workers/kdco-registry/tests/notify-backend.test.ts workers/kdco-registry/tests/notify-plugin.test.ts`
- `bun test workers/kdco-registry/tests/notify-cmux.test.ts workers/kdco-registry/tests/notify-backend.test.ts workers/kdco-registry/tests/notify-plugin.test.ts`
- `bun run --cwd workers/kdco-registry check:types`

QA gate also independently inspected the diff and reran the targeted tests/typecheck plus a manual PATH-hijack replay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `cmux` notification execution by resolving a trusted absolute `cmux` path at plugin startup and using it for all notify/status calls. Fixes an edge case where root-cwd trust checks could over-block and tightens CI/release permissions.

- **Bug Fixes**
  - Added `resolveCmuxNotificationCommand()` to resolve and trust-check an absolute `cmux` path once; rejects bare/relative, project-local, and temp-directory binaries, and correctly handles root cwd.
  - `canUseCmuxNotification()` now uses the resolver and returns false for untrusted/bare paths.
  - `sendCmuxNotification`, `sendCmuxStatus`, and `clearCmuxStatus` now require an explicit `cmuxCommand`; they do not spawn without it and return false on non-zero exit or timeout.
  - CI/release: smoke jobs use `contents: read` and `actions: read`; release uses `id-token: write`, `contents: write`, `pull-requests: read`, and `actions: read`.

- **Migration**
  - If you call `sendCmuxNotification`, `sendCmuxStatus`, or `clearCmuxStatus` directly, pass `{ cmuxCommand: resolveCmuxNotificationCommand() }`.
  - Prefer `resolveCmuxNotificationCommand()` over relying on PATH in `canUseCmuxNotification()` checks.

<sup>Written for commit bbbbcfaac2ef1abe3e46c9cd547f5181f163dd41. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/219?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

