### PR TITLE
fix(notify): restore VS Code native tab focus

### DIFF
--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -68,6 +68,7 @@ interface TerminalInfo {
 	name: string | null
 	bundleId: string | null
 	processName: string | null
+	nativeTabTitle: string | null
 }
 
 const DEFAULT_CONFIG: NotifyConfig = {
@@ -159,12 +160,39 @@ async function getFrontmostApp(): Promise<string | null> {
 	)
 }
 
+function isVSCodeTerminal(terminalName: string): boolean {
+	const normalized = terminalName.toLowerCase()
+	return normalized === "vscode" || normalized === "vscode-insiders"
+}
+
+function toAppleScriptString(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+async function getVSCodeNativeTabTitle(processName: string): Promise<string | null> {
+	const escapedProcessName = toAppleScriptString(processName)
+	return runOsascript(`
+		tell application "System Events"
+			tell process "${escapedProcessName}"
+				set activeWindow to first window whose value of attribute "AXMain" is true
+				tell tab group 1 of activeWindow
+					repeat with rb in radio buttons
+						if (value of attribute "AXValue" of rb) is true then
+							return value of attribute "AXTitle" of rb
+						end if
+					end repeat
+				end tell
+			end tell
+		end tell
+	`)
+}
+
 async function detectTerminalInfo(config: NotifyConfig): Promise<TerminalInfo> {
 	// Use config override if provided
 	const terminalName = config.terminal || detectTerminal() || null
 
 	if (!terminalName) {
-		return { name: null, bundleId: null, processName: null }
+		return { name: null, bundleId: null, processName: null, nativeTabTitle: null }
 	}
 
 	// Get process name for focus detection
@@ -172,11 +200,15 @@ async function detectTerminalInfo(config: NotifyConfig): Promise<TerminalInfo> {
 
 	// Dynamically get bundle ID from macOS (no hardcoding!)
 	const bundleId = await getBundleId(processName)
+	const nativeTabTitle = isVSCodeTerminal(terminalName)
+		? await getVSCodeNativeTabTitle(processName)
+		: null
 
 	return {
 		name: terminalName,
 		bundleId,
 		processName,
+		nativeTabTitle,
 	}
 }
 
@@ -399,6 +431,8 @@ async function sendDesktopNotification(options: NotificationOptions): Promise<vo
 		subtitle: options.subtitle,
 		sound,
 		senderBundleId: terminalInfo.bundleId,
+		processName: terminalInfo.processName,
+		nativeTabTitle: terminalInfo.nativeTabTitle,
 		sendNodeNotifierNotification: () => notifier.notify(notifyOptions),
 	})
 }

