### PR TITLE
fix: Harden PR preview token handling

### DIFF
--- a/.github/workflows/pr-preview-cli.yml
+++ b/.github/workflows/pr-preview-cli.yml
@@ -15,7 +15,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   publish-cli-preview:
@@ -24,6 +23,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -43,5 +44,3 @@ jobs:
       # Use repo-locked pkg-pr-new from devDependencies.
       - name: Publish PR preview package
         run: npx --no-install pkg-pr-new publish --bin --packageManager=npm,pnpm,bun ./packages/cli
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/cli/tests/github-actions-security.test.ts
+++ b/packages/cli/tests/github-actions-security.test.ts
@@ -11,6 +11,15 @@ const syncWorkflowPath = join(
 	"workflows",
 	"sync-facades.yml",
 )
+const prPreviewWorkflowPath = join(
+	import.meta.dir,
+	"..",
+	"..",
+	"..",
+	".github",
+	"workflows",
+	"pr-preview-cli.yml",
+)
 
 describe("GitHub Actions security", () => {
 	it("pins the facade sync action when passing FACADE_SYNC_PAT", () => {
@@ -23,5 +32,20 @@ describe("GitHub Actions security", () => {
 		expect(syncStep).toBeDefined()
 		expect(syncStep).toContain(facadePatInput)
 		expect(syncStep).toMatch(/uses:\s*BetaHuhn\/repo-file-sync-action@[a-f0-9]{40}\n/)
+	})
+
+	it("does not expose a write-scoped token to PR preview build code", () => {
+		const workflow = readFileSync(prPreviewWorkflowPath, "utf8")
+
+		expect(workflow).toContain("pull_request:")
+		expect(workflow).toContain("contents: read")
+		expect(workflow).not.toContain("pull-requests: write")
+		expect(workflow).toMatch(
+			/uses:\s*actions\/checkout@v6\n\s+with:\n\s+persist-credentials:\s*false\n/,
+		)
+		expect(workflow).not.toMatch(/GITHUB_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/)
+		expect(workflow).toContain(
+			"npx --no-install pkg-pr-new publish --bin --packageManager=npm,pnpm,bun ./packages/cli",
+		)
 	})
 })


### PR DESCRIPTION
## Summary
- Remove `pull-requests: write` from the PR preview workflow token permissions
- Disable persisted checkout credentials before PR-controlled install/build steps run
- Stop passing `GITHUB_TOKEN` to the workspace-resolved `pkg-pr-new` publish command
- Add a focused regression test for the PR preview workflow credential boundary

## Security validation
The original finding was valid: the `pull_request` workflow checked out PR-controlled code, ran install/build commands, and later executed `pkg-pr-new` with a write-scoped token available. This change closes that path by ensuring the workflow only has `contents: read`, checkout does not persist credentials, and the publish step has no explicit `GITHUB_TOKEN` environment.

## Verification
- `bun install --frozen-lockfile`
- `bun test packages/cli/tests/github-actions-security.test.ts`
- `bun run check`
- `bun run --cwd packages/cli build`
- `git diff --check`

## Review gates
- Plan review: pass, no blocking findings; recommended keeping the fix scoped and not restoring a write token to the publish step.
- QA review: pass, independently inspected the diff and ran the focused security test.

## Residual risk
I did not execute the GitHub-hosted PR preview workflow end to end, so runtime behavior of `pkg-pr-new` without `GITHUB_TOKEN` was not proven locally. Security-wise, the reported token exposure path is removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the PR preview workflow to prevent write-token exposure to PR-controlled code. It now uses read-only permissions, does not persist checkout credentials, and does not pass `GITHUB_TOKEN` to `pkg-pr-new` publish.

- **Bug Fixes**
  - Removed `pull-requests: write`; kept `contents: read`.
  - Set `actions/checkout@v6` with `persist-credentials: false`.
  - Removed `GITHUB_TOKEN` from the publish step; `pkg-pr-new` runs without it.
  - Added a regression test to verify these constraints in the workflow.

<sup>Written for commit 87885f49d588b338b2aa3b6f8f8a60d78a0548d4. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

