### PR TITLE
fix(cli): Restore missing files during update

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -23,7 +23,7 @@ import { handleError } from "../utils/handle-error"
 import { logger } from "../utils/logger"
 import { resolveTargetPath } from "../utils/paths"
 import { registerPlannedWriteOrThrow } from "../utils/planned-writes"
-import { hashBundle, hashContent } from "../utils/receipt"
+import { checkFileIntegrity, hashBundle, hashContent } from "../utils/receipt"
 import { addCommonOptions, addGlobalOption, addVerboseOption } from "../utils/shared-options"
 import { createSpinner } from "../utils/spinner"
 
@@ -279,8 +279,14 @@ export async function runUpdateCore(
 			const newHash = await hashBundle(files)
 			const newVersion = `sha256:${newHash}` // Use hash as version/revision
 
-			// Compare hashes
-			if (newHash === entry.hash) {
+			// A matching registry hash only proves the source bundle is unchanged.
+			// Verify the installed files too so update can repair local drift.
+			const bundleIsUnchanged = newHash === entry.hash
+			const installedFilesAreIntact = bundleIsUnchanged
+				? (await checkFileIntegrity(provider.cwd, entry)).intact
+				: false
+
+			if (bundleIsUnchanged && installedFilesAreIntact) {
 				results.push({
 					qualifiedName: canonicalId,
 					oldVersion: entry.revision,

--- a/packages/cli/tests/update.test.ts
+++ b/packages/cli/tests/update.test.ts
@@ -101,6 +101,38 @@ describe("ocx update", () => {
 		expect(pluginEntry?.[1].updatedAt).toBeDefined()
 	})
 
+	it("restores a missing installed file when the registry bundle is unchanged", async () => {
+		testDir = await setupProject("update-missing-file")
+		await installComponent(testDir, "kdco/test-plugin")
+
+		const filePath = join(testDir, ".opencode", "plugins", "test-plugin.ts")
+		const originalContent = await readFile(filePath, "utf-8")
+		await fsRm(filePath)
+		expect(existsSync(filePath)).toBe(false)
+
+		const { exitCode, output } = await runCLI(["update", "kdco/test-plugin"], testDir)
+
+		expect(exitCode).toBe(0)
+		expect(output).not.toContain("All components are up to date")
+		expect(existsSync(filePath)).toBe(true)
+		expect(await readFile(filePath, "utf-8")).toBe(originalContent)
+	})
+
+	it("restores a modified installed file when the registry bundle is unchanged", async () => {
+		testDir = await setupProject("update-modified-file")
+		await installComponent(testDir, "kdco/test-plugin")
+
+		const filePath = join(testDir, ".opencode", "plugins", "test-plugin.ts")
+		const originalContent = await readFile(filePath, "utf-8")
+		await writeFile(filePath, "// locally modified")
+
+		const { exitCode, output } = await runCLI(["update", "kdco/test-plugin"], testDir)
+
+		expect(exitCode).toBe(0)
+		expect(output).not.toContain("All components are up to date")
+		expect(await readFile(filePath, "utf-8")).toBe(originalContent)
+	})
+
 	// =========================================================================
 	// --all flag tests
 	// =========================================================================


### PR DESCRIPTION
## Summary

- verify managed on-disk files even when the registry bundle hash still matches the receipt
- route missing or modified files through the existing atomic update transaction
- cover both missing-file and modified-file drift with regression tests

## Root cause

`ocx update` treated a matching receipt/registry bundle hash as proof that the component was fully applied. It never checked the actual installed files, so deleted or locally divergent managed files were reported as up to date and could not self-heal.

This fixes the original file-drift report in #240. The broader `opencode.jsonc` ownership/reconciliation and receipt-normalization concerns raised later in that thread are intentionally not coupled to this focused change; they need separate merge, stale-value, and rollback semantics.

## Red/green verification

Before the fix, the focused regression run had 0 passing and 2 failing tests: both missing and modified files were left untouched while the CLI reported all components up to date.

After the fix:

- focused missing/modified regression tests: 2 passed
- complete update suite: 33 passed
- complete CLI suite: passed
- CLI typecheck and Biome: passed
- `git diff --check`: passed

Fixes #240

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates now self-heal missing or locally modified managed files by verifying installed file integrity even when the registry bundle hash matches, routing drift through the atomic update path. Fixes #240.

- **Bug Fixes**
  - Verify on-disk files with `checkFileIntegrity` when the registry bundle hash matches; skip only when both bundle and files are unchanged.
  - Restore missing files and revert modified files via the atomic transaction (no “All components are up to date” on drift).
  - Add regression tests for missing-file and modified-file scenarios.

<sup>Written for commit b2c75fdb600dfede130601b98350e26c006670bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

