### PR TITLE
chore(release): Prepare v2.0.13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "packages/cli": {
       "name": "ocx",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "bin": {
         "ocx": "./dist/index.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ocx",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"description": "OCX CLI - OpenCode extension manager with portable, isolated profiles. Your setup, anywhere.",
 	"author": "kdcokenny",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- bump the publishable `ocx` package from 2.0.12 to 2.0.13
- keep the workspace lock entry aligned with the package manifest
- prepare the guarded tag workflow for the fix merged in #248

## Verification

- `bun install --frozen-lockfile`
- `bun run check`
- `bun run --cwd packages/cli build`
- built CLI reports `2.0.13`

## Release safety

The release tag will only be created after this PR is reviewed, all checks pass, and this version is present on remote `main`. The repository's `release:tag` helper will then revalidate the clean worktree, remote main manifest, npm state, and tag state before pushing `v2.0.13`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `ocx` from 2.0.12 to 2.0.13 and sync the lockfile. Also prepares the guarded release-tag workflow to pick up the fix from #248.

<sup>Written for commit 0cff3b4407c2863a877e45388fb3c0705a72d52e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

