### PR TITLE
fix(schemas): Support plugin option tuples

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -375,7 +375,10 @@ async function handleNpmPlugins(
 		// Build a map of existing plugin names (without version) for conflict detection
 		const existingPluginMap = new Map<string, OpencodePluginSpec>()
 		for (const plugin of existingPlugins) {
-			const name = extractPackageName(getPluginSpecifier(plugin))
+			const specifier = getPluginSpecifier(plugin)
+			const name = isNpmSpecifier(specifier)
+				? parseNpmSpecifier(specifier).name
+				: extractPackageName(specifier)
 			existingPluginMap.set(name, plugin)
 		}
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,6 +15,7 @@ import { ConfigResolver } from "../config/resolver"
 import { CLI_VERSION, GITHUB_REPO } from "../constants"
 import { getProfileDir } from "../profile/paths"
 import { fetchFileContent, fetchRegistryIndex } from "../registry/fetcher"
+import { getPluginSpecifier } from "../registry/merge"
 import type { ResolvedComponent } from "../registry/resolver"
 import { resolveDependencies } from "../registry/resolver"
 import {
@@ -24,7 +25,7 @@ import {
 	readReceipt,
 	writeReceipt,
 } from "../schemas/config"
-import type { ComponentFileObject, RegistryIndex } from "../schemas/registry"
+import type { ComponentFileObject, OpencodePluginSpec, RegistryIndex } from "../schemas/registry"
 import { parseQualifiedComponent } from "../schemas/registry"
 import {
 	findOpencodeConfig,
@@ -369,12 +370,12 @@ async function handleNpmPlugins(
 
 		// Read existing opencode config
 		const existingConfig = await readOpencodeJsonConfig(cwd)
-		const existingPlugins: string[] = existingConfig?.config.plugin ?? []
+		const existingPlugins: OpencodePluginSpec[] = existingConfig?.config.plugin ?? []
 
 		// Build a map of existing plugin names (without version) for conflict detection
-		const existingPluginMap = new Map<string, string>()
+		const existingPluginMap = new Map<string, OpencodePluginSpec>()
 		for (const plugin of existingPlugins) {
-			const name = extractPackageName(plugin)
+			const name = extractPackageName(getPluginSpecifier(plugin))
 			existingPluginMap.set(name, plugin)
 		}
 

--- a/packages/cli/src/commands/opencode.ts
+++ b/packages/cli/src/commands/opencode.ts
@@ -18,6 +18,7 @@ import {
 	OPENCODE_CONFIG_FILE,
 } from "../profile/paths"
 import { dedupePluginsByCanonicalName, extractCanonicalPluginName } from "../registry/merge"
+import { type OpencodePluginSpec, opencodePluginSpecSchema } from "../schemas/registry"
 import { ConfigError } from "../utils/errors"
 import { getGitInfo } from "../utils/git-context"
 import { handleError } from "../utils/handle-error"
@@ -133,8 +134,8 @@ function mergeInstructionArrayOrigins(
 }
 
 function mergePluginArrayOrigins(
-	profileValues: string[],
-	localValues: string[],
+	profileValues: OpencodePluginSpec[],
+	localValues: OpencodePluginSpec[],
 	pathSegments: OpencodePathSegment[],
 	origins: Map<string, OpencodeLeafOrigin>,
 ): void {
@@ -154,11 +155,13 @@ function mergePluginArrayOrigins(
 		}
 	}
 
-	for (const [index, pluginSpecifier] of mergedValues.entries()) {
-		const canonicalName = extractCanonicalPluginName(pluginSpecifier)
-		origins.set(
-			pathSegmentsToKey([...pathSegments, index]),
+	for (const [index, plugin] of mergedValues.entries()) {
+		const canonicalName = extractCanonicalPluginName(plugin)
+		collectLeafOriginsForValue(
+			plugin,
 			lastOwnerByCanonical.get(canonicalName) ?? "local",
+			[...pathSegments, index],
+			origins,
 		)
 	}
 }
@@ -214,8 +217,12 @@ function mergeLeafOriginsAtPath(args: {
 
 		if (isTopLevelOpencodeArrayPath(pathSegments, "plugin")) {
 			if (
-				profileValue.every((value) => typeof value === "string") &&
-				localValue.every((value) => typeof value === "string")
+				profileValue.every(
+					(value): value is OpencodePluginSpec => opencodePluginSpecSchema.safeParse(value).success,
+				) &&
+				localValue.every(
+					(value): value is OpencodePluginSpec => opencodePluginSpecSchema.safeParse(value).success,
+				)
 			) {
 				mergePluginArrayOrigins(profileValue, localValue, pathSegments, origins)
 				return

--- a/packages/cli/src/registry/merge.ts
+++ b/packages/cli/src/registry/merge.ts
@@ -11,7 +11,14 @@
  */
 
 import { mergeDeep } from "remeda"
-import type { NormalizedOpencodeConfig } from "../schemas/registry"
+import type { NormalizedOpencodeConfig, OpencodePluginSpec } from "../schemas/registry"
+
+/**
+ * Return the string specifier from either supported OpenCode plugin entry form.
+ */
+export function getPluginSpecifier(plugin: OpencodePluginSpec): string {
+	return typeof plugin === "string" ? plugin : plugin[0]
+}
 
 /**
  * Extract canonical plugin name by stripping version suffix.
@@ -26,7 +33,9 @@ import type { NormalizedOpencodeConfig } from "../schemas/registry"
  * The version delimiter is the LAST "@" that is not at position 0
  * and not immediately after "npm:" (scoped package prefix).
  */
-export function extractCanonicalPluginName(specifier: string): string {
+export function extractCanonicalPluginName(plugin: OpencodePluginSpec): string {
+	const specifier = getPluginSpecifier(plugin)
+
 	// Strip npm: prefix for parsing, re-add later
 	const hasNpmPrefix = specifier.startsWith("npm:")
 	const remainder = hasNpmPrefix ? specifier.slice(4) : specifier
@@ -62,11 +71,11 @@ export function extractCanonicalPluginName(specifier: string): string {
  * the later entry wins (higher-priority source overwrites lower-priority target).
  * This matches OpenCode's mergeConfigWithPlugins semantics.
  */
-export function dedupePluginsByCanonicalName(plugins: string[]): string[] {
+export function dedupePluginsByCanonicalName(plugins: OpencodePluginSpec[]): OpencodePluginSpec[] {
 	// Walk backwards: first seen (from end) wins
 	const seen = new Map<string, number>()
 	for (let i = plugins.length - 1; i >= 0; i--) {
-		const plugin = plugins[i] as string
+		const plugin = plugins[i] as OpencodePluginSpec
 		const canonical = extractCanonicalPluginName(plugin)
 		if (!seen.has(canonical)) {
 			seen.set(canonical, i)
@@ -74,7 +83,7 @@ export function dedupePluginsByCanonicalName(plugins: string[]): string[] {
 	}
 
 	// Collect in original order, keeping only the last occurrence per canonical name
-	const result: string[] = []
+	const result: OpencodePluginSpec[] = []
 	for (const [i, plugin] of plugins.entries()) {
 		const canonical = extractCanonicalPluginName(plugin)
 		if (seen.get(canonical) === i) {

--- a/packages/cli/src/schemas/index.ts
+++ b/packages/cli/src/schemas/index.ts
@@ -64,9 +64,11 @@ export {
 	normalizeFile,
 	normalizeMcpServer,
 	type OpencodeConfig,
+	type OpencodePluginSpec,
 	// Name schemas
 	openCodeNameSchema,
 	opencodeConfigSchema,
+	opencodePluginSpecSchema,
 	type Packument,
 	type PermissionConfig,
 	packumentSchema,

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -7,7 +7,18 @@
 
 import { isAbsolute, normalize } from "node:path"
 import type { infer as ZodInfer } from "zod"
-import { any, array, boolean, number, object, record, string, union, enum as zEnum } from "zod"
+import {
+	any,
+	array,
+	boolean,
+	number,
+	object,
+	record,
+	string,
+	tuple,
+	union,
+	enum as zEnum,
+} from "zod"
 import {
 	OCX_DOMAIN,
 	REGISTRY_SCHEMA_LATEST_MAJOR,
@@ -535,6 +546,19 @@ const OPENCODE_CONFIG_FIELDS: ReadonlySet<string> = new Set(
 )
 
 /**
+ * OpenCode plugin entry.
+ *
+ * OpenCode accepts either a plugin specifier or a tuple containing the
+ * specifier and an options object.
+ */
+export const opencodePluginSpecSchema = union([
+	string(),
+	tuple([string(), record(string(), any())]),
+])
+
+export type OpencodePluginSpec = ZodInfer<typeof opencodePluginSpecSchema>
+
+/**
  * OpenCode configuration block.
  *
  * ocx does NOT re-validate opencode's entire config — opencode does that at runtime
@@ -571,8 +595,8 @@ export const opencodeConfigSchema = object({
 	/** MCP servers (matches opencode.json 'mcp' field) */
 	mcp: record(string(), mcpServerRefSchema).optional(),
 
-	/** NPM plugin packages to add to opencode.json 'plugin' array */
-	plugin: array(string()).optional(),
+	/** Plugin specifiers, optionally paired with plugin-specific options */
+	plugin: array(opencodePluginSpecSchema).optional(),
 
 	/** Tool enable/disable patterns */
 	tools: record(string(), boolean()).optional(),

--- a/packages/cli/src/updaters/update-opencode-config.ts
+++ b/packages/cli/src/updaters/update-opencode-config.ts
@@ -15,7 +15,7 @@ import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { applyEdits, type ModificationOptions, modify, parse as parseJsonc } from "jsonc-parser"
 import { resolveOpencodePathScope } from "../profile/paths"
-import type { OpencodeConfig } from "../schemas/registry"
+import type { OpencodeConfig, OpencodePluginSpec } from "../schemas/registry"
 import { isPlainObject } from "../utils/type-guards"
 
 const LOCAL_CONFIG_DIR = ".opencode"
@@ -41,7 +41,7 @@ export interface OpencodeJsonConfig {
 	mcp?: Record<string, unknown>
 	tools?: Record<string, boolean>
 	agent?: Record<string, unknown>
-	plugin?: string[]
+	plugin?: OpencodePluginSpec[]
 	instructions?: string[]
 	permission?: unknown
 	[key: string]: unknown

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -888,6 +888,52 @@ describe("ocx add --json mixed-input contract", () => {
 		expect(payload.installed).toEqual(["kdco/test-plugin"])
 	})
 
+	it("preserves configured plugin tuples and detects npm conflicts by their specifier", async () => {
+		testDir = await createTempDir("add-npm-plugin-tuple")
+		const configDir = join(testDir, ".opencode")
+		await mkdir(configDir, { recursive: true })
+		const configuredTuple = ["configured-plugin@1.0.0", { nested: { enabled: true } }] as const
+		await writeFile(
+			join(configDir, "opencode.jsonc"),
+			JSON.stringify({ plugin: [configuredTuple] }),
+		)
+
+		spyOn(global, "fetch").mockImplementation(
+			mock(async (input: string | URL | Request, init?: RequestInit) => {
+				const url = getRequestUrl(input)
+				const packageName = url.split("/").at(-1)
+				if (packageName === "new-plugin" || packageName === "configured-plugin") {
+					return new Response(
+						JSON.stringify({
+							name: packageName,
+							"dist-tags": { latest: "1.0.0" },
+							versions: {},
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					)
+				}
+
+				return originalFetch(input as RequestInfo | URL, init)
+			}) as unknown as typeof fetch,
+		)
+
+		const { runAddCore } = await importAddCommandModule()
+		const provider = {
+			cwd: testDir,
+			getRegistries: () => ({}),
+			getComponentPath: () => ".opencode/components",
+		}
+
+		await runAddCore(["npm:new-plugin"], { quiet: true, trust: true }, provider)
+
+		const config = parseJsonc(await readFile(join(configDir, "opencode.jsonc"), "utf-8"))
+		expect(config.plugin).toEqual([configuredTuple, "new-plugin"])
+
+		await expect(
+			runAddCore(["npm:configured-plugin"], { quiet: true, trust: true }, provider),
+		).rejects.toThrow("Plugin(s) already exist")
+	})
+
 	it("emits strict single-channel JSON on mixed-mode conflict failure without stderr contamination", async () => {
 		testDir = await createTempDir("add-json-mixed-failure")
 

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -892,7 +892,7 @@ describe("ocx add --json mixed-input contract", () => {
 		testDir = await createTempDir("add-npm-plugin-tuple")
 		const configDir = join(testDir, ".opencode")
 		await mkdir(configDir, { recursive: true })
-		const configuredTuple = ["configured-plugin@1.0.0", { nested: { enabled: true } }] as const
+		const configuredTuple = ["npm:configured-plugin@1.0.0", { nested: { enabled: true } }] as const
 		await writeFile(
 			join(configDir, "opencode.jsonc"),
 			JSON.stringify({ plugin: [configuredTuple] }),

--- a/packages/cli/tests/merge.test.ts
+++ b/packages/cli/tests/merge.test.ts
@@ -70,6 +70,12 @@ describe("extractCanonicalPluginName", () => {
 	it("handles npm: with empty remainder", () => {
 		expect(extractCanonicalPluginName("npm:")).toBe("npm:")
 	})
+
+	it("extracts the canonical name from a plugin option tuple", () => {
+		expect(extractCanonicalPluginName(["npm:@scope/pkg@2.0.0", { mode: "strict" }])).toBe(
+			"npm:@scope/pkg",
+		)
+	})
 })
 
 // =============================================================================
@@ -115,6 +121,16 @@ describe("dedupePluginsByCanonicalName", () => {
 		const combined = ["npm:@franlol/formatter@0.0.2", "npm:@franlol/formatter@0.0.3"]
 		const result = dedupePluginsByCanonicalName(combined)
 		expect(result).toEqual(["npm:@franlol/formatter@0.0.3"])
+	})
+
+	it("deduplicates strings and tuples while retaining the winning options", () => {
+		const result = dedupePluginsByCanonicalName([
+			["npm:pkg@1.0.0", { source: "profile" }],
+			"npm:other",
+			["npm:pkg@2.0.0", { source: "local" }],
+		])
+
+		expect(result).toEqual(["npm:other", ["npm:pkg@2.0.0", { source: "local" }]])
 	})
 })
 
@@ -236,6 +252,26 @@ describe("mergeOpencodeConfig", () => {
 			const result = mergeOpencodeConfig(target, source)
 
 			expect(result.plugin).toEqual(["npm:chalk@5.0.0"])
+		})
+
+		it("merges plugin option tuples by canonical specifier without dropping options", () => {
+			const target: NormalizedOpencodeConfig = {
+				plugin: [
+					["npm:formatter@1.0.0", { source: "profile" }],
+					["npm:keep", { setting: true }],
+				],
+			}
+			const source: NormalizedOpencodeConfig = {
+				plugin: [["npm:formatter@2.0.0", { source: "local" }], "npm:new"],
+			}
+
+			const result = mergeOpencodeConfig(target, source)
+
+			expect(result.plugin).toEqual([
+				["npm:keep", { setting: true }],
+				["npm:formatter@2.0.0", { source: "local" }],
+				"npm:new",
+			])
 		})
 
 		it("preserves plugins when later component has none", () => {

--- a/packages/cli/tests/opencode.test.ts
+++ b/packages/cli/tests/opencode.test.ts
@@ -1279,8 +1279,8 @@ describe("oc command CLI contract", () => {
 				join(profileDir, "opencode.jsonc"),
 				JSON.stringify({
 					plugin: [
-						"npm:@scope/tool@1.0.0",
-						"{file:./prompts/profile-plugin-token.md}",
+						["npm:@scope/tool@1.0.0", { source: "profile" }],
+						["{file:./prompts/profile-plugin-token.md}", { source: "profile" }],
 						"npm:keep-profile",
 					],
 				}),
@@ -1291,7 +1291,10 @@ describe("oc command CLI contract", () => {
 			await Bun.write(
 				join(localConfigDir, "opencode.jsonc"),
 				JSON.stringify({
-					plugin: ["npm:@scope/tool@2.0.0", "{file:./prompts/local-plugin-token.md}"],
+					plugin: [
+						["npm:@scope/tool@2.0.0", { source: "local" }],
+						["{file:./prompts/local-plugin-token.md}", { source: "local" }],
+					],
 				}),
 			)
 
@@ -1308,13 +1311,13 @@ describe("oc command CLI contract", () => {
 				configContent: string | null
 			}
 			const parsedConfig = JSON.parse(payload.configContent as string) as {
-				plugin?: string[]
+				plugin?: Array<string | [string, Record<string, unknown>]>
 			}
 			expect(parsedConfig.plugin).toEqual([
-				`{file:${join(profileDir, "prompts", "profile-plugin-token.md")}}`,
+				[`{file:${join(profileDir, "prompts", "profile-plugin-token.md")}}`, { source: "profile" }],
 				"npm:keep-profile",
-				"npm:@scope/tool@2.0.0",
-				"{file:./prompts/local-plugin-token.md}",
+				["npm:@scope/tool@2.0.0", { source: "local" }],
+				["{file:./prompts/local-plugin-token.md}", { source: "local" }],
 			])
 		} finally {
 			await cleanupTempDir(testDir)

--- a/packages/cli/tests/schemas.test.ts
+++ b/packages/cli/tests/schemas.test.ts
@@ -649,6 +649,47 @@ describe("schemas", () => {
 			expect(result.success).toBe(true)
 		})
 
+		it("accepts and retains plugin option tuples", () => {
+			const plugin = [
+				"./plugins/demo/index.ts",
+				{ someConfig: { use: { data: true } }, retries: 2 },
+			]
+			const result = opencodeConfigSchema.safeParse({
+				plugin: ["plain-plugin", plugin],
+			})
+
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.data.plugin).toEqual(["plain-plugin", plugin])
+			}
+		})
+
+		it("rejects malformed plugin option tuples", () => {
+			expect(opencodeConfigSchema.safeParse({ plugin: [["plugin-only"]] }).success).toBe(false)
+			expect(
+				opencodeConfigSchema.safeParse({ plugin: [["plugin", { enabled: true }, "extra"]] })
+					.success,
+			).toBe(false)
+			expect(opencodeConfigSchema.safeParse({ plugin: [["plugin", true]] }).success).toBe(false)
+		})
+
+		it("retains plugin option tuples through the component manifest boundary", () => {
+			const plugin = ["./plugins/demo/index.ts", { enabled: true }]
+			const result = componentManifestSchema.safeParse({
+				name: "x",
+				type: "plugin",
+				description: "d",
+				files: [],
+				dependencies: [],
+				opencode: { plugin: [plugin] },
+			})
+
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.data.opencode?.plugin).toEqual([plugin])
+			}
+		})
+
 		it("rejects a top-level key that is not in opencode's field set", () => {
 			const result = opencodeConfigSchema.safeParse({ bogus_key: 1 })
 			expect(result.success).toBe(false)

--- a/packages/cli/tests/updaters.test.ts
+++ b/packages/cli/tests/updaters.test.ts
@@ -273,12 +273,12 @@ describe("updateOpencodeJsonConfig", () => {
 
 	it("should add plugins", async () => {
 		await updateOpencodeJsonConfig(testDir, {
-			plugin: ["@some/plugin@1.0.0", "@another/plugin"],
+			plugin: ["@some/plugin@1.0.0", ["@another/plugin", { nested: { enabled: true } }]],
 		})
 
 		const config = parseJsonc(await readFile(join(testDir, ".opencode", "opencode.jsonc"), "utf-8"))
 		expect(config.plugin).toContain("@some/plugin@1.0.0")
-		expect(config.plugin).toContain("@another/plugin")
+		expect(config.plugin).toContainEqual(["@another/plugin", { nested: { enabled: true } }])
 	})
 
 	it("should add instructions", async () => {


### PR DESCRIPTION
## Summary

- accept OpenCode plugin entries in both string and `[specifier, options]` tuple forms
- preserve tuple options through canonical deduplication, profile/local merging, JSONC updates, and `ocx add`
- track tuple leaf ownership so profile-relative `{file:...}` tokens are rewritten correctly without rewriting local winners

## Red-green verification

Before the change, the reported input reproduced the issue exactly:

```text
components.0.opencode.plugin.0: Invalid input: expected string, received array
```

After the change, the same nested options tuple validates and is retained unchanged.

## Testing

- `bun run check`
- `bun run test` — 1,407 passed, 7 skipped, 0 failed
- `bun run build`
- focused schema, merge, updater, profile-launch, and npm-add regressions — 250 passed

Fixes #246

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for plugin option tuples in OpenCode config so plugins can be strings or [specifier, options]. Fixes validation and preserves options across merge/dedupe, `ocx add`, and JSONC updates, with normalized npm specifiers for accurate conflict detection.

- **Bug Fixes**
  - Accept tuple entries in `opencodeConfigSchema` via `opencodePluginSpecSchema`/`OpencodePluginSpec`.
  - Deduplicate by canonical plugin name for strings and tuples, keeping the winner’s options.
  - Track tuple-level ownership so profile `{file:...}` tokens are rewritten correctly without changing local winners.
  - Update `ocx add` to normalize npm specifiers (handle `npm:` prefix, versions, and tuples) when detecting conflicts, keeping existing tuple entries.

<sup>Written for commit 21c3140eb422a1134e8ee0f7fda7af45055d19c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

