### PR TITLE
fix(schemas): Preserve MCP OAuth fields

### DIFF
--- a/docs/reference/mcp.mdx
+++ b/docs/reference/mcp.mdx
@@ -81,6 +81,14 @@ MCP (Model Context Protocol) servers add external tools to OpenCode. Configure l
 }
 ```
 
+| Option | Type | Description |
+|--------|------|-------------|
+| `clientId` | string | OAuth client ID; dynamic client registration is attempted when omitted |
+| `clientSecret` | string | OAuth client secret, when required by the authorization server |
+| `scope` | string | Space-delimited OAuth scopes requested during authorization |
+| `callbackPort` | integer | Local callback port from 1–65535; defaults to 19876 |
+| `redirectUri` | string | Full redirect URI; takes precedence over `callbackPort` |
+
 ## Per-Agent MCP Tools
 
 Restrict MCP tools to specific agents:

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -264,10 +264,16 @@
 												"type": "object",
 												"properties": {
 													"clientId": { "type": "string" },
-													"scopes": { "type": "array", "items": { "type": "string" } },
-													"authUrl": { "type": "string", "format": "uri" },
-													"tokenUrl": { "type": "string", "format": "uri" }
-												}
+													"clientSecret": { "type": "string" },
+													"scope": { "type": "string" },
+													"callbackPort": {
+														"type": "integer",
+														"minimum": 1,
+														"maximum": 65535
+													},
+													"redirectUri": { "type": "string" }
+												},
+												"additionalProperties": false
 											}
 										],
 										"description": "OAuth configuration for MCP server"

--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -10,6 +10,7 @@ import {
 	classifyRegistrySchemaIssue,
 	componentManifestSchema,
 	componentTypeSchema,
+	legacyComponentManifestSchema,
 	packumentSchema,
 	registryIndexSchema,
 } from "../schemas/registry"
@@ -190,7 +191,29 @@ function hasLegacySignalsInManifest(manifest: unknown): boolean {
 		return true
 	}
 
-	return collectLegacyManifestTargetIssues(manifest).length > 0
+	if (collectLegacyManifestTargetIssues(manifest).length > 0) {
+		return true
+	}
+
+	const opencode = manifest.opencode
+	if (!isPlainObject(opencode) || !isPlainObject(opencode.mcp)) {
+		return false
+	}
+
+	for (const server of Object.values(opencode.mcp)) {
+		if (!isPlainObject(server) || !isPlainObject(server.oauth)) {
+			continue
+		}
+		if (
+			Object.hasOwn(server.oauth, "scopes") ||
+			Object.hasOwn(server.oauth, "authUrl") ||
+			Object.hasOwn(server.oauth, "tokenUrl")
+		) {
+			return true
+		}
+	}
+
+	return false
 }
 
 async function resolveRegistrySchemaMode(baseUrl: string): Promise<RegistrySchemaMode | null> {
@@ -612,12 +635,14 @@ export async function fetchComponentVersion(
 			// 3. Validate manifest (legacy adaptation is version-gated)
 			const context = `component "${name}@${resolvedVersion}"`
 			let candidateManifest: unknown = manifest
+			let manifestSchema = componentManifestSchema
 
 			if (hasLegacySignalsInManifest(manifest)) {
 				const schemaMode = await resolveRegistrySchemaMode(baseUrl)
 
 				if (schemaMode !== "v2") {
 					candidateManifest = adaptLegacyComponentManifest(manifest, context)
+					manifestSchema = legacyComponentManifestSchema
 				} else {
 					const legacyTargetIssues = collectLegacyManifestTargetIssues(manifest)
 					const firstLegacyTargetIssue = legacyTargetIssues[0]
@@ -637,7 +662,7 @@ export async function fetchComponentVersion(
 				}
 			}
 
-			const manifestResult = componentManifestSchema.safeParse(candidateManifest)
+			const manifestResult = manifestSchema.safeParse(candidateManifest)
 			if (!manifestResult.success) {
 				throw new ValidationError(
 					`Invalid component manifest for "${name}@${resolvedVersion}": ${manifestResult.error.message}`,

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -221,15 +221,26 @@ export const targetPathSchema = string()
 export const oauthConfigSchema = object({
 	/** OAuth client ID */
 	clientId: string().optional(),
-	/** OAuth scopes to request */
-	scopes: array(string()).optional(),
-	/** OAuth authorization URL */
-	authUrl: string().optional(),
-	/** OAuth token URL */
-	tokenUrl: string().optional(),
-})
+	/** OAuth client secret, when required by the authorization server */
+	clientSecret: string().optional(),
+	/** Space-delimited OAuth scopes to request */
+	scope: string().optional(),
+	/** Port for the local OAuth callback server */
+	callbackPort: number().int().min(1).max(65535).optional(),
+	/** Full OAuth redirect URI (takes precedence over callbackPort) */
+	redirectUri: string().optional(),
+}).strict()
 
 export type OAuthConfig = ZodInfer<typeof oauthConfigSchema>
+
+const legacyOAuthConfigSchema = oauthConfigSchema.safeExtend({
+	/** @deprecated Registry v1 compatibility; v2 uses singular `scope` */
+	scopes: array(string()).optional(),
+	/** @deprecated Registry v1 compatibility */
+	authUrl: string().optional(),
+	/** @deprecated Registry v1 compatibility */
+	tokenUrl: string().optional(),
+})
 
 /**
  * Full MCP server configuration object
@@ -269,6 +280,10 @@ export const mcpServerObjectSchema = object({
 
 export type McpServer = ZodInfer<typeof mcpServerObjectSchema>
 
+const legacyMcpServerObjectSchema = mcpServerObjectSchema.safeExtend({
+	oauth: union([boolean(), legacyOAuthConfigSchema]).optional(),
+})
+
 /**
  * Cargo-style MCP server reference:
  * - String: URL shorthand for remote server (e.g., "https://mcp.example.com")
@@ -277,6 +292,8 @@ export type McpServer = ZodInfer<typeof mcpServerObjectSchema>
 export const mcpServerRefSchema = union([string(), mcpServerObjectSchema])
 
 export type McpServerRef = ZodInfer<typeof mcpServerRefSchema>
+
+const legacyMcpServerRefSchema = union([string(), legacyMcpServerObjectSchema])
 
 // =============================================================================
 // COMPONENT FILE SCHEMA (Cargo-style: string path or full object)
@@ -584,6 +601,10 @@ export const opencodeConfigSchema = object({
 
 export type OpencodeConfig = ZodInfer<typeof opencodeConfigSchema>
 
+const legacyOpencodeConfigSchema = opencodeConfigSchema.extend({
+	mcp: record(string(), legacyMcpServerRefSchema).optional(),
+})
+
 // =============================================================================
 // COMPONENT MANIFEST SCHEMA
 // =============================================================================
@@ -627,6 +648,10 @@ export const componentManifestSchema = object({
 })
 
 export type ComponentManifest = ZodInfer<typeof componentManifestSchema>
+
+export const legacyComponentManifestSchema = componentManifestSchema.extend({
+	opencode: legacyOpencodeConfigSchema.optional(),
+})
 
 // =============================================================================
 // NORMALIZER FUNCTIONS (Parse, Don't Validate - Law 2)

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -601,7 +601,7 @@ export const opencodeConfigSchema = object({
 
 export type OpencodeConfig = ZodInfer<typeof opencodeConfigSchema>
 
-const legacyOpencodeConfigSchema = opencodeConfigSchema.extend({
+const legacyOpencodeConfigSchema = opencodeConfigSchema.safeExtend({
 	mcp: record(string(), legacyMcpServerRefSchema).optional(),
 })
 

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -85,6 +85,104 @@ describe("ocx build", () => {
 		expect(index.components[0].name).toBe("comp-1")
 	})
 
+	it("should preserve valid MCP OAuth fields in built component manifests", async () => {
+		const sourceDir = join(testDir, "registry-mcp-oauth")
+		await mkdir(sourceDir, { recursive: true })
+
+		const oauth = {
+			clientId: "client-id",
+			clientSecret: "client-secret",
+			scope: "files:read files:write",
+			callbackPort: 24567,
+			redirectUri: "http://127.0.0.1:24567/mcp/oauth/callback",
+		}
+		const registryJson = {
+			$schema: REGISTRY_SCHEMA_V2_URL,
+			name: "MCP OAuth Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "oauth-mcp",
+					type: "bundle",
+					description: "Remote MCP server with OAuth",
+					files: [],
+					dependencies: [],
+					opencode: {
+						mcp: {
+							remote: {
+								type: "remote",
+								url: "https://mcp.example.com/mcp",
+								oauth,
+							},
+						},
+					},
+				},
+			],
+		}
+
+		await writeFile(join(sourceDir, "registry.json"), JSON.stringify(registryJson, null, 2))
+
+		const outDir = "dist-mcp-oauth"
+		const { exitCode, output } = await runCLI(
+			["build", "registry-mcp-oauth", "--out", outDir],
+			testDir,
+		)
+
+		expect(exitCode).toBe(0)
+		expect(output).toContain("Built 1 component")
+
+		const packument = JSON.parse(
+			await readFile(join(testDir, outDir, "components", "oauth-mcp.json"), "utf-8"),
+		)
+		expect(packument.versions["1.0.0"].opencode.mcp.remote.oauth).toEqual(oauth)
+	})
+
+	it("should reject legacy MCP OAuth fields in v2 registries", async () => {
+		const sourceDir = join(testDir, "registry-legacy-mcp-oauth")
+		await mkdir(sourceDir, { recursive: true })
+
+		const registryJson = {
+			$schema: REGISTRY_SCHEMA_V2_URL,
+			name: "Invalid Legacy MCP OAuth Registry",
+			version: "1.0.0",
+			author: "Test Author",
+			components: [
+				{
+					name: "legacy-oauth-mcp",
+					type: "bundle",
+					description: "MCP server using registry v1 OAuth fields",
+					files: [],
+					dependencies: [],
+					opencode: {
+						mcp: {
+							remote: {
+								type: "remote",
+								url: "https://mcp.example.com/mcp",
+								oauth: {
+									scopes: ["files:read"],
+									authUrl: "https://auth.example.com",
+									tokenUrl: "https://token.example.com",
+								},
+							},
+						},
+					},
+				},
+			],
+		}
+
+		await writeFile(join(sourceDir, "registry.json"), JSON.stringify(registryJson, null, 2))
+
+		const { exitCode, output } = await runCLI(
+			["build", "registry-legacy-mcp-oauth", "--out", "dist-legacy-mcp-oauth"],
+			testDir,
+		)
+
+		expect(exitCode).toBe(EXIT_CODES.GENERAL)
+		expect(output).toContain("components.0.opencode.mcp.remote")
+		expect(existsSync(join(testDir, "dist-legacy-mcp-oauth"))).toBe(false)
+	})
+
 	it("should display validation results when --show-validation is used", async () => {
 		const sourceDir = join(testDir, "registry")
 		await mkdir(sourceDir, { recursive: true })

--- a/packages/cli/tests/registry/fetcher.test.ts
+++ b/packages/cli/tests/registry/fetcher.test.ts
@@ -824,9 +824,7 @@ describe("fetchComponentVersion legacy manifest adaptation", () => {
 		const { manifest } = await fetchComponentVersion("https://legacy.example.com", "legacy-mcp")
 		const remote = manifest.opencode?.mcp?.remote
 		expect(typeof remote).toBe("object")
-		if (typeof remote === "object" && remote !== null && "oauth" in remote) {
-			expect(remote.oauth).toEqual(legacyOauth)
-		}
+		expect(remote).toMatchObject({ oauth: legacyOauth })
 	})
 
 	it("adapts legacy manifest when schema mode is null (index fetch fails)", async () => {

--- a/packages/cli/tests/registry/fetcher.test.ts
+++ b/packages/cli/tests/registry/fetcher.test.ts
@@ -764,6 +764,71 @@ describe("fetchComponentVersion legacy manifest adaptation", () => {
 		expect(manifest.files[0]).toEqual({ path: "plugin.ts", target: "plugins/legacy-plugin.ts" })
 	})
 
+	it("preserves legacy v1 MCP OAuth fields during manifest adaptation", async () => {
+		const legacyOauth = {
+			clientId: "legacy-client",
+			scopes: ["files:read"],
+			authUrl: "https://auth.example.com",
+			tokenUrl: "https://token.example.com",
+		}
+		globalThis.fetch = mock((input) => {
+			const requestUrl = new URL(String(input))
+
+			if (requestUrl.pathname === "/index.json") {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							author: "Legacy",
+							components: [{ name: "legacy-mcp", type: "ocx:bundle", description: "Legacy MCP" }],
+						}),
+						{
+							status: 200,
+							headers: { "content-type": "application/json" },
+						},
+					),
+				)
+			}
+
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						name: "legacy-mcp",
+						"dist-tags": { latest: "1.4.6" },
+						versions: {
+							"1.4.6": {
+								name: "legacy-mcp",
+								type: "ocx:bundle",
+								description: "Legacy MCP",
+								files: [],
+								dependencies: [],
+								opencode: {
+									mcp: {
+										remote: {
+											type: "remote",
+											url: "https://mcp.example.com",
+											oauth: legacyOauth,
+										},
+									},
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				),
+			)
+		})
+
+		const { manifest } = await fetchComponentVersion("https://legacy.example.com", "legacy-mcp")
+		const remote = manifest.opencode?.mcp?.remote
+		expect(typeof remote).toBe("object")
+		if (typeof remote === "object" && remote !== null && "oauth" in remote) {
+			expect(remote.oauth).toEqual(legacyOauth)
+		}
+	})
+
 	it("adapts legacy manifest when schema mode is null (index fetch fails)", async () => {
 		globalThis.fetch = mock((input) => {
 			const requestUrl = new URL(String(input))

--- a/packages/cli/tests/schemas.test.ts
+++ b/packages/cli/tests/schemas.test.ts
@@ -14,6 +14,7 @@ import {
 	namespaceSchema,
 	normalizeFile,
 	normalizeMcpServer,
+	oauthConfigSchema,
 	openCodeNameSchema,
 	parseQualifiedComponent,
 	permissionConfigSchema,
@@ -350,6 +351,40 @@ describe("schemas", () => {
 			const result = normalizeMcpServer(input)
 			expect(result).toEqual(input)
 			expect(result.command).toBe("npx some-mcp-server --port 3000")
+		})
+	})
+
+	describe("oauthConfigSchema", () => {
+		it("rejects legacy v1 fields in current manifests", () => {
+			const result = oauthConfigSchema.safeParse({
+				scopes: ["files:read"],
+				authUrl: "https://auth.example.com",
+				tokenUrl: "https://token.example.com",
+			})
+
+			expect(result.success).toBe(false)
+			if (!result.success) {
+				expect(result.error.issues[0]?.code).toBe("unrecognized_keys")
+				expect(result.error.issues[0]?.message).toContain("scopes")
+			}
+		})
+
+		it("rejects unknown fields instead of silently stripping them", () => {
+			const result = oauthConfigSchema.safeParse({ unexpected: true })
+
+			expect(result.success).toBe(false)
+			if (!result.success) {
+				expect(result.error.issues[0]?.code).toBe("unrecognized_keys")
+				expect(result.error.issues[0]?.message).toContain("unexpected")
+			}
+		})
+
+		it("enforces the callback port range from OpenCode's schema", () => {
+			expect(oauthConfigSchema.safeParse({ callbackPort: 1 }).success).toBe(true)
+			expect(oauthConfigSchema.safeParse({ callbackPort: 65535 }).success).toBe(true)
+			expect(oauthConfigSchema.safeParse({ callbackPort: 0 }).success).toBe(false)
+			expect(oauthConfigSchema.safeParse({ callbackPort: 65536 }).success).toBe(false)
+			expect(oauthConfigSchema.safeParse({ callbackPort: 1.5 }).success).toBe(false)
 		})
 	})
 


### PR DESCRIPTION
## Summary

- align nested MCP OAuth validation with OpenCode's current `clientId`, `clientSecret`, `scope`, `callbackPort`, and `redirectUri` fields
- make the current OAuth object strict so unsupported keys fail instead of being silently stripped
- retain registry v1 compatibility behind the existing schema-version gate
- update the published registry schema and MCP reference documentation

## Root cause

The hand-maintained nested OAuth schema recognized only `clientId` plus legacy v1 fields. Zod therefore removed four valid current fields while parsing a component manifest, before `ocx build` wrote the packument.

## Red / green verification

**Red:** a build fixture containing all five current OAuth fields retained only `clientId`; `clientSecret`, `scope`, `callbackPort`, and `redirectUri` were lost.

**Green:** the regression test now preserves the complete OAuth object. Additional coverage verifies callback-port bounds, strict rejection of unknown and legacy-only fields in v2, and version-gated preservation of legacy v1 OAuth manifests.

## Validation

- `bun run --cwd packages/cli check`
- focused build, schema, and fetcher suites: 190 passed, 0 failed
- `bun test packages/cli/tests`: 1,381 passed, 7 skipped, 0 failed
- `git diff --check`

Fixes #241

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves MCP OAuth config in component manifests by aligning with OpenCode’s current fields and making the OAuth object strict. Adds safe legacy handling and validation so v1 registries continue to work. Fixes #241.

- **Bug Fixes**
  - Accept and persist `clientId`, `clientSecret`, `scope`, `callbackPort`, `redirectUri` in v2; disallow extra keys in the JSON schema.
  - Reject v1-only fields (`scopes`, `authUrl`, `tokenUrl`) and unknown keys in v2; document current OAuth fields in MCP docs.
  - Detect legacy OAuth fields during fetch; when not in v2 mode, adapt and validate with a legacy schema so v1 manifests (including legacy OAuth) are preserved.
  - Add tests for v2 field preservation, legacy OAuth preservation during fetch, v2 rejection, and callback-port bounds; update `registry.schema.json`.

<sup>Written for commit b6b3e8c74118c3570c8040d096d9e7ab9e391f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

