### PR TITLE
fix(cli): Validate self-update release versions

### DIFF
--- a/packages/cli/src/commands/self/update-runner.ts
+++ b/packages/cli/src/commands/self/update-runner.ts
@@ -18,10 +18,9 @@ import { notifyUpdated, notifyUpToDate } from "../../self-update/notify"
 import { fetchChecksums, verifyChecksum } from "../../self-update/verify"
 import { SelfUpdateError } from "../../utils/errors"
 import { outputJson } from "../../utils/json-output"
+import { isValidSemver } from "../../utils/semver"
 import { createSpinner } from "../../utils/spinner"
 import type { UpdateOptions } from "./update"
-
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[\w.]+)?$/
 
 const UPDATE_ERROR_MESSAGES: Record<CheckFailure["reason"], string> = {
 	"dev-version":
@@ -100,6 +99,10 @@ async function updateViaCurl(
 	targetVersion: string,
 	jsonOutput: boolean,
 ): Promise<void> {
+	if (!isValidSemver(targetVersion)) {
+		throw new SelfUpdateError(`Invalid version format: ${targetVersion}`)
+	}
+
 	const url = getDownloadUrl(targetVersion)
 	const filename = url.split("/").pop()
 	if (!filename) {
@@ -141,7 +144,7 @@ async function updateViaPackageManager(
 	targetVersion: string,
 	jsonOutput: boolean,
 ): Promise<void> {
-	if (!SEMVER_PATTERN.test(targetVersion)) {
+	if (!isValidSemver(targetVersion)) {
 		throw new SelfUpdateError(`Invalid version format: ${targetVersion}`)
 	}
 

--- a/packages/cli/src/self-update/download.ts
+++ b/packages/cli/src/self-update/download.ts
@@ -12,6 +12,7 @@
 
 import { chmodSync, existsSync, renameSync, unlinkSync } from "node:fs"
 import { SelfUpdateError } from "../utils/errors"
+import { isValidSemver } from "../utils/semver"
 import { createSpinner } from "../utils/spinner"
 import { getExecutablePath } from "./detect-method"
 
@@ -72,6 +73,10 @@ export function getDownloadBaseUrl(): string {
  * @throws SelfUpdateError if platform is unsupported
  */
 export function getDownloadUrl(version: string): string {
+	if (!isValidSemver(version)) {
+		throw new SelfUpdateError(`Invalid version format: ${version}`)
+	}
+
 	const platform = `${process.arch}-${process.platform}`
 	const target = PLATFORM_MAP[platform]
 

--- a/packages/cli/src/self-update/verify.ts
+++ b/packages/cli/src/self-update/verify.ts
@@ -11,6 +11,7 @@
 
 import { IntegrityError, SelfUpdateError } from "../utils/errors"
 import { hashContent } from "../utils/receipt"
+import { isValidSemver } from "../utils/semver"
 
 const GITHUB_REPO = "kdcokenny/ocx"
 
@@ -49,6 +50,10 @@ export function parseSha256Sums(content: string): Map<string, string> {
  * @throws SelfUpdateError if checksums cannot be fetched
  */
 export async function fetchChecksums(version: string): Promise<Map<string, string>> {
+	if (!isValidSemver(version)) {
+		throw new SelfUpdateError(`Invalid version format: ${version}`)
+	}
+
 	const url = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/SHA256SUMS.txt`
 	const response = await fetch(url)
 	if (!response.ok) {

--- a/packages/cli/src/utils/semver.ts
+++ b/packages/cli/src/utils/semver.ts
@@ -11,6 +11,13 @@ export interface ParsedVersion {
 	patch: number
 }
 
+const SEMVER_PATTERN =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+
+export function isValidSemver(v: string): boolean {
+	return SEMVER_PATTERN.test(v)
+}
+
 /**
  * Parse a semver string into components.
  * Returns null if invalid. Ignores prerelease suffixes for comparison.
@@ -19,11 +26,15 @@ export interface ParsedVersion {
  * @returns Parsed version or null if invalid
  */
 export function parseVersion(v: string): ParsedVersion | null {
-	const [main = ""] = v.split("-") // Ignore prerelease for comparison
+	if (!isValidSemver(v)) {
+		return null
+	}
+
+	const [main = ""] = v.split(/[+-]/) // Ignore prerelease/build metadata for comparison
 	const parts = main.split(".")
-	const major = parseInt(parts[0] ?? "", 10)
-	const minor = parseInt(parts[1] ?? "", 10)
-	const patch = parseInt(parts[2] ?? "", 10)
+	const major = Number(parts[0])
+	const minor = Number(parts[1])
+	const patch = Number(parts[2])
 
 	// Early exit: invalid version components
 	if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
@@ -36,6 +47,8 @@ export function parseVersion(v: string): ParsedVersion | null {
 /**
  * Compare two semver versions.
  * Returns null if either version is invalid (cannot compare).
+ * Compares major/minor/patch only; prerelease and build metadata are validated
+ * by parseVersion, then ignored for this compatibility check.
  *
  * @param a - First version string (e.g., "1.2.3")
  * @param b - Second version string (e.g., "1.0.0")

--- a/packages/cli/tests/self-update/check.test.ts
+++ b/packages/cli/tests/self-update/check.test.ts
@@ -201,6 +201,21 @@ describe("checkForUpdate with mocked registry", () => {
 			expect(result.reason).toBe("invalid-response")
 		}
 	})
+
+	it("rejects malformed latest version with path traversal content", async () => {
+		mockFetchPackageVersion.mockResolvedValue({
+			name: "ocx",
+			version: "2.0.0/../../../../../evil/repo/releases/download/v1.0.0",
+		} as NpmPackageVersion)
+
+		const { checkForUpdate } = await importCheckModule()
+		const result = await checkForUpdate({ version: "1.0.0" })
+
+		expect(result.ok).toBe(false)
+		if (!result.ok) {
+			expect(result.reason).toBe("invalid-response")
+		}
+	})
 })
 
 // =============================================================================

--- a/packages/cli/tests/self-update/download.test.ts
+++ b/packages/cli/tests/self-update/download.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "bun:test"
+import { getDownloadUrl } from "../../src/self-update/download"
+
+describe("self-update download URLs", () => {
+	it("rejects malformed versions before constructing release URLs", () => {
+		const malicious = "2.0.0/../../../../../evil/repo/releases/download/v1.0.0"
+
+		expect(() => getDownloadUrl(malicious)).toThrow("Invalid version format")
+	})
+})

--- a/packages/cli/tests/self-update/hook.test.ts
+++ b/packages/cli/tests/self-update/hook.test.ts
@@ -1,11 +1,12 @@
 import { afterAll, afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { createHash } from "node:crypto"
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { Command } from "commander"
 import { cleanupTempDir, createTempDir } from "../helpers"
 
 const SELF_UPDATE_COMMAND_MODULE_PATH = require.resolve("../../src/commands/self/update.js")
+const SELF_UPDATE_RUNNER_MODULE_PATH = require.resolve("../../src/commands/self/update-runner.js")
 const SELF_UPDATE_CHECK_MODULE_PATH = require.resolve("../../src/self-update/check.js")
 const SELF_UPDATE_DETECT_METHOD_MODULE_PATH = require.resolve(
 	"../../src/self-update/detect-method.js",
@@ -16,6 +17,7 @@ const SPINNER_MODULE_PATH = require.resolve("../../src/utils/spinner.js")
 
 const SELF_UPDATE_MOCKED_MODULE_PATHS = [
 	SELF_UPDATE_COMMAND_MODULE_PATH,
+	SELF_UPDATE_RUNNER_MODULE_PATH,
 	SELF_UPDATE_CHECK_MODULE_PATH,
 	SELF_UPDATE_DETECT_METHOD_MODULE_PATH,
 	SELF_UPDATE_VERIFY_MODULE_PATH,
@@ -33,6 +35,12 @@ async function importSelfUpdateCommandModule() {
 	clearSelfUpdateModuleCache()
 	const uniqueId = Bun.randomUUIDv7()
 	return import(`../../src/commands/self/update.js?test=${uniqueId}`)
+}
+
+async function importSelfUpdateRunnerModule() {
+	clearSelfUpdateModuleCache()
+	const uniqueId = Bun.randomUUIDv7()
+	return import(`../../src/commands/self/update-runner.js?test=${uniqueId}`)
 }
 
 // =============================================================================
@@ -374,5 +382,45 @@ describe("self update --json curl strict output", () => {
 		expect(payload.success).toBe(true)
 		expect(payload.data?.method).toBe("curl")
 		expect(payload.data?.updated).toBe(true)
+	})
+
+	it("rejects malformed curl target versions before fetching or replacing the executable", async () => {
+		testDir = await createTempDir("self-update-curl-malformed-version")
+		const executablePath = join(testDir, "bin", "ocx")
+
+		await mkdir(dirname(executablePath), { recursive: true })
+		await writeFile(executablePath, "old-binary")
+
+		mock.module("../../src/self-update/check.js", () => ({
+			EXPLICIT_UPDATE_TIMEOUT_MS: 10_000,
+			checkForUpdate: mock(async () => ({
+				ok: true,
+				current: "1.0.0",
+				latest: "2.0.0/../../../../../evil/repo/releases/download/v1.0.0",
+				updateAvailable: true,
+			})),
+		}))
+
+		const realDetectMethod = require("../../src/self-update/detect-method.js?malformed")
+		mock.module("../../src/self-update/detect-method.js", () => ({
+			...realDetectMethod,
+			getExecutablePath: () => executablePath,
+		}))
+
+		mock.module("../../src/self-update/notify.js", () => ({
+			notifyUpdated: mock(() => {}),
+			notifyUpToDate: mock(() => {}),
+		}))
+
+		const fetchSpy = spyOn(global, "fetch").mockImplementation(
+			mock(async () => new Response("", { status: 500 })) as unknown as typeof fetch,
+		)
+
+		const { runSelfUpdateCommand } = await importSelfUpdateRunnerModule()
+
+		await expect(runSelfUpdateCommand({ method: "curl" })).rejects.toThrow("Invalid version format")
+
+		expect(fetchSpy).not.toHaveBeenCalled()
+		expect(await readFile(executablePath, "utf-8")).toBe("old-binary")
 	})
 })

--- a/packages/cli/tests/self-update/verify.test.ts
+++ b/packages/cli/tests/self-update/verify.test.ts
@@ -3,8 +3,8 @@
  *
  * Ported from memospot/Prisma OSS test patterns.
  */
-import { describe, expect, it } from "bun:test"
-import { parseSha256Sums } from "../../src/self-update/verify"
+import { describe, expect, it, spyOn } from "bun:test"
+import { fetchChecksums, parseSha256Sums } from "../../src/self-update/verify"
 import { hashContent } from "../../src/utils/receipt"
 
 // Valid 64-character SHA256 hashes for testing
@@ -43,6 +43,20 @@ describe("parseSha256Sums", () => {
 		const content = `${HASH_UPPER}  file.txt\n`
 		const map = parseSha256Sums(content)
 		expect(map.get("file.txt")).toBe(HASH_UPPER.toLowerCase())
+	})
+})
+
+describe("fetchChecksums", () => {
+	it("rejects malformed versions before fetching checksum URLs", async () => {
+		const malicious = "2.0.0/../../../../../evil/repo/releases/download/v1.0.0"
+		const fetchSpy = spyOn(global, "fetch")
+
+		try {
+			await expect(fetchChecksums(malicious)).rejects.toThrow("Invalid version format")
+			expect(fetchSpy).not.toHaveBeenCalled()
+		} finally {
+			fetchSpy.mockRestore()
+		}
 	})
 })
 

--- a/packages/cli/tests/utils/semver.test.ts
+++ b/packages/cli/tests/utils/semver.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test"
+import { compareSemver, isValidSemver, parseVersion } from "../../src/utils/semver"
+
+describe("semver utilities", () => {
+	it("accepts release, prerelease, and build metadata versions", () => {
+		expect(isValidSemver("1.2.3")).toBe(true)
+		expect(isValidSemver("1.2.3-beta.1")).toBe(true)
+		expect(isValidSemver("1.2.3+build.7")).toBe(true)
+		expect(isValidSemver("1.2.3-beta.1+build.7")).toBe(true)
+	})
+
+	it("rejects versions with path traversal content", () => {
+		const malicious = "2.0.0/../../../../../evil/repo/releases/download/v1.0.0"
+
+		expect(isValidSemver(malicious)).toBe(false)
+		expect(parseVersion(malicious)).toBeNull()
+		expect(compareSemver(malicious, "1.0.0")).toBeNull()
+	})
+
+	it("rejects partial numeric parsing and malformed versions", () => {
+		expect(parseVersion("1.2.3abc")).toBeNull()
+		expect(parseVersion("1.2")).toBeNull()
+		expect(parseVersion("01.2.3")).toBeNull()
+		expect(parseVersion("v1.2.3")).toBeNull()
+		expect(parseVersion(" 1.2.3")).toBeNull()
+	})
+
+	it("compares core version components after strict validation", () => {
+		expect(compareSemver("1.2.4", "1.2.3")).toBe(1)
+		expect(compareSemver("1.2.3-beta.1", "1.2.3")).toBe(0)
+		expect(compareSemver("1.2.3+build.7", "1.2.3")).toBe(0)
+	})
+})


### PR DESCRIPTION
## Summary

- Enforce strict semver validation in the shared semver parser so malformed registry versions no longer compare as valid updates.
- Reject invalid self-update versions at the curl runner, download URL, and checksum-fetch boundaries before any fetch or executable replacement can occur.
- Add regression coverage for the malicious path-traversal version, lower-level URL/checksum helpers, and valid semver variants.

## Security

Fixes the validated self-update release URL path traversal issue where a malicious version like `2.0.0/../../../../../evil/repo/releases/download/v1.0.0` could be treated as newer and then interpolated into both binary and checksum GitHub release URLs.

The original issue no longer reproduces because:

- `compareSemver(malicious, "1.0.0")` now returns `null`.
- `checkForUpdate()` returns `invalid-response` for the malicious registry version.
- `runSelfUpdateCommand({ method: "curl" })` rejects the malicious target before `fetch()` or replacement.
- `getDownloadUrl()` and `fetchChecksums()` reject the same malformed version at their own boundaries.

## Validation

- `bun install` passed after initial missing dependency setup.
- `bun test packages/cli/tests/utils/semver.test.ts packages/cli/tests/self-update/check.test.ts packages/cli/tests/self-update/download.test.ts packages/cli/tests/self-update/verify.test.ts packages/cli/tests/self-update/hook.test.ts` passed: 37 pass, 0 fail.
- Reproducer probe passed: malicious version yielded `comparison: null`, `getDownloadUrlRejected: true`, and `fetchChecksumsRejected: true`.
- `bun run --cwd packages/cli check:biome` passed.
- `bun run --cwd packages/cli check:types` passed.
- `bun run --cwd packages/cli test` passed: 1366 pass, 7 skip, 0 fail.

## Review Notes

Plan review requested lower-level validation in addition to runner validation; this PR adds those guards in `getDownloadUrl()` and `fetchChecksums()`. The execution-capable QA subagent did not return before interruption, so final QA was completed locally via focused security tests, full CLI tests, type checking, Biome, and `git diff --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the CLI self-update by enforcing strict semver validation and rejecting malformed release versions before any network calls or binary replacement. Fixes a path traversal risk where crafted versions could be interpolated into release URLs.

- **Bug Fixes**
  - Added `isValidSemver` and updated parser to strictly validate semver (including prerelease/build metadata) and return null on invalid comparison.
  - Validated target versions in the update runner (curl and package manager) and fail fast with `SelfUpdateError`.
  - Guarded `getDownloadUrl()` and `fetchChecksums()` to validate versions before building URLs or fetching.
  - Added tests covering the malicious path-traversal version, URL/checksum helpers, and valid semver variants.

<sup>Written for commit 32ae6d576e81fdfa2541375a0bc0156fe775691a. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