--- a/workers/kdco-registry/files/plugins/notify/backend.ts
+++ b/workers/kdco-registry/files/plugins/notify/backend.ts
@@ -10,6 +10,8 @@ export interface DesktopNotificationOptions {
 	subtitle?: string
 	sound?: string
 	senderBundleId?: string | null
+	nativeTabTitle?: string | null
+	processName?: string | null
 }
 
 interface DesktopNotificationRouterOptions extends DesktopNotificationOptions {
@@ -20,11 +22,13 @@ interface DesktopNotificationRouterOptions extends DesktopNotificationOptions {
 
 interface AlerterProcess {
 	exited: Promise<number>
+	stdout?: ReadableStream | null
 }
 
 interface AlerterRuntime {
 	which?: (command: string) => string | null | Promise<string | null>
 	spawnProcess?: (argv: string[]) => AlerterProcess
+	focusBundleId?: (bundleId: string, options?: DesktopNotificationOptions) => Promise<void>
 	warn?: (message: string) => void
 }
 
@@ -49,11 +53,124 @@ export function buildAlerterArguments(options: DesktopNotificationOptions): stri
 	return argv
 }
 
+async function readAlerterOutput(process: AlerterProcess): Promise<string> {
+	if (!process.stdout) return ""
+
+	try {
+		return (await new Response(process.stdout).text()).trim()
+	} catch {
+		return ""
+	}
+}
+
+function shouldActivateBundleId(alerterOutput: string): boolean {
+	const normalizedOutput = alerterOutput.trim().toUpperCase()
+	if (!normalizedOutput) return false
+	if (normalizedOutput === "@CLOSED" || normalizedOutput === "@TIMEOUT") return false
+	return true
+}
+
+async function focusBundleId(bundleId: string): Promise<void> {
+	try {
+		const activateProcess = Bun.spawn(
+			["osascript", "-e", `tell application id \"${bundleId}\" to activate`],
+			{
+				stdout: "ignore",
+				stderr: "ignore",
+			},
+		)
+		if ((await activateProcess.exited) === 0) return
+	} catch {
+		// Fall through to `open -b` fallback.
+	}
+
+	try {
+		const openProcess = Bun.spawn(["open", "-b", bundleId], {
+			stdout: "ignore",
+			stderr: "ignore",
+		})
+		await openProcess.exited
+	} catch {
+		// Best-effort focus only.
+	}
+}
+
+function toAppleScriptString(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+async function focusVSCodeNativeTab(
+	processName: string,
+	nativeTabTitle: string,
+): Promise<boolean> {
+	try {
+		const escapedProcessName = toAppleScriptString(processName)
+		const escapedTabTitle = toAppleScriptString(nativeTabTitle)
+		const result = Bun.spawn(
+			[
+				"osascript",
+				"-e",
+				`tell application \"System Events\" to tell process \"${escapedProcessName}\"`,
+				"-e",
+				"repeat with w in windows",
+				"-e",
+				"try",
+				"-e",
+				"tell tab group 1 of w",
+				"-e",
+				`if exists radio button \"${escapedTabTitle}\" then`,
+				"-e",
+				'perform action "AXRaise" of w',
+				"-e",
+				`tell radio button \"${escapedTabTitle}\" to perform action \"AXPress\"`,
+				"-e",
+				'return "matched"',
+				"-e",
+				"end if",
+				"-e",
+				"end tell",
+				"-e",
+				"end try",
+				"-e",
+				"end repeat",
+				"-e",
+				'return "not-found"',
+				"-e",
+				"end tell",
+			],
+			{ stdout: "pipe", stderr: "ignore" },
+		)
+		const [exitCode, output] = await Promise.all([
+			result.exited,
+			new Response(result.stdout).text(),
+		])
+		return exitCode === 0 && output.trim() === "matched"
+	} catch {
+		return false
+	}
+}
+
+async function focusBundleIdWithContext(
+	bundleId: string,
+	options?: DesktopNotificationOptions,
+): Promise<void> {
+	await focusBundleId(bundleId)
+
+	if (
+		process.platform === "darwin" &&
+		options?.processName === "Code" &&
+		options.nativeTabTitle
+	) {
+		await focusVSCodeNativeTab(options.processName, options.nativeTabTitle)
+	}
+}
+
 export async function sendMacOSAlerterNotification(
 	options: DesktopNotificationOptions,
 	runtime: AlerterRuntime = {},
 ): Promise<boolean> {
 	const which = runtime.which ?? Bun.which
+	const activateBundle = runtime.focusBundleId ?? focusBundleIdWithContext
 	const warn = runtime.warn ?? console.warn
 
 	try {
@@ -64,11 +181,19 @@ export async function sendMacOSAlerterNotification(
 		}
 
 		const alerterArguments = buildAlerterArguments(options)
-		const spawnProcess = runtime.spawnProcess ?? ((argv: string[]) => Bun.spawn(argv, { stdout: "ignore", stderr: "pipe" }))
+		const spawnProcess = runtime.spawnProcess ?? ((argv: string[]) => Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" }))
 		const process = spawnProcess([alerterPath, ...alerterArguments.slice(1)])
-		const exitCode = await process.exited
+		const [exitCode, alerterOutput] = await Promise.all([
+			process.exited,
+			readAlerterOutput(process),
+		])
 
-		if (exitCode === 0) return true
+		if (exitCode === 0) {
+			if (options.senderBundleId && shouldActivateBundleId(alerterOutput)) {
+				await activateBundle(options.senderBundleId, options)
+			}
+			return true
+		}
 
 		warn(`notify: macOS desktop notification skipped; alerter exited with code ${exitCode}.`)
 		return false


### PR DESCRIPTION
## Summary
Fix the macOS `notify` plugin flow for VS Code integrated terminal users with native tabs enabled.
This change:
- captures the active VS Code native tab title when the plugin initializes
- reads `alerter` click output before deciding whether to activate the app
- explicitly activates VS Code after notification clicks
- reselects the matching native tab through macOS Accessibility APIs
## Problem
When OpenCode was running inside the VS Code integrated terminal, clicking a desktop notification did not reliably take the user back to the correct place.
Observed behavior on macOS:
- notification could appear correctly
- clicking it might only focus VS Code in general
- with native tabs enabled, it did not restore the correct tab
## Implementation
Files changed:
- `workers/kdco-registry/files/plugins/notify.ts`
- `workers/kdco-registry/files/plugins/notify/backend.ts`
Main implementation details:
- extend terminal detection context with the active VS Code native tab title
- pass tab/process context into the macOS notification backend
- inspect `alerter` stdout so activation only happens on actual click interactions
- activate the sender app and, for VS Code, raise the matching window and press the matching native tab
## Verification
- `bun run --cwd workers/kdco-registry check:types`
Manual verification on macOS:
- OpenCode running in VS Code integrated terminal
- desktop notification appears when the session becomes idle / waits for input
- clicking the notification focuses VS Code
- clicking the notification restores the correct native tab
## Notes
The VS Code native-tab restore behavior relies on macOS Accessibility permission for VS Code.
If you want, I can also tailor this into a shorter “maintainer-style” version before you open the PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS notifications so clicking from VS Code’s integrated terminal with native tabs focuses VS Code and restores the correct tab. We capture the active tab title, read `alerter` output to detect clicks, and target the matching tab via Accessibility.

- **Bug Fixes**
  - Capture the active VS Code native tab title during terminal detection.
  - Pass process/tab context to the macOS backend and read `alerter` stdout to confirm clicks.
  - Activate the sender app; for VS Code, raise the window and press the matching native tab.

- **Migration**
  - On macOS, grant VS Code Accessibility permission to enable native-tab restoration.

<sup>Written for commit e32857f278c346abc22d8b848cfa0595514fa94f. Summary will update on new commits. <a href="https://cubic.dev/pr/kdcokenny/ocx/pull/228?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

