### PR TITLE
chore(release): Prepare v2.0.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "packages/cli": {
       "name": "ocx",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "bin": {
         "ocx": "./dist/index.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ocx",
-	"version": "2.0.13",
+	"version": "2.0.14",
 	"description": "OCX CLI - OpenCode extension manager with portable, isolated profiles. Your setup, anywhere.",
 	"author": "kdcokenny",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- bump the publishable `ocx` package from 2.0.13 to 2.0.14
- keep the workspace lock entry aligned with the package manifest
- prepare the guarded tag workflow for the fix merged in #251

## Verification

- `bun install --frozen-lockfile`
- `bun run check`
- `bun run --cwd packages/cli build`
- built CLI reports `2.0.14`
- `git diff --check`

## Release safety

The release tag will only be created after this PR is reviewed, all checks pass, and this version is present on remote `main`. The repository's `release:tag` helper will then revalidate the clean worktree, remote main manifest, npm state, and tag state before pushing `v2.0.14`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `ocx` CLI from 2.0.13 to 2.0.14 and syncs the lockfile with the manifest. Prepares the guarded release-tag workflow so v2.0.14 is only created after checks pass on remote main and the #251 fix is included.

<sup>Written for commit 0b61f065c0cd94e03a1b09440c67d4d371ea6e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

