### PR TITLE
fix(registry): Contain worktree sync paths

### DIFF
--- a/workers/kdco-registry/files/plugins/worktree.ts
+++ b/workers/kdco-registry/files/plugins/worktree.ts
@@ -13,7 +13,7 @@
 
 import type { Database } from "bun:sqlite"
 import { constants as fsConstants } from "node:fs"
-import { access, copyFile, cp, mkdir, rm, stat, symlink } from "node:fs/promises"
+import { access, copyFile, cp, lstat, mkdir, realpath, rm, stat, symlink } from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
 import { type Plugin, tool } from "@opencode-ai/plugin"
@@ -692,6 +692,85 @@ function isPathSafe(filePath: string, baseDir: string, log: Logger): boolean {
 	return true
 }
 
+function isWithinRealRoot(rootRealPath: string, candidateRealPath: string): boolean {
+	const relative = path.relative(rootRealPath, candidateRealPath)
+	return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+async function resolveExistingPathWithinRoot(
+	rootDir: string,
+	relativePath: string,
+	log: Logger,
+): Promise<string | null> {
+	const rootRealPath = await realpath(rootDir).catch(() => null)
+	if (!rootRealPath) {
+		log.warn(`[worktree] Failed to resolve worktree root: ${rootDir}`)
+		return null
+	}
+
+	const candidatePath = path.resolve(rootDir, relativePath)
+	const candidateRealPath = await realpath(candidatePath).catch(() => null)
+	if (!candidateRealPath) return null
+
+	if (!isWithinRealRoot(rootRealPath, candidateRealPath)) {
+		log.warn(`[worktree] Rejected path escaping worktree via symlink: ${relativePath}`)
+		return null
+	}
+
+	return candidateRealPath
+}
+
+async function ensureDirectoryWithinRoot(
+	rootDir: string,
+	relativeDir: string,
+	log: Logger,
+): Promise<string | null> {
+	const rootRealPath = await realpath(rootDir).catch(() => null)
+	if (!rootRealPath) {
+		log.warn(`[worktree] Failed to resolve worktree root: ${rootDir}`)
+		return null
+	}
+
+	const rootPath = path.resolve(rootDir)
+	const targetDir = path.resolve(rootDir, relativeDir)
+	const resolvedRootRelative = path.relative(rootPath, targetDir)
+	if (
+		resolvedRootRelative !== "" &&
+		(resolvedRootRelative.startsWith("..") || path.isAbsolute(resolvedRootRelative))
+	) {
+		log.warn(`[worktree] Rejected path escaping worktree: ${relativeDir}`)
+		return null
+	}
+
+	const rootRelative = path.relative(rootDir, targetDir)
+	const parts = rootRelative.split(path.sep).filter(Boolean)
+	let cursor = rootDir
+
+	for (const part of parts) {
+		cursor = path.join(cursor, part)
+		const entry = await lstat(cursor).catch(() => null)
+		if (entry?.isSymbolicLink()) {
+			log.warn(`[worktree] Rejected symlinked target parent: ${relativeDir}`)
+			return null
+		}
+		if (entry && !entry.isDirectory()) {
+			log.warn(`[worktree] Rejected non-directory target parent: ${relativeDir}`)
+			return null
+		}
+		if (!entry) {
+			await mkdir(cursor)
+		}
+	}
+
+	const finalRealPath = await realpath(targetDir).catch(() => null)
+	if (!finalRealPath || !isWithinRealRoot(rootRealPath, finalRealPath)) {
+		log.warn(`[worktree] Rejected path escaping worktree via symlink: ${relativeDir}`)
+		return null
+	}
+
+	return targetDir
+}
+
 /**
  * Copy files from source directory to target directory.
  * Skips missing files silently (production pattern).
@@ -705,7 +784,9 @@ async function copyFiles(
 	for (const file of files) {
 		if (!isPathSafe(file, sourceDir, log)) continue
 
-		const sourcePath = path.join(sourceDir, file)
+		const sourcePath = await resolveExistingPathWithinRoot(sourceDir, file, log)
+		if (!sourcePath) continue
+
 		const targetPath = path.join(targetDir, file)
 
 		try {
@@ -717,7 +798,14 @@ async function copyFiles(
 
 			// Ensure target directory exists
 			const targetFileDir = path.dirname(targetPath)
-			await mkdir(targetFileDir, { recursive: true })
+			const targetFileRelativeDir = path.relative(targetDir, targetFileDir)
+			if (!(await ensureDirectoryWithinRoot(targetDir, targetFileRelativeDir, log))) continue
+
+			const existingTarget = await lstat(targetPath).catch(() => null)
+			if (existingTarget?.isSymbolicLink()) {
+				log.warn(`[worktree] Rejected symlinked target file: ${file}`)
+				continue
+			}
 
 			// Copy file
 			await Bun.write(targetPath, sourceFile)
@@ -748,20 +836,29 @@ async function symlinkDirs(
 	for (const dir of dirs) {
 		if (!isPathSafe(dir, sourceDir, log)) continue
 
-		const sourcePath = path.join(sourceDir, dir)
+		const sourcePath = await resolveExistingPathWithinRoot(sourceDir, dir, log)
+		if (!sourcePath) continue
+
 		const targetPath = path.join(targetDir, dir)
 
 		try {
 			// Check if source directory exists
 			const fileStat = await stat(sourcePath).catch(() => null)
-			if (!fileStat || !fileStat.isDirectory()) {
+			if (!fileStat?.isDirectory()) {
 				log.debug(`[worktree] Skipping missing directory: ${dir}`)
 				continue
 			}
 
 			// Ensure parent directory exists
 			const targetParentDir = path.dirname(targetPath)
-			await mkdir(targetParentDir, { recursive: true })
+			const targetParentRelativeDir = path.relative(targetDir, targetParentDir)
+			if (!(await ensureDirectoryWithinRoot(targetDir, targetParentRelativeDir, log))) continue
+
+			const existingTarget = await lstat(targetPath).catch(() => null)
+			if (existingTarget?.isSymbolicLink()) {
+				log.warn(`[worktree] Rejected symlinked target: ${dir}`)
+				continue
+			}
 
 			// Remove existing target if it exists (might be empty dir from git)
 			await rm(targetPath, { recursive: true, force: true })
@@ -1105,11 +1202,13 @@ const WorktreePlugin: Plugin = async (ctx) => {
 
 const WorktreePluginWithInternals = Object.assign(WorktreePlugin, {
 	testInternals: {
-	isPathLikeCommand,
-	ensureLaunchContextExecutable,
-	validateOcxProfileAvailability,
-	ensureLaunchContextProfile,
-	finalizeWorktreeLaunch,
+		isPathLikeCommand,
+		copyFiles,
+		ensureLaunchContextExecutable,
+		validateOcxProfileAvailability,
+		ensureLaunchContextProfile,
+		finalizeWorktreeLaunch,
+		symlinkDirs,
 	},
 } as const)
 

--- a/workers/kdco-registry/tests/worktree-sync-security.test.ts
+++ b/workers/kdco-registry/tests/worktree-sync-security.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+import WorktreePlugin from "../files/plugins/worktree"
+
+const { copyFiles, symlinkDirs } = WorktreePlugin.testInternals
+
+const log = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+}
+
+let testDir: string
+
+beforeEach(async () => {
+	testDir = await mkdtemp(path.join(os.tmpdir(), "worktree-sync-security-"))
+})
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true })
+})
+
+async function writeText(filePath: string, content: string): Promise<void> {
+	await mkdir(path.dirname(filePath), { recursive: true })
+	await Bun.write(filePath, content)
+}
+
+describe("worktree sync path containment", () => {
+	it("does not copy files from source paths that resolve outside the source worktree", async () => {
+		const sourceDir = path.join(testDir, "source")
+		const targetDir = path.join(testDir, "target")
+		const externalDir = path.join(testDir, "external-source")
+		await writeText(path.join(sourceDir, ".keep"), "")
+		await writeText(path.join(targetDir, ".keep"), "")
+		await writeText(path.join(externalDir, ".env"), "external secret")
+		await symlink(externalDir, path.join(sourceDir, "secrets"), "dir")
+
+		await copyFiles(sourceDir, targetDir, ["secrets/.env"], log)
+
+		expect(await Bun.file(path.join(targetDir, "secrets", ".env")).exists()).toBe(false)
+	})
+
+	it("does not copy files through symlinked target parents outside the target worktree", async () => {
+		const sourceDir = path.join(testDir, "source")
+		const targetDir = path.join(testDir, "target")
+		const externalDir = path.join(testDir, "external-target")
+		await writeText(path.join(sourceDir, "secrets", ".env"), "attacker controlled")
+		await writeText(path.join(targetDir, ".keep"), "")
+		await writeText(path.join(externalDir, ".env"), "original external")
+		await symlink(externalDir, path.join(targetDir, "secrets"), "dir")
+
+		await copyFiles(sourceDir, targetDir, ["secrets/.env"], log)
+
+		expect(await readFile(path.join(externalDir, ".env"), "utf8")).toBe("original external")
+	})
+
+	it("does not symlink directories from source paths that resolve outside the source worktree", async () => {
+		const sourceDir = path.join(testDir, "source")
+		const targetDir = path.join(testDir, "target")
+		const externalDir = path.join(testDir, "external-source")
+		await writeText(path.join(sourceDir, ".keep"), "")
+		await writeText(path.join(targetDir, ".keep"), "")
+		await writeText(path.join(externalDir, "package.json"), "{}")
+		await symlink(externalDir, path.join(sourceDir, "node_modules"), "dir")
+
+		await symlinkDirs(sourceDir, targetDir, ["node_modules"], log)
+
+		expect(await Bun.file(path.join(targetDir, "node_modules")).exists()).toBe(false)
+	})
+
+	it("does not remove or symlink through symlinked target parents outside the target worktree", async () => {
+		const sourceDir = path.join(testDir, "source")
+		const targetDir = path.join(testDir, "target")
+		const externalDir = path.join(testDir, "external-target")
+		await writeText(path.join(sourceDir, "p", "opencode", "source-marker.txt"), "source")
+		await writeText(path.join(targetDir, ".keep"), "")
+		await writeText(path.join(externalDir, "opencode", "victim-marker.txt"), "victim")
+		await symlink(externalDir, path.join(targetDir, "p"), "dir")
+
+		await symlinkDirs(sourceDir, targetDir, ["p/opencode"], log)
+
+		expect(await readFile(path.join(externalDir, "opencode", "victim-marker.txt"), "utf8")).toBe(
+			"victim",
+		)
+		expect((await lstat(path.join(externalDir, "opencode"))).isDirectory()).toBe(true)
+	})
+
+	it("still copies regular files and symlinks regular directories within the worktree roots", async () => {
+		const sourceDir = path.join(testDir, "source")
+		const targetDir = path.join(testDir, "target")
+		await writeText(path.join(sourceDir, ".env"), "local env")
+		await writeText(path.join(sourceDir, "node_modules", "package.txt"), "installed")
+		await writeText(path.join(targetDir, ".keep"), "")
+
+		await copyFiles(sourceDir, targetDir, [".env"], log)
+		await symlinkDirs(sourceDir, targetDir, ["node_modules"], log)
+
+		expect(await readFile(path.join(targetDir, ".env"), "utf8")).toBe("local env")
+		const modulesStat = await lstat(path.join(targetDir, "node_modules"))
+		expect(modulesStat.isSymbolicLink()).toBe(true)
+		expect(await readFile(path.join(targetDir, "node_modules", "package.txt"), "utf8")).toBe(
+			"installed",
+		)
+	})
+})


### PR DESCRIPTION
## Summary
- Add symlink-aware containment checks for worktree sync source paths and target parents
- Reject sync writes, deletes, and symlink creation when configured paths resolve outside either worktree root
- Add focused regression tests for source symlink escapes, target-parent symlink escapes, and normal sync behavior

## Validation
- `bun install` to repair missing workspace dependencies before validation
- `bun test workers/kdco-registry/tests/worktree-sync-security.test.ts` - 5 pass, 0 fail
- `bun test workers/kdco-registry/tests/worktree-*.test.ts` - 151 pass, 0 fail
- `bun run --cwd workers/kdco-registry check:types` - pass
- `bunx biome check workers/kdco-registry/files/plugins/worktree.ts workers/kdco-registry/tests/worktree-sync-security.test.ts` - pass
- `git diff --check` - pass

## Security Notes
The original issue no longer reproduces in the covered sync boundary: configured source paths that resolve through symlinks outside the source worktree are skipped, and target parent symlinks are rejected before file copy, recursive remove, or symlink creation. Residual risk is the normal same-user filesystem TOCTOU window between `realpath`/`lstat` checks and subsequent operations; this patch is scoped to preventing project-controlled symlink traversal in checked-out worktree contents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain worktree sync to the source/target roots to prevent symlink traversal. Sync now resolves real paths and rejects writes/removals and symlink creation that escape either worktree.

- **Bug Fixes**
  - Resolve source paths with `realpath` and verify containment before copy.
  - Walk target parent dirs with `lstat`; reject symlinked or non-directory parents; create missing dirs inside the root.
  - Block writes to symlinked target files and symlink creation at symlinked targets.
  - Update `copyFiles` and `symlinkDirs` to enforce these checks.
  - Add targeted tests for source and target symlink escapes and normal in-root behavior.

<sup>Written for commit 4f65be19ce44244265738d95ff3e6a45fbe95f09. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/223?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

