### PR TITLE
fix: Pin facade sync action

### DIFF
--- a/.github/workflows/sync-facades.yml
+++ b/.github/workflows/sync-facades.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Sync Files
-        uses: BetaHuhn/repo-file-sync-action@v1
+        uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619
         with:
           GH_PAT: ${{ secrets.FACADE_SYNC_PAT }}
           SKIP_PR: true

--- a/packages/cli/tests/github-actions-security.test.ts
+++ b/packages/cli/tests/github-actions-security.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const syncWorkflowPath = join(
+	import.meta.dir,
+	"..",
+	"..",
+	"..",
+	".github",
+	"workflows",
+	"sync-facades.yml",
+)
+
+describe("GitHub Actions security", () => {
+	it("pins the facade sync action when passing FACADE_SYNC_PAT", () => {
+		const workflow = readFileSync(syncWorkflowPath, "utf8")
+		const facadePatInput = "GH_PAT: $" + "{{ secrets.FACADE_SYNC_PAT }}"
+		const syncStep = workflow.match(
+			/ {6}- name: Sync Files\n(?<body>(?: {8}.*\n?)+?)(?=\n {6}- name:|\n*$)/,
+		)?.groups?.body
+
+		expect(syncStep).toBeDefined()
+		expect(syncStep).toContain(facadePatInput)
+		expect(syncStep).toMatch(/uses:\s*BetaHuhn\/repo-file-sync-action@[a-f0-9]{40}\n/)
+	})
+})


### PR DESCRIPTION
## Summary
- Pin the third-party facade sync action to a reviewed full-length commit SHA instead of the mutable `v1` tag.
- Add a focused Bun regression test that checks the `Sync Files` step both receives `FACADE_SYNC_PAT` and uses a 40-character SHA-pinned `BetaHuhn/repo-file-sync-action` reference.

## Security validation
- The original vulnerable path no longer reproduces: `.github/workflows/sync-facades.yml` no longer uses `BetaHuhn/repo-file-sync-action@v1`; the PAT remains in the same step as a SHA-pinned action.
- Remaining operational follow-up: repository-local validation cannot prove the live `FACADE_SYNC_PAT` scope, expiration, or repository allowlist.

## Tests
- `bun test packages/cli/tests/github-actions-security.test.ts` ✅
- `bun run --cwd packages/cli check` ✅
- Static step check for pinned action + `FACADE_SYNC_PAT` in the same workflow step ✅
- `bun test packages/cli/tests` ❌ existing unrelated timeouts/failures in `profile-commands.test.ts` and `update.test.ts`; the new security test passed within the full suite.

## Review gates
- Plan review: approved with tightening; regression test now ties the PAT and pinned action to the same `Sync Files` step.
- Execution-capable QA: independently inspected the workflow/test and ran focused validation; no blocker for this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the facade sync workflow to a full commit SHA for `BetaHuhn/repo-file-sync-action` instead of the mutable `v1` tag to avoid tag changes and reduce supply‑chain risk. Add a focused Bun test that ensures the `Sync Files` step passes `FACADE_SYNC_PAT` and uses a SHA‑pinned action.

<sup>Written for commit 43c6519aefc1518bb6a34923f7e4273d569dbe0d. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/224?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

