### PR TITLE
fix(release): Safeguard the 2.0.12 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           bun-version-file: package.json
 
+      - name: Validate release tag version
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./packages/cli/package.json').version")"
+          if [ "$GITHUB_REF_NAME" != "v${package_version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match packages/cli/package.json version ${package_version}."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -131,6 +141,42 @@ jobs:
           done
           # Generate consolidated SHA256SUMS.txt
           sha256sum ocx-* | grep -v '\.sha256' > SHA256SUMS.txt
+
+      - name: Revalidate release source
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./packages/cli/package.json').version")"
+          lock_version="$(
+            cd packages/cli
+            bun -e 'import { parse } from "jsonc-parser"; const lock = parse(await Bun.file("../../bun.lock").text()); process.stdout.write(lock.workspaces["packages/cli"].version)'
+          )"
+
+          if [ "$GITHUB_REF_NAME" != "v${package_version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match packages/cli/package.json version ${package_version}."
+            exit 1
+          fi
+          if [ "$lock_version" != "$package_version" ]; then
+            echo "::error::bun.lock CLI version ${lock_version} does not match packages/cli/package.json version ${package_version}."
+            exit 1
+          fi
+
+          git fetch --no-tags origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "refs/remotes/origin/${DEFAULT_BRANCH}"; then
+            echo "::error::Tag commit ${GITHUB_SHA} is not on origin/${DEFAULT_BRANCH}."
+            exit 1
+          fi
+
+          remote_version="$(
+            git show "refs/remotes/origin/${DEFAULT_BRANCH}:packages/cli/package.json" |
+              node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version'
+          )"
+          if [ "$remote_version" != "$package_version" ]; then
+            echo "::error::origin/${DEFAULT_BRANCH} package version ${remote_version} does not match release version ${package_version}."
+            exit 1
+          fi
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "packages/cli": {
       "name": "ocx",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "bin": {
         "ocx": "./dist/index.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ocx",
-	"version": "2.0.11",
+	"version": "2.0.12",
 	"description": "OCX CLI - OpenCode extension manager with portable, isolated profiles. Your setup, anywhere.",
 	"author": "kdcokenny",
 	"license": "MIT",

--- a/packages/cli/scripts/release-tag.ts
+++ b/packages/cli/scripts/release-tag.ts
@@ -4,6 +4,9 @@
  * Safety contract:
  * - Reads version from packages/cli/package.json only
  * - Requires HEAD to exactly match origin/<defaultBranch>
+ * - Requires the working-tree manifest to match origin/<defaultBranch>
+ * - Requires a clean working tree
+ * - Revalidates the live default branch immediately before a guarded tag push
  * - Uses exact npm name@version lookup as source of truth
  * - Never rewrites existing semver tags
  * - `--force` only retries pushing an already-correct local tag
@@ -28,6 +31,9 @@ const USAGE_TEXT = [
 	"",
 	"Safety:",
 	"- Requires HEAD to equal origin/<defaultBranch> after refresh.",
+	"- Requires packages/cli/package.json to match origin/<defaultBranch>.",
+	"- Requires a clean working tree.",
+	"- Revalidates origin/<defaultBranch> immediately before a guarded tag push.",
 	"- Requires exact npm name@version to be definitively missing.",
 	"- Never rewrites semver tags or overrides immutable npm releases.",
 	"",
@@ -131,6 +137,10 @@ async function readCliPackageManifest(
 ): Promise<{ name: string; version: string }> {
 	const packagePath = resolve(repoRoot, "packages", "cli", "package.json")
 	const rawManifest = await readFile(packagePath, "utf-8")
+	return parsePackageManifest(rawManifest)
+}
+
+function parsePackageManifest(rawManifest: string): { name: string; version: string } {
 	const parsed = JSON.parse(rawManifest) as { name?: unknown; version?: unknown }
 
 	if (typeof parsed.name !== "string" || typeof parsed.version !== "string") {
@@ -216,6 +226,42 @@ async function getRemoteTagState(
 	}
 
 	return { sha: parseRemoteTagSha(tag, result.stdout), error: false }
+}
+
+function parseRemoteBranchSha(branch: string, stdout: string): string | null {
+	for (const line of stdout.split("\n")) {
+		const [sha, ref] = line.trim().split(/\s+/, 2)
+		if (sha && ref === `refs/heads/${branch}`) {
+			return sha
+		}
+	}
+
+	return null
+}
+
+async function getRemoteBranchState(
+	runGit: ReleaseTagDependencies["runGit"],
+	cwd: string,
+	branch: string,
+): Promise<TagState> {
+	const result = await runGit(["ls-remote", "--heads", "origin", `refs/heads/${branch}`], cwd)
+
+	if (result.exitCode !== 0) {
+		return { sha: null, error: true }
+	}
+
+	return { sha: parseRemoteBranchSha(branch, result.stdout), error: false }
+}
+
+function getGuardedTagPushArgs(defaultBranch: string, headSha: string, tag: string): string[] {
+	return [
+		"push",
+		"--atomic",
+		`--force-with-lease=refs/heads/${defaultBranch}:${headSha}`,
+		"origin",
+		`${headSha}:refs/heads/${defaultBranch}`,
+		`refs/tags/${tag}`,
+	]
 }
 
 function success(message: string): ReleaseTagExecutionResult {
@@ -323,6 +369,43 @@ export async function executeReleaseTag(
 		)
 	}
 
+	const remoteManifestResult = await deps.runGit(
+		["show", `refs/remotes/origin/${defaultBranch}:packages/cli/package.json`],
+		deps.cwd,
+	)
+	if (remoteManifestResult.exitCode !== 0) {
+		return failure(
+			`Could not verify packages/cli/package.json on origin/${defaultBranch}; aborting without tag changes.`,
+		)
+	}
+
+	let remoteManifest: { name: string; version: string }
+	try {
+		remoteManifest = parsePackageManifest(remoteManifestResult.stdout)
+	} catch {
+		return failure(
+			`Could not verify packages/cli/package.json on origin/${defaultBranch}; aborting without tag changes.`,
+		)
+	}
+
+	if (manifest.name !== remoteManifest.name || manifest.version !== remoteManifest.version) {
+		return failure(
+			`CLI package manifest must match origin/${defaultBranch} ` +
+				`(origin: ${remoteManifest.name}@${remoteManifest.version}, ` +
+				`working tree: ${manifest.name}@${manifest.version}); aborting without tag changes.`,
+		)
+	}
+
+	const statusResult = await deps.runGit(["status", "--porcelain=v1"], deps.cwd)
+	if (statusResult.exitCode !== 0) {
+		return failure("Could not inspect working tree status; aborting without tag changes.")
+	}
+	if (statusResult.stdout) {
+		return failure(
+			"Working tree must be clean to create a release tag; aborting without tag changes.",
+		)
+	}
+
 	const npmState = await ensureMissingNpmVersion(
 		deps.lookupNpmVersionState,
 		manifest.name,
@@ -355,6 +438,18 @@ export async function executeReleaseTag(
 
 	if (remoteTagState.sha) {
 		return failure(getRemoteTagExistsMessage(releaseTag, options.force))
+	}
+
+	const liveDefaultBranchState = await getRemoteBranchState(deps.runGit, deps.cwd, defaultBranch)
+	if (liveDefaultBranchState.error || !liveDefaultBranchState.sha) {
+		return failure(
+			`Could not verify current origin/${defaultBranch}; aborting without tag changes.`,
+		)
+	}
+	if (liveDefaultBranchState.sha !== headSha) {
+		return failure(
+			`origin/${defaultBranch} changed during release validation; aborting without tag changes.`,
+		)
 	}
 
 	if (localTagState.sha) {
@@ -390,12 +485,13 @@ export async function executeReleaseTag(
 		}
 
 		const pushExistingTagResult = await deps.runGit(
-			["push", "origin", `refs/tags/${releaseTag}`],
+			getGuardedTagPushArgs(defaultBranch, headSha, releaseTag),
 			deps.cwd,
 		)
 		if (pushExistingTagResult.exitCode !== 0) {
 			return failure(
-				`Failed to push existing local release tag ${releaseTag}; aborting without tag changes.`,
+				`Guarded push failed for existing local release tag ${releaseTag}; ` +
+					`inspect origin/${defaultBranch} before retrying.`,
 			)
 		}
 
@@ -409,10 +505,18 @@ export async function executeReleaseTag(
 		)
 	}
 
-	const pushTagResult = await deps.runGit(["push", "origin", `refs/tags/${releaseTag}`], deps.cwd)
+	// If push advertisement sees the branch move from headSha, its exact lease
+	// rejects that refspec and --atomic rejects the tag with it. Git may elide
+	// the no-op branch refspec when it is still current, so the live ls-remote
+	// check immediately above remains the primary revalidation.
+	const pushTagResult = await deps.runGit(
+		getGuardedTagPushArgs(defaultBranch, headSha, releaseTag),
+		deps.cwd,
+	)
 	if (pushTagResult.exitCode !== 0) {
 		return failure(
-			`Created local tag ${releaseTag} but failed to push to origin; rerun with --force after fixing the push problem.`,
+			`Created local tag ${releaseTag} but the guarded push failed; ` +
+				`inspect origin/${defaultBranch} and rerun with --force only if the local tag is still correct.`,
 		)
 	}
 

--- a/packages/cli/tests/github-actions-security.test.ts
+++ b/packages/cli/tests/github-actions-security.test.ts
@@ -20,6 +20,15 @@ const prPreviewWorkflowPath = join(
 	"workflows",
 	"pr-preview-cli.yml",
 )
+const releaseWorkflowPath = join(
+	import.meta.dir,
+	"..",
+	"..",
+	"..",
+	".github",
+	"workflows",
+	"release.yml",
+)
 
 describe("GitHub Actions security", () => {
 	it("pins the facade sync action when passing FACADE_SYNC_PAT", () => {
@@ -47,5 +56,23 @@ describe("GitHub Actions security", () => {
 		expect(workflow).toContain(
 			"npx --no-install pkg-pr-new publish --bin --packageManager=npm,pnpm,bun ./packages/cli",
 		)
+	})
+
+	it("fails closed when a release tag is not aligned with remote main", () => {
+		const workflow = readFileSync(releaseWorkflowPath, "utf8")
+		const revalidationIndex = workflow.indexOf("- name: Revalidate release source")
+		const releaseIndex = workflow.indexOf("- name: Release\n", revalidationIndex)
+		const publishIndex = workflow.indexOf("- name: Publish ocx to npm", revalidationIndex)
+
+		expect(workflow).toContain("- name: Validate release tag version")
+		expect(workflow).toContain('"$GITHUB_REF_NAME" != "v$' + '{package_version}"')
+		expect(workflow).toContain('"$lock_version" != "$package_version"')
+		expect(workflow).toContain(
+			'git merge-base --is-ancestor "$GITHUB_SHA" "refs/remotes/origin/$' + '{DEFAULT_BRANCH}"',
+		)
+		expect(workflow).toContain('"$remote_version" != "$package_version"')
+		expect(revalidationIndex).toBeGreaterThan(-1)
+		expect(releaseIndex).toBeGreaterThan(revalidationIndex)
+		expect(publishIndex).toBeGreaterThan(revalidationIndex)
 	})
 })

--- a/packages/cli/tests/release-tag.test.ts
+++ b/packages/cli/tests/release-tag.test.ts
@@ -171,6 +171,21 @@ async function createCommit(repo: TestRepo, fileName: string, contents: string):
 	return gitOrThrow(repo.workDir, ["rev-parse", "HEAD"])
 }
 
+async function advanceRemoteMainWithoutMovingHead(repo: TestRepo): Promise<string> {
+	const parentSha = await getHeadSha(repo)
+	const treeSha = await gitOrThrow(repo.workDir, ["rev-parse", "HEAD^{tree}"])
+	const commitSha = await gitOrThrow(repo.workDir, [
+		"commit-tree",
+		treeSha,
+		"-p",
+		parentSha,
+		"-m",
+		"chore: advance remote main",
+	])
+	await gitOrThrow(repo.workDir, ["push", "origin", `${commitSha}:refs/heads/main`])
+	return commitSha
+}
+
 async function installRejectTagHook(repo: TestRepo, tag: string): Promise<string> {
 	const hookPath = join(repo.remoteDir, "hooks", "pre-receive")
 	await writeFile(
@@ -195,6 +210,46 @@ function missingLookup(): Promise<ExactNpmVersionState> {
 	return Promise.resolve({ state: "missing" })
 }
 
+const failClosedGitScenarios: Array<{
+	name: string
+	intercept: (args: string[]) => boolean
+	result: GitResult
+	expectedMessage: string
+}> = [
+	{
+		name: "the remote manifest cannot be read",
+		intercept: (args) => args[0] === "show",
+		result: { exitCode: 1, stdout: "", stderr: "show failed" },
+		expectedMessage:
+			"Could not verify packages/cli/package.json on origin/main; aborting without tag changes.",
+	},
+	{
+		name: "the remote manifest is malformed",
+		intercept: (args) => args[0] === "show",
+		result: { exitCode: 0, stdout: "{not-json", stderr: "" },
+		expectedMessage:
+			"Could not verify packages/cli/package.json on origin/main; aborting without tag changes.",
+	},
+	{
+		name: "working-tree status cannot be inspected",
+		intercept: (args) => args[0] === "status",
+		result: { exitCode: 1, stdout: "", stderr: "status failed" },
+		expectedMessage: "Could not inspect working tree status; aborting without tag changes.",
+	},
+	{
+		name: "the live default-branch lookup fails",
+		intercept: (args) => args[0] === "ls-remote" && args[1] === "--heads",
+		result: { exitCode: 1, stdout: "", stderr: "ls-remote failed" },
+		expectedMessage: "Could not verify current origin/main; aborting without tag changes.",
+	},
+	{
+		name: "the live default branch is missing",
+		intercept: (args) => args[0] === "ls-remote" && args[1] === "--heads",
+		result: { exitCode: 0, stdout: "", stderr: "" },
+		expectedMessage: "Could not verify current origin/main; aborting without tag changes.",
+	},
+]
+
 describe("release-tag helper", () => {
 	it("creates and pushes a fresh tag when npm is missing and no tags exist", async () => {
 		const repo = await setupRepo("1.2.3")
@@ -216,6 +271,83 @@ describe("release-tag helper", () => {
 		expect(await getRemoteTagSha(repo, tag)).toBe(headSha)
 	})
 
+	it("refuses when the working-tree manifest is newer than origin/<defaultBranch>", async () => {
+		const repo = await setupRepo("1.2.3")
+		const tag = "v1.2.4"
+		const packageJsonPath = join(repo.workDir, "packages", "cli", "package.json")
+
+		await writeFile(
+			packageJsonPath,
+			JSON.stringify(
+				{
+					name: "ocx",
+					version: "1.2.4",
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = await executeReleaseTag(
+			{ force: false },
+			{
+				cwd: repo.workDir,
+				lookupNpmVersionState: missingLookup,
+			},
+		)
+
+		expect(result.exitCode).toBe(1)
+		expect(result.message).toBe(
+			"CLI package manifest must match origin/main (origin: ocx@1.2.3, working tree: ocx@1.2.4); aborting without tag changes.",
+		)
+		expect(await getLocalTagSha(repo, tag)).toBeNull()
+		expect(await getRemoteTagSha(repo, tag)).toBeNull()
+	})
+
+	it("refuses when the working tree has unrelated changes", async () => {
+		const repo = await setupRepo("1.2.3")
+		const tag = "v1.2.3"
+
+		await writeFile(join(repo.workDir, "untracked.txt"), "not committed")
+
+		const result = await executeReleaseTag(
+			{ force: false },
+			{
+				cwd: repo.workDir,
+				lookupNpmVersionState: missingLookup,
+			},
+		)
+
+		expect(result.exitCode).toBe(1)
+		expect(result.message).toBe(
+			"Working tree must be clean to create a release tag; aborting without tag changes.",
+		)
+		expect(await getLocalTagSha(repo, tag)).toBeNull()
+		expect(await getRemoteTagSha(repo, tag)).toBeNull()
+	})
+
+	for (const scenario of failClosedGitScenarios) {
+		it(`fails closed when ${scenario.name}`, async () => {
+			const repo = await setupRepo("1.2.3")
+			const tag = "v1.2.3"
+
+			const result = await executeReleaseTag(
+				{ force: false },
+				{
+					cwd: repo.workDir,
+					lookupNpmVersionState: missingLookup,
+					runGit: (args, cwd) =>
+						scenario.intercept(args) ? Promise.resolve(scenario.result) : git(cwd, args),
+				},
+			)
+
+			expect(result.exitCode).toBe(1)
+			expect(result.message).toBe(scenario.expectedMessage)
+			expect(await getLocalTagSha(repo, tag)).toBeNull()
+			expect(await getRemoteTagSha(repo, tag)).toBeNull()
+		})
+	}
+
 	it("keeps local tag after push failure and reports deterministic recovery message", async () => {
 		const repo = await setupRepo("1.2.3")
 		const tag = "v1.2.3"
@@ -232,11 +364,68 @@ describe("release-tag helper", () => {
 
 		expect(result.exitCode).toBe(1)
 		expect(result.message).toBe(
-			"Created local tag v1.2.3 but failed to push to origin; rerun with --force after fixing the push problem.",
+			"Created local tag v1.2.3 but the guarded push failed; inspect origin/main and rerun with --force only if the local tag is still correct.",
 		)
 
 		const headSha = await getHeadSha(repo)
 		expect(await getLocalTagSha(repo, tag)).toBe(headSha)
+		expect(await getRemoteTagSha(repo, tag)).toBeNull()
+	})
+
+	it("refuses when origin/<defaultBranch> advances during npm validation", async () => {
+		const repo = await setupRepo("1.2.3")
+		const tag = "v1.2.3"
+		const originalHead = await getHeadSha(repo)
+		let advancedSha: string | null = null
+
+		const result = await executeReleaseTag(
+			{ force: false },
+			{
+				cwd: repo.workDir,
+				lookupNpmVersionState: async () => {
+					advancedSha = await advanceRemoteMainWithoutMovingHead(repo)
+					return { state: "missing" }
+				},
+			},
+		)
+
+		expect(result.exitCode).toBe(1)
+		expect(result.message).toBe(
+			"origin/main changed during release validation; aborting without tag changes.",
+		)
+		expect(advancedSha).not.toBe(originalHead)
+		expect(await getHeadSha(repo)).toBe(originalHead)
+		expect(await getLocalTagSha(repo, tag)).toBeNull()
+		expect(await getRemoteTagSha(repo, tag)).toBeNull()
+	})
+
+	it("refuses the remote tag when origin/<defaultBranch> moves before the guarded push", async () => {
+		const repo = await setupRepo("1.2.3")
+		const tag = "v1.2.3"
+		const originalHead = await getHeadSha(repo)
+		let advancedSha: string | null = null
+
+		const result = await executeReleaseTag(
+			{ force: false },
+			{
+				cwd: repo.workDir,
+				lookupNpmVersionState: missingLookup,
+				runGit: async (args, cwd) => {
+					if (!advancedSha && args[0] === "push" && args.includes("--atomic")) {
+						advancedSha = await advanceRemoteMainWithoutMovingHead(repo)
+					}
+					return git(cwd, args)
+				},
+			},
+		)
+
+		expect(result.exitCode).toBe(1)
+		expect(result.message).toBe(
+			"Created local tag v1.2.3 but the guarded push failed; inspect origin/main and rerun with --force only if the local tag is still correct.",
+		)
+		expect(advancedSha).not.toBe(originalHead)
+		expect(await getHeadSha(repo)).toBe(originalHead)
+		expect(await getLocalTagSha(repo, tag)).toBe(originalHead)
 		expect(await getRemoteTagSha(repo, tag)).toBeNull()
 	})
 


### PR DESCRIPTION
## Summary

- Bump the publishable `ocx` CLI package and workspace lockfile from 2.0.11 to 2.0.12.
- Make `release:tag` require a clean worktree whose CLI manifest matches freshly fetched remote `main`, then revalidate live `main` immediately before a guarded tag push.
- Add fail-closed release-workflow gates for tag/package/lock alignment, tag ancestry on remote `main`, and the package version currently recorded on remote `main` before GitHub Release creation or npm publication.
- Add regressions for uncommitted version bumps, unrelated dirty files, Git command ambiguity, and remote-main movement during release validation/push.

## Testing

- `bun install --frozen-lockfile`
- `bun run check`
- `bun run test` — 1,400 passed, 7 skipped, 0 failed
- `bun run build` — CLI and registries built; CLI reports `2.0.12`
- Focused release/workflow suite — 89 passed, 0 failed
- Isolated manual release-helper testing against a temporary bare remote:
  - clean synchronized source created the expected temporary tag
  - uncommitted manifest mismatch was rejected with no tag
  - unrelated dirty worktree was rejected with no tag
  - remote `main` movement immediately before push rejected the remote tag and did not alter `main`

## Release safety

Do not create `v2.0.12` until this PR is merged and the exact merged `main` commit is green. After merge, verify remote `main` contains 2.0.12 in both `packages/cli/package.json` and `bun.lock`, confirm npm `ocx@2.0.12` and remote tag `v2.0.12` are absent, then run the built-in `bun run release:tag` helper from a clean synchronized `main` checkout.

## Risk

Low runtime risk: CLI behavior is unchanged. The release path adds fail-closed gates; its operational failure mode is refusing an unsafe release rather than publishing from the wrong source state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fail-closed release safeguards for the 2.0.12 cut and bumps the publishable `ocx` CLI to 2.0.12. Prevents mis-tagging or publishing from the wrong commit.

- **Bug Fixes**
  - Release workflow adds strict checks before creating a GitHub Release or publishing: tag equals `packages/cli/package.json` version, `bun.lock` matches, tag commit is on the remote default branch, and the remote default branch records the same package version.
  - `release:tag` now requires a clean worktree and a manifest that matches the freshly fetched remote default branch; it revalidates the live branch and uses a guarded push (`--atomic` + `--force-with-lease`) to refuse if the branch moves.
  - Expanded tests cover dirty worktrees, manifest mismatches, remote-main movement during validation/push, and failure paths for Git command issues.

- **Dependencies**
  - Bump `ocx` to 2.0.12 and update the workspace lockfile.

<sup>Written for commit 634e143b118e3a1cae701a006c9e54ae1f58ab6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

