### PR TITLE
fix(profile): Inherit source registry for dependencies

### DIFF
--- a/packages/cli/src/commands/profile/install-from-registry.ts
+++ b/packages/cli/src/commands/profile/install-from-registry.ts
@@ -52,6 +52,17 @@ export interface InstallProfileOptions {
 	quiet?: boolean
 }
 
+export function resolveProfileRegistries(
+	namespace: string,
+	registryUrl: string,
+	profileRegistries: Record<string, RegistryConfig> = {},
+): Record<string, RegistryConfig> {
+	return {
+		[namespace]: { url: registryUrl },
+		...profileRegistries,
+	}
+}
+
 function formatProfileRollbackCleanupWarning(
 	action: string,
 	targetPath: string,
@@ -513,6 +524,7 @@ export async function installProfileFromRegistry(options: InstallProfileOptions)
 				dep.includes("/") ? dep : `${namespace}/${dep}`,
 			)
 			let profileRegistries: Record<string, RegistryConfig> = {}
+			let dependencyRegistries = resolveProfileRegistries(namespace, registryUrl)
 
 			try {
 				// ========================================================================
@@ -540,12 +552,13 @@ export async function installProfileFromRegistry(options: InstallProfileOptions)
 					// If parse fails and no registries field, just use empty {} (already initialized)
 				}
 
-				// Create provider with FULL profile registries
-				// Pass all registries from the profile's ocx.jsonc to support transitive dependencies.
-				// The profile's ocx.jsonc should declare all registries needed (including transitive).
+				// Same-registry dependencies inherit the source registry automatically. Explicit
+				// profile declarations remain available for overrides and cross-registry dependencies.
+				dependencyRegistries = resolveProfileRegistries(namespace, registryUrl, profileRegistries)
+
 				const provider: ConfigProvider = {
 					cwd: profileDir,
-					getRegistries: () => profileRegistries,
+					getRegistries: () => dependencyRegistries,
 					getComponentPath: () => "", // Flat install - no .opencode/ prefix
 				}
 
@@ -560,7 +573,7 @@ export async function installProfileFromRegistry(options: InstallProfileOptions)
 						namespace,
 						component,
 						registryUrl,
-						profileRegistries,
+						profileRegistries: dependencyRegistries,
 					})
 
 					throw withRegistryDiagnostics(error, {

--- a/packages/cli/tests/profile-add-registry.test.ts
+++ b/packages/cli/tests/profile-add-registry.test.ts
@@ -3,7 +3,10 @@ import { existsSync } from "node:fs"
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { parseSourceOption } from "../src/commands/profile/add"
-import { resolveEmbeddedProfileTarget } from "../src/commands/profile/install-from-registry"
+import {
+	resolveEmbeddedProfileTarget,
+	resolveProfileRegistries,
+} from "../src/commands/profile/install-from-registry"
 import { _clearFetcherCacheForTests } from "../src/registry/fetcher"
 import { validateSafePath } from "../src/schemas/registry"
 import { ValidationError } from "../src/utils/errors"
@@ -104,6 +107,26 @@ describe("Path security", () => {
 			expect(() => validateSafePath("foo/../bar")).not.toThrow()
 			// ./foo/bar normalizes to "foo/bar" which is safe
 			expect(() => validateSafePath("./foo/bar")).not.toThrow()
+		})
+	})
+})
+
+describe("resolveProfileRegistries()", () => {
+	it("adds the source registry when the profile does not declare it", () => {
+		expect(resolveProfileRegistries("demo", "https://registry.example.com")).toEqual({
+			demo: { url: "https://registry.example.com" },
+		})
+	})
+
+	it("preserves explicit profile overrides and cross-registry declarations", () => {
+		expect(
+			resolveProfileRegistries("demo", "https://source.example.com", {
+				demo: { url: "https://override.example.com" },
+				dependency: { url: "https://dependency.example.com" },
+			}),
+		).toEqual({
+			demo: { url: "https://override.example.com" },
+			dependency: { url: "https://dependency.example.com" },
 		})
 	})
 })
@@ -1044,6 +1067,8 @@ describe("ocx profile add --source (registry installation)", () => {
 	})
 
 	afterEach(async () => {
+		registry.clearFileContent()
+		_clearFetcherCacheForTests()
 		if (originalXdgConfigHome === undefined) {
 			delete process.env.XDG_CONFIG_HOME
 		} else {
@@ -1836,7 +1861,7 @@ describe("ocx profile add --source (registry installation)", () => {
 		}
 	})
 
-	it("should install profile dependencies flat (not in .opencode/)", async () => {
+	it("inherits the configured source registry for same-registry profile dependencies", async () => {
 		// Setup global config with registry configured
 		const globalConfigDir = join(testDir, "opencode")
 		const profilesDir = join(globalConfigDir, "profiles")
@@ -1852,6 +1877,12 @@ describe("ocx profile add --source (registry installation)", () => {
 
 		const workDir = join(testDir, "workspace")
 		await mkdir(workDir, { recursive: true })
+		registry.setFileContent(
+			"test-profile-with-deps",
+			"ocx.jsonc",
+			JSON.stringify({ registries: {} }, null, 2),
+		)
+		_clearFetcherCacheForTests()
 
 		// V2: Install profile with dependencies from registry using --source
 		const { exitCode, output } = await runCLI(


### PR DESCRIPTION
## Summary

- inherit the resolved source registry when installing dependencies for a registry-provided profile
- preserve explicit profile registry declarations for overrides and cross-registry dependencies
- add integration and direct unit coverage for profiles whose `ocx.jsonc` does not redeclare the configured source alias

## Red/green verification

Before the fix, the regression case downloaded the profile and then failed during dependency resolution with exit code 66:

```text
Registry alias 'demo' not found. Add it with 'ocx registry add <url> --name demo'.
```

After the fix, the same profile and dependency install successfully, including flat file placement and receipt creation.

## Validation

- `bun test packages/cli/tests/profile-add-registry.test.ts` — 58 pass
- `bun run check` — 4 tasks pass
- `bun run test` — 1,409 pass, 7 skipped, 0 fail
- `bun run build` — 3 tasks pass
- published preview `npx https://pkg.pr.new/ocx@251` at `5dfb446` — complete issue workflow passes

## Risk

Low. The fallback is scoped to the already-resolved source alias and URL. Explicit registry entries shipped by the profile retain precedence, so existing cross-registry and override behavior is preserved and directly tested.

Fixes #250