### PR TITLE
fix(config): Normalize paths before glob filtering

### DIFF
--- a/packages/cli/src/config/resolver.ts
+++ b/packages/cli/src/config/resolver.ts
@@ -232,21 +232,32 @@ function normalizePattern(pattern: string): string {
 }
 
 /**
+ * Normalize discovered paths for glob matching across platforms.
+ * node:path.relative() returns backslashes on Windows, while Bun glob patterns
+ * are written with forward slashes.
+ */
+function normalizePathForGlobMatch(path: string): string {
+	return path.replaceAll("\\", "/")
+}
+
+/**
  * Filter files using TypeScript/Vite style include/exclude.
  * Include overrides exclude, order is preserved.
  */
-function filterByPatterns(files: string[], exclude: string[], include: string[]): string[] {
+export function filterByPatterns(files: string[], exclude: string[], include: string[]): string[] {
 	return files.filter((file) => {
+		const normalizedFile = normalizePathForGlobMatch(file)
+
 		// Check include first - include overrides exclude
 		for (const pattern of include) {
 			const glob = new Glob(normalizePattern(pattern))
-			if (glob.match(file)) return true
+			if (glob.match(normalizedFile)) return true
 		}
 
 		// Check exclude
 		for (const pattern of exclude) {
 			const glob = new Glob(normalizePattern(pattern))
-			if (glob.match(file)) return false
+			if (glob.match(normalizedFile)) return false
 		}
 
 		// Not matched by include or exclude - keep it
@@ -608,6 +619,7 @@ export class ConfigResolver {
 
 		// Get relative path of local config dir from root
 		const relativePath = relative(root, this.localConfigDir)
+		const normalizedRelativePath = normalizePathForGlobMatch(relativePath)
 
 		// Check if .opencode directory matches exclude patterns
 		const exclude = this.profile.ocx.exclude ?? []
@@ -617,7 +629,7 @@ export class ConfigResolver {
 		for (const pattern of include) {
 			const glob = new Glob(normalizePattern(pattern))
 			// Match the directory path with trailing content
-			if (glob.match(`${relativePath}/`) || glob.match(relativePath)) {
+			if (glob.match(`${normalizedRelativePath}/`) || glob.match(normalizedRelativePath)) {
 				return true
 			}
 		}
@@ -626,7 +638,7 @@ export class ConfigResolver {
 		for (const pattern of exclude) {
 			const glob = new Glob(normalizePattern(pattern))
 			// Check if pattern matches .opencode directory
-			if (glob.match(`${relativePath}/`) || glob.match(`${relativePath}/**`)) {
+			if (glob.match(`${normalizedRelativePath}/`) || glob.match(`${normalizedRelativePath}/**`)) {
 				return false
 			}
 		}

--- a/packages/cli/tests/config/instructions.test.ts
+++ b/packages/cli/tests/config/instructions.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import * as fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { ConfigResolver } from "../../src/config/resolver"
+import { ConfigResolver, filterByPatterns } from "../../src/config/resolver"
 import { readOpencodeJsonConfig } from "../../src/updaters/update-opencode-config"
 import { tmpdir } from "../fixture"
 
@@ -179,6 +179,36 @@ describe("instruction discovery", () => {
 		// Should NOT find CLAUDE.md (excluded, not in include)
 		const hasClaude = config.instructions.some((p) => p.endsWith("CLAUDE.md"))
 		expect(hasClaude).toBe(false)
+	})
+
+	it("matches forward-slash exclude patterns against Windows-style discovered paths", () => {
+		const filtered = filterByPatterns(
+			["workspace\\project\\CLAUDE.md", "workspace\\project\\notes.md"],
+			["**/CLAUDE.md"],
+			[],
+		)
+
+		expect(filtered).toEqual(["workspace\\project\\notes.md"])
+	})
+
+	it("preserves include override for Windows-style discovered paths", () => {
+		const filtered = filterByPatterns(
+			["workspace\\project\\CLAUDE.md"],
+			["**/*.md"],
+			["**/CLAUDE.md"],
+		)
+
+		expect(filtered).toEqual(["workspace\\project\\CLAUDE.md"])
+	})
+
+	it("matches default .opencode excludes against Windows-style discovered paths", () => {
+		const filtered = filterByPatterns(
+			["workspace\\project\\.opencode\\ocx.jsonc", "workspace\\project\\README.md"],
+			["**/.opencode/**"],
+			[],
+		)
+
+		expect(filtered).toEqual(["workspace\\project\\README.md"])
 	})
 
 	it("discovers CONTEXT.md as instruction file", async () => {


### PR DESCRIPTION
## Summary
- Normalize discovered paths before matching profile include/exclude globs so Windows backslashes cannot bypass forward-slash patterns.
- Apply the same normalization to local `.opencode` config directory filtering.
- Add focused regression coverage for Windows-style instruction and `.opencode` paths, including include-overrides-exclude behavior.

## Validation
- `bun install --frozen-lockfile`
- `bun test packages/cli/tests/config/instructions.test.ts packages/cli/tests/config/isolation.test.ts packages/cli/tests/config/config-resolver.test.ts` - 35 pass, 0 fail
- `bun run --cwd packages/cli check:types` - pass
- `bun run --cwd packages/cli check:biome` - pass
- Sanity checked Bun glob behavior: forward-slash patterns match normalized paths but not raw backslash paths.

## Security
Fixes a Windows path-separator bypass where repo-relative paths from `node:path.relative()` could evade profile ghost/config exclude globs and allow excluded project instructions or local config directories to survive filtering.