### PR TITLE
feat: Adds support for TUI plugins

### DIFF
--- a/docs/cli/add.mdx
+++ b/docs/cli/add.mdx
@@ -13,6 +13,11 @@ ocx add <components...> [options]
 
 Add components or npm plugins to your project. Components are copied into `.opencode/` (not `node_modules`) — you own the code and can customize freely.
 
+A component's [`opencode` block](/registries/create#opencode-config-block) is merged into
+`opencode.jsonc`, and its [`tui` block](/registries/create#tui-config-block) is merged into
+`~/.config/opencode/tui.json` (with `./…` entries resolved to absolute install paths). Both merges
+add + dedupe, preserving unrelated entries.
+
 ## Arguments
 
 | Argument | Required | Description |

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -13,6 +13,10 @@ ocx update [components...] [options]
 
 Update installed components from their registries to the latest version. You can update specific components, all components, or all components from a particular registry.
 
+If an updated component declares a [`tui` block](/registries/create#tui-config-block), `update`
+reconciles `~/.config/opencode/tui.json` with its new upstream contribution — adding newly-declared
+TUI plugins and dropping ones the component no longer declares, while leaving unrelated entries intact.
+
 ## Arguments
 
 | Argument | Required | Description |

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -83,6 +83,13 @@ Globally enable or disable tools:
 }
 ```
 
+<Note>
+  This `tui` **field inside `opencode.jsonc`** tunes TUI behavior (scroll, diff style, …). It is
+  distinct from `~/.config/opencode/tui.json`, the separate file that lists TUI **plugins**
+  (`*.tui.tsx`). Registry components register TUI plugins via a top-level `tui` block — see
+  [TUI Plugins](/reference/plugins#tui-plugins).
+</Note>
+
 ## Server Configuration
 
 ```jsonc

--- a/docs/reference/plugins.mdx
+++ b/docs/reference/plugins.mdx
@@ -46,6 +46,35 @@ ocx add npm:@scope/plugin
 ocx add kdco/researcher npm:some-plugin
 ```
 
+## TUI Plugins
+
+OpenCode TUI plugins (`*.tui.tsx`) extend the terminal UI and are loaded from a **separate** file —
+`~/.config/opencode/tui.json` — not `opencode.jsonc`. Its `plugin` array holds absolute paths or npm
+names:
+
+```jsonc title="~/.config/opencode/tui.json"
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["/home/me/.config/opencode/plugins/my-plugin/status.tui.tsx"]
+}
+```
+
+A registry component registers a TUI plugin by shipping the file **and** declaring a top-level
+[`tui` block](/registries/create#tui-config-block):
+
+```jsonc title="registry.jsonc"
+{
+  "name": "my-plugin",
+  "type": "plugin",
+  "files": ["plugins/my-plugin/status.tui.tsx"],
+  "tui": { "plugin": ["./plugins/my-plugin/status.tui.tsx"] }
+}
+```
+
+On `ocx add`, ocx resolves the `./…` entry to the absolute install path, adds it to `tui.json`, and
+dedupes — leaving unrelated entries untouched. `ocx update` reconciles the file with the component's
+new `tui` block; `ocx remove` leaves it in place.
+
 ## Basic Plugin Structure
 
 ```typescript

--- a/docs/registries/create.mdx
+++ b/docs/registries/create.mdx
@@ -159,6 +159,43 @@ Components can specify settings to merge into the user's `opencode.jsonc`:
 | `opencode.permission` | Permission settings for bash/edit/mcp |
 | `opencode.instructions` | Global instructions appended to config |
 
+### TUI Config Block
+
+OpenCode TUI plugins (`*.tui.tsx`) are **not** registered in `opencode.jsonc`. They live in a
+separate file, `~/.config/opencode/tui.json`, whose `plugin` array holds absolute paths or npm names.
+Declare a top-level `tui` block (a sibling of `opencode`) and ocx will merge it into that file:
+
+```jsonc
+{
+  "name": "my-plugin",
+  "type": "plugin",
+  "files": ["plugins/my-plugin/status.tui.tsx"],
+  "tui": {
+    "plugin": ["./plugins/my-plugin/status.tui.tsx"]
+  }
+}
+```
+
+On `ocx add`, ocx resolves each `./…` entry to the **absolute install path** of the shipped file
+(`tui.json` requires absolute paths), adds it to the `plugin` array, and dedupes — leaving any
+unrelated entries (e.g. `@streetturtle/opencode-context-progress`) untouched.
+
+| Field | Description |
+|-------|-------------|
+| `tui.plugin` | TUI plugin entries merged into `~/.config/opencode/tui.json`. Each is a `./relative` path (resolved to the absolute install path), an already-absolute path, or an npm name. |
+
+<Note>
+  `tui` is a **manifest block**, not a component `type`. A TUI-plugin component is still
+  `type: "plugin"`; the `tui` block just tells ocx which config file to register it in. A single
+  component may declare `opencode` (→ `opencode.jsonc`), `tui` (→ `tui.json`), or both.
+</Note>
+
+Lifecycle:
+
+- **`ocx add`** — merges the component's TUI entries into `tui.json` (add + dedupe; unrelated entries preserved).
+- **`ocx update`** — reconciles against the component's new upstream `tui` block: adds newly-declared entries and drops ones the component no longer declares.
+- **`ocx remove`** — leaves `tui.json` untouched (like `opencode.jsonc`); remove the entry by hand if you no longer want it.
+
 ## Plugin Discovery vs Registration
 
 OpenCode handles plugins in two ways:
@@ -180,6 +217,18 @@ npm plugins installed via `ocx add npm:package-name` require registration in `op
 ```bash
 ocx add npm:@franlol/opencode-md-table-formatter
 # Adds to opencode.jsonc: {"plugin": ["@franlol/opencode-md-table-formatter"]}
+```
+
+### TUI Plugins (Registered in `tui.json`)
+
+TUI plugins (`*.tui.tsx`) are neither auto-discovered nor registered in `opencode.jsonc` — OpenCode
+loads them from `~/.config/opencode/tui.json`. Ship the file **and** declare a [`tui` block](#tui-config-block)
+so ocx registers its absolute path there:
+
+```bash
+ocx add kdco/my-tui-plugin
+# Installs: plugins/my-tui-plugin/status.tui.tsx
+# Registers its absolute path in ~/.config/opencode/tui.json
 ```
 
 ## Instruction Files for Components

--- a/docs/registries/protocol.mdx
+++ b/docs/registries/protocol.mdx
@@ -120,11 +120,18 @@ Returns full component metadata in npm-style packument format.
         }
       ],
       "dependencies": [],
-      "opencode": {}
+      "opencode": {},
+      "tui": {}
     }
   }
 }
 ```
+
+<Note>
+  The optional `opencode` block merges into `opencode.jsonc`; the optional `tui` block merges TUI
+  plugins into `~/.config/opencode/tui.json`. Both are manifest fields, not component types. See
+  [Creating a Registry](/registries/create#opencode-config-block).
+</Note>
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -413,12 +413,8 @@
 		"tuiConfig": {
 			"type": "object",
 			"description": "TUI configuration to merge into opencode's TUI config file (~/.config/opencode/tui.json)",
-			"additionalProperties": true,
+			"additionalProperties": false,
 			"properties": {
-				"$schema": {
-					"type": "string",
-					"description": "JSON Schema URL for IDE support"
-				},
 				"plugin": {
 					"type": "array",
 					"description": "TUI plugin entries (absolute path, npm name, or ./relative path resolved to absolute at install)",

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -110,6 +110,9 @@
 				"opencode": {
 					"$ref": "#/definitions/opencodeConfig"
 				},
+				"tui": {
+					"$ref": "#/definitions/tuiConfig"
+				},
 				"npmDependencies": {
 					"type": "array",
 					"description": "NPM packages to install as dependencies",
@@ -404,6 +407,22 @@
 							}
 						}
 					}
+				}
+			}
+		},
+		"tuiConfig": {
+			"type": "object",
+			"description": "TUI configuration to merge into opencode's TUI config file (~/.config/opencode/tui.json)",
+			"additionalProperties": true,
+			"properties": {
+				"$schema": {
+					"type": "string",
+					"description": "JSON Schema URL for IDE support"
+				},
+				"plugin": {
+					"type": "array",
+					"description": "TUI plugin entries (absolute path, npm name, or ./relative path resolved to absolute at install)",
+					"items": { "type": "string" }
 				}
 			}
 		}

--- a/examples/registry-starter/AGENTS.md
+++ b/examples/registry-starter/AGENTS.md
@@ -572,6 +572,34 @@ This prevents registry components from polluting the root instruction file.
 
 ---
 
+## TUI Plugins
+
+OpenCode TUI plugins (`*.tui.tsx`) are **not** part of `opencode.jsonc`. They live in a separate file,
+`~/.config/opencode/tui.json`, whose `plugin` array holds absolute paths or npm names. Declare a
+top-level `tui` block (a sibling of `opencode`, **not** a component `type`) and OCX merges it there:
+
+```json
+{
+  "name": "my-plugin",
+  "type": "plugin",
+  "files": ["plugins/my-plugin/status.tui.tsx"],
+  "tui": {
+    "plugin": ["./plugins/my-plugin/status.tui.tsx"]
+  }
+}
+```
+
+- `./…` entries are resolved to the **absolute install path** of the shipped file (`tui.json`
+  requires absolute paths); npm names and absolute paths pass through unchanged.
+- `ocx add` adds + dedupes into `tui.json`, preserving unrelated third-party entries.
+- `ocx update` reconciles against the component's new `tui` block (adds new entries, drops ones the
+  component no longer declares).
+- `ocx remove` leaves `tui.json` untouched.
+
+A component may declare `opencode`, `tui`, or both — they target different files.
+
+---
+
 ## File Patterns
 
 Components can specify files in two formats:

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -32,6 +32,11 @@ import {
 	readOpencodeJsonConfig,
 	updateOpencodeJsonConfig,
 } from "../updaters/update-opencode-config"
+import {
+	applyTuiConfigDelta,
+	getGlobalTuiConfigPath,
+	resolveTuiPluginEntries,
+} from "../updaters/update-tui-config"
 import { isContentIdentical } from "../utils/content"
 import {
 	buildInvalidationDryRunAction,
@@ -621,6 +626,15 @@ async function runRegistryAddCore(
 				actions.push(buildInvalidationDryRunAction(packageDir, dryDeltaEntries))
 			}
 
+			// Report tui.json merge if any component declares TUI plugins.
+			if (resolved.tui?.plugin?.length) {
+				actions.push({
+					action: "modify",
+					target: getGlobalTuiConfigPath(),
+					details: { plugins: resolveTuiPluginEntries(resolved.tui.plugin, cwd) },
+				})
+			}
+
 			const dryRunResult: DryRunResult = {
 				dryRun: true,
 				command: "add",
@@ -886,6 +900,8 @@ async function runRegistryAddCore(
 				installedAt: new Date().toISOString(),
 				// Store component's opencode config for runtime instruction path resolution
 				...(component.opencode && { opencode: component.opencode as Record<string, unknown> }),
+				// Store component's raw tui block so `ocx update` can reconcile tui.json
+				...(component.tui && { tui: component.tui as Record<string, unknown> }),
 			}
 		}
 
@@ -901,6 +917,18 @@ async function runRegistryAddCore(
 				} else {
 					logger.info(`Updated ${result.path}`)
 				}
+			}
+		}
+
+		// Merge TUI plugins into the global ~/.config/opencode/tui.json.
+		// Relative ./… entries resolve to the absolute install path; unrelated
+		// third-party entries are preserved (add-only, no removals).
+		if (resolved.tui?.plugin?.length) {
+			const additions = resolveTuiPluginEntries(resolved.tui.plugin, cwd)
+			const result = await applyTuiConfigDelta([], additions)
+
+			if (!options.quiet && result.changed) {
+				logger.info(`${result.created ? "Created" : "Updated"} ${result.path}`)
 			}
 		}
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -836,6 +836,7 @@ async function runRegistryAddCore(
 			cwd,
 			isFlattened,
 			trackOpencodeConfig: Boolean(resolved.opencode && Object.keys(resolved.opencode).length > 0),
+			trackTuiConfig: Boolean(resolved.tui?.plugin?.length),
 			trackNpmManifests:
 				resolved.npmDependencies.length > 0 || resolved.npmDevDependencies.length > 0,
 			quiet: options.quiet,
@@ -1161,6 +1162,7 @@ async function createAddManifestSideEffectTransaction(options: {
 	cwd: string
 	isFlattened: boolean
 	trackOpencodeConfig: boolean
+	trackTuiConfig: boolean
 	trackNpmManifests: boolean
 	quiet?: boolean
 }): Promise<AddManifestSideEffectTransaction> {
@@ -1179,6 +1181,11 @@ async function createAddManifestSideEffectTransaction(options: {
 	if (options.trackOpencodeConfig) {
 		const opencodeConfigPath = findOpencodeConfig(options.cwd).path
 		await trackPath(opencodeConfigPath)
+	}
+
+	if (options.trackTuiConfig) {
+		// tui.json is the single global file, regardless of install scope.
+		await trackPath(getGlobalTuiConfigPath())
 	}
 
 	if (options.trackNpmManifests) {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -17,7 +17,11 @@ import {
 	normalizeComponentManifest,
 	parseQualifiedComponent,
 } from "../schemas/registry"
-import { applyTuiConfigDelta, resolveTuiPluginEntries } from "../updaters/update-tui-config"
+import {
+	applyTuiConfigDelta,
+	getGlobalTuiConfigPath,
+	resolveTuiPluginEntries,
+} from "../updaters/update-tui-config"
 import { type DryRunAction, type DryRunResult, outputDryRun } from "../utils/dry-run"
 import { ConfigError, NotFoundError, ValidationError } from "../utils/errors"
 import { handleError } from "../utils/handle-error"
@@ -91,6 +95,19 @@ interface UpdateFileOps {
 }
 
 type UpdateFailurePhase = "check" | "apply"
+
+/** Extract the TUI plugin entries from a raw `tui` block (receipt or manifest). */
+function tuiPluginList(tui: unknown): string[] {
+	const plugin = (tui as { plugin?: unknown } | undefined)?.plugin
+	return Array.isArray(plugin) ? plugin.filter((p): p is string => typeof p === "string") : []
+}
+
+/** True when two `tui` blocks declare a different set of plugin entries (order-insensitive). */
+function tuiConfigChanged(oldTui: unknown, newTui: unknown): boolean {
+	const before = [...tuiPluginList(oldTui)].sort()
+	const after = [...tuiPluginList(newTui)].sort()
+	return before.length !== after.length || before.some((value, index) => value !== after[index])
+}
 
 function formatAddCommandHint(component: string, options: UpdateOptions): string {
 	return `ocx add${options.global ? " --global" : ""} ${component}`
@@ -287,7 +304,12 @@ export async function runUpdateCore(
 				? (await checkFileIntegrity(provider.cwd, entry)).intact
 				: false
 
-			if (bundleIsUnchanged && installedFilesAreIntact) {
+			// The bundle hash covers file content only. A component can change its `tui`
+			// block (add/drop TUI plugins) without touching file bytes; detect that so the
+			// tui.json reconcile still runs.
+			const tuiChanged = tuiConfigChanged(entry.tui, normalizedManifest.tui)
+
+			if (bundleIsUnchanged && installedFilesAreIntact && !tuiChanged) {
 				results.push({
 					qualifiedName: canonicalId,
 					oldVersion: entry.revision,
@@ -464,15 +486,34 @@ export async function runUpdateCore(
 		await appliedWriteTransaction.commit()
 		appliedWriteTransaction = null
 
-		// Reflect upstream TUI changes in the global tui.json: resolve both the old
-		// and new contributions to absolute paths, then reconcile by delta. Unrelated
-		// third-party entries stay untouched.
+		// Reflect upstream TUI changes in the global tui.json: reconcile by delta.
+		// This runs AFTER the update is committed (files + receipt), so a tui.json
+		// failure must not report the update itself as failed — warn and continue.
 		if (tuiOldRaw.length > 0 || tuiNewRaw.length > 0) {
-			const removeAbsolute = resolveTuiPluginEntries(tuiOldRaw, provider.cwd)
-			const addAbsolute = resolveTuiPluginEntries(tuiNewRaw, provider.cwd)
-			const tuiResult = await applyTuiConfigDelta(removeAbsolute, addAbsolute)
-			if (!options.quiet && tuiResult.changed) {
-				logger.info(`${tuiResult.created ? "Created" : "Updated"} ${tuiResult.path}`)
+			try {
+				// Entries still declared by SOME installed component after this update —
+				// the receipt already holds the new tui blocks. Never remove these: another
+				// component may share an entry the updated one dropped.
+				const stillReferencedRaw = Object.values(receipt.installed).flatMap((installed) =>
+					tuiPluginList(installed.tui),
+				)
+				const stillReferenced = new Set(resolveTuiPluginEntries(stillReferencedRaw, provider.cwd))
+
+				const removeAbsolute = resolveTuiPluginEntries(tuiOldRaw, provider.cwd).filter(
+					(entry) => !stillReferenced.has(entry),
+				)
+				const addAbsolute = resolveTuiPluginEntries(tuiNewRaw, provider.cwd)
+
+				const tuiResult = await applyTuiConfigDelta(removeAbsolute, addAbsolute)
+				if (!options.quiet && tuiResult.changed) {
+					logger.info(`${tuiResult.created ? "Created" : "Updated"} ${tuiResult.path}`)
+				}
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				logger.warn(
+					`Components updated, but failed to update ${getGlobalTuiConfigPath()}: ${message}. ` +
+						"Re-run `ocx update` or edit tui.json manually.",
+				)
 			}
 		}
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -17,6 +17,7 @@ import {
 	normalizeComponentManifest,
 	parseQualifiedComponent,
 } from "../schemas/registry"
+import { applyTuiConfigDelta, resolveTuiPluginEntries } from "../updaters/update-tui-config"
 import { type DryRunAction, type DryRunResult, outputDryRun } from "../utils/dry-run"
 import { ConfigError, NotFoundError, ValidationError } from "../utils/errors"
 import { handleError } from "../utils/handle-error"
@@ -401,6 +402,12 @@ export async function runUpdateCore(
 			fileOps,
 		})
 
+		// Accumulate raw TUI plugin entries across all updated components so tui.json
+		// can be reconciled once after the write transaction commits: drop entries a
+		// component no longer declares, add newly-declared ones.
+		const tuiOldRaw: string[] = []
+		const tuiNewRaw: string[] = []
+
 		for (const prepared of preparedUpdates) {
 			const { update, preparedFiles } = prepared
 
@@ -408,6 +415,16 @@ export async function runUpdateCore(
 			const existingEntry = receipt.installed[update.canonicalId]
 			if (!existingEntry) {
 				throw new NotFoundError(`Component '${update.canonicalId}' not found in receipt.`)
+			}
+
+			// Capture the component's previous vs new TUI contribution (raw entries)
+			// BEFORE the receipt entry is overwritten below.
+			const oldTuiPlugins = existingEntry.tui?.plugin
+			if (Array.isArray(oldTuiPlugins)) {
+				tuiOldRaw.push(...oldTuiPlugins.filter((p): p is string => typeof p === "string"))
+			}
+			if (update.component.tui?.plugin) {
+				tuiNewRaw.push(...update.component.tui.plugin)
 			}
 
 			// Compute individual file hashes
@@ -432,6 +449,10 @@ export async function runUpdateCore(
 				...(update.component.opencode && {
 					opencode: update.component.opencode as Record<string, unknown>,
 				}),
+				// Update TUI config so `ocx update` can reconcile tui.json next time
+				...(update.component.tui && {
+					tui: update.component.tui as Record<string, unknown>,
+				}),
 			}
 		}
 
@@ -442,6 +463,18 @@ export async function runUpdateCore(
 		}
 		await appliedWriteTransaction.commit()
 		appliedWriteTransaction = null
+
+		// Reflect upstream TUI changes in the global tui.json: resolve both the old
+		// and new contributions to absolute paths, then reconcile by delta. Unrelated
+		// third-party entries stay untouched.
+		if (tuiOldRaw.length > 0 || tuiNewRaw.length > 0) {
+			const removeAbsolute = resolveTuiPluginEntries(tuiOldRaw, provider.cwd)
+			const addAbsolute = resolveTuiPluginEntries(tuiNewRaw, provider.cwd)
+			const tuiResult = await applyTuiConfigDelta(removeAbsolute, addAbsolute)
+			if (!options.quiet && tuiResult.changed) {
+				logger.info(`${tuiResult.created ? "Created" : "Updated"} ${tuiResult.path}`)
+			}
+		}
 
 		installSpin?.succeed(`Updated ${updates.length} component(s)`)
 

--- a/packages/cli/src/profile/paths.ts
+++ b/packages/cli/src/profile/paths.ts
@@ -13,6 +13,9 @@ export const OCX_CONFIG_FILE = "ocx.jsonc"
 /** OpenCode configuration file name */
 export const OPENCODE_CONFIG_FILE = "opencode.jsonc"
 
+/** OpenCode TUI configuration file name (global-only, lives at the OpenCode root) */
+export const TUI_CONFIG_FILE = "tui.json"
+
 /** Local config directory name */
 export const LOCAL_CONFIG_DIR = ".opencode"
 

--- a/packages/cli/src/registry/merge.ts
+++ b/packages/cli/src/registry/merge.ts
@@ -95,6 +95,42 @@ export function dedupePluginsByCanonicalName(plugins: OpencodePluginSpec[]): Ope
 }
 
 /**
+ * True when a TUI plugin entry is a filesystem path (absolute or `./`/`../`
+ * relative) rather than an npm specifier. npm names never start with `/` or `.`
+ * (scoped names start with `@`).
+ */
+function isTuiFilesystemPath(entry: string): boolean {
+	return entry.startsWith("/") || entry.startsWith("./") || entry.startsWith("../")
+}
+
+/**
+ * Deduplicate TUI plugin entries (for `tui.json`).
+ *
+ * Filesystem paths are deduped by **exact string** — canonical-name extraction
+ * would truncate a path at its first `@` (e.g. a `@scope` directory), collapsing
+ * distinct plugins. npm specifiers still dedupe by canonical name (version-stripped).
+ * Order is preserved; the last occurrence of each key wins (matching
+ * {@link dedupePluginsByCanonicalName}).
+ */
+export function dedupeTuiEntries(entries: string[]): string[] {
+	const keyOf = (entry: string): string =>
+		isTuiFilesystemPath(entry) ? entry : extractCanonicalPluginName(entry)
+
+	const lastIndexByKey = new Map<string, number>()
+	entries.forEach((entry, index) => {
+		lastIndexByKey.set(keyOf(entry), index)
+	})
+
+	const result: string[] = []
+	entries.forEach((entry, index) => {
+		if (lastIndexByKey.get(keyOf(entry)) === index) {
+			result.push(entry)
+		}
+	})
+	return result
+}
+
+/**
  * Merge two OpenCode config objects with special array handling.
  *
  * INTERNAL UTILITY - expects pre-validated configs.

--- a/packages/cli/src/registry/merge.ts
+++ b/packages/cli/src/registry/merge.ts
@@ -100,7 +100,13 @@ export function dedupePluginsByCanonicalName(plugins: OpencodePluginSpec[]): Ope
  * (scoped names start with `@`).
  */
 function isTuiFilesystemPath(entry: string): boolean {
-	return entry.startsWith("/") || entry.startsWith("./") || entry.startsWith("../")
+	return (
+		entry.startsWith("/") ||
+		/^[A-Za-z]:[\\/]/.test(entry) ||
+		entry.startsWith("\\\\") ||
+		entry.startsWith("./") ||
+		entry.startsWith("../")
+	)
 }
 
 /**

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -6,6 +6,7 @@
 import type { RegistryConfig } from "../schemas/config"
 import {
 	type ComponentManifest,
+	type ComponentTuiConfig,
 	createQualifiedComponent,
 	type NormalizedComponentManifest,
 	type NormalizedOpencodeConfig,
@@ -15,7 +16,7 @@ import {
 } from "../schemas/registry"
 import { NetworkError, NotFoundError, OCXError, ValidationError } from "../utils/errors"
 import { fetchComponent } from "./fetcher"
-import { mergeOpencodeConfig } from "./merge"
+import { dedupePluginsByCanonicalName, mergeOpencodeConfig } from "./merge"
 
 /**
  * Parse a component reference into registry alias and component name.
@@ -64,6 +65,8 @@ export interface ResolvedDependencies {
 	npmDevDependencies: string[]
 	/** Merged opencode configuration from all components (deep merged) */
 	opencode: OpencodeConfig
+	/** Merged TUI configuration from all components (plugin entries concatenated + deduped) */
+	tui: ComponentTuiConfig
 }
 
 /**
@@ -79,6 +82,7 @@ export async function resolveDependencies(
 	const npmDeps = new Set<string>()
 	const npmDevDeps = new Set<string>()
 	let opencode: NormalizedOpencodeConfig = {}
+	const tuiPlugins: string[] = []
 
 	async function resolve(
 		componentNamespace: string,
@@ -173,6 +177,12 @@ export async function resolveDependencies(
 				normalizedComponent.opencode as NormalizedOpencodeConfig,
 			)
 		}
+
+		// Collect TUI plugin entries (raw ./relative or npm/absolute); resolved to
+		// absolute install paths later, in the install/update commands.
+		if (normalizedComponent.tui?.plugin) {
+			tuiPlugins.push(...normalizedComponent.tui.plugin)
+		}
 	}
 
 	// Resolve all requested components
@@ -192,5 +202,8 @@ export async function resolveDependencies(
 		npmDependencies: Array.from(npmDeps),
 		npmDevDependencies: Array.from(npmDevDeps),
 		opencode,
+		// tui entries are plain strings (paths / npm names), never tuples, so the
+		// deduped result is string[] — the cast just narrows the shared helper's type.
+		tui: { plugin: dedupePluginsByCanonicalName(tuiPlugins) as string[] },
 	}
 }

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -16,7 +16,7 @@ import {
 } from "../schemas/registry"
 import { NetworkError, NotFoundError, OCXError, ValidationError } from "../utils/errors"
 import { fetchComponent } from "./fetcher"
-import { dedupePluginsByCanonicalName, mergeOpencodeConfig } from "./merge"
+import { dedupeTuiEntries, mergeOpencodeConfig } from "./merge"
 
 /**
  * Parse a component reference into registry alias and component name.
@@ -202,8 +202,7 @@ export async function resolveDependencies(
 		npmDependencies: Array.from(npmDeps),
 		npmDevDependencies: Array.from(npmDevDeps),
 		opencode,
-		// tui entries are plain strings (paths / npm names), never tuples, so the
-		// deduped result is string[] — the cast just narrows the shared helper's type.
-		tui: { plugin: dedupePluginsByCanonicalName(tuiPlugins) as string[] },
+		// Dedupe paths by exact string and npm names by canonical name (see dedupeTuiEntries).
+		tui: { plugin: dedupeTuiEntries(tuiPlugins) },
 	}
 }

--- a/packages/cli/src/schemas/config.ts
+++ b/packages/cli/src/schemas/config.ts
@@ -120,6 +120,14 @@ export const installedComponentSchema = object({
 	 * Install-root-relative paths in instructions array are resolved at runtime.
 	 */
 	opencode: record(string(), unknown()).optional(),
+
+	/**
+	 * TUI config provided by this component (raw block, relative entries).
+	 * Stored so `ocx update` can reconcile ~/.config/opencode/tui.json against the
+	 * component's new upstream `tui` block (add newly-declared entries, drop the
+	 * ones it previously contributed but no longer declares).
+	 */
+	tui: record(string(), unknown()).optional(),
 })
 
 export type InstalledComponent = ZodInfer<typeof installedComponentSchema>

--- a/packages/cli/src/schemas/index.ts
+++ b/packages/cli/src/schemas/index.ts
@@ -42,11 +42,13 @@ export {
 	type ComponentFile,
 	type ComponentFileObject,
 	type ComponentManifest,
+	type ComponentTuiConfig,
 	// Types
 	type ComponentType,
 	componentFileObjectSchema,
 	componentFileSchema,
 	componentManifestSchema,
+	componentTuiConfigSchema,
 	// Component schemas
 	componentTypeSchema,
 	createQualifiedComponent,

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -666,14 +666,15 @@ const legacyOpencodeConfigSchema = opencodeConfigSchema.safeExtend({
  * Distinct from `tuiConfigSchema` above (opencode's `tui.disabled` sub-field).
  */
 export const componentTuiConfigSchema = object({
-	/** JSON Schema URL for IDE support */
-	$schema: string().optional(),
 	/**
 	 * TUI plugin entries. Each is an absolute path, an npm name, or a `./relative`
 	 * path (resolved to the absolute install path at install time).
 	 */
 	plugin: array(string()).optional(),
-}).passthrough()
+})
+	// `plugin` is the only field ocx acts on. Reject unknown keys (fail loud) rather
+	// than silently accepting settings that would never reach tui.json.
+	.strict()
 
 export type ComponentTuiConfig = ZodInfer<typeof componentTuiConfigSchema>
 

--- a/packages/cli/src/schemas/registry.ts
+++ b/packages/cli/src/schemas/registry.ts
@@ -655,6 +655,28 @@ const legacyOpencodeConfigSchema = opencodeConfigSchema.safeExtend({
 	mcp: record(string(), legacyMcpServerRefSchema).optional(),
 })
 
+/**
+ * Component-level TUI configuration block.
+ *
+ * Mirrors the `opencode` block, but targets opencode's separate TUI config file
+ * (`~/.config/opencode/tui.json`) instead of `opencode.jsonc`. TUI plugins
+ * (`*.tui.tsx`) are declared here; ocx resolves each `./…` entry to the absolute
+ * install path and merges it into `tui.json`.
+ *
+ * Distinct from `tuiConfigSchema` above (opencode's `tui.disabled` sub-field).
+ */
+export const componentTuiConfigSchema = object({
+	/** JSON Schema URL for IDE support */
+	$schema: string().optional(),
+	/**
+	 * TUI plugin entries. Each is an absolute path, an npm name, or a `./relative`
+	 * path (resolved to the absolute install path at install time).
+	 */
+	plugin: array(string()).optional(),
+}).passthrough()
+
+export type ComponentTuiConfig = ZodInfer<typeof componentTuiConfigSchema>
+
 // =============================================================================
 // COMPONENT MANIFEST SCHEMA
 // =============================================================================
@@ -695,6 +717,12 @@ export const componentManifestSchema = object({
 	 * Use this for: mcp servers, plugins, tools, agent config, instructions, permissions
 	 */
 	opencode: opencodeConfigSchema.optional(),
+
+	/**
+	 * TUI configuration to merge into opencode's separate TUI config file
+	 * (`~/.config/opencode/tui.json`). Use this to register TUI plugins (`*.tui.tsx`).
+	 */
+	tui: componentTuiConfigSchema.optional(),
 })
 
 export type ComponentManifest = ZodInfer<typeof componentManifestSchema>

--- a/packages/cli/src/updaters/update-tui-config.ts
+++ b/packages/cli/src/updaters/update-tui-config.ts
@@ -21,7 +21,8 @@ import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { applyEdits, type ModificationOptions, modify, parse as parseJsonc } from "jsonc-parser"
 import { getGlobalOpencodeRoot, resolveOpencodePathScope, TUI_CONFIG_FILE } from "../profile/paths"
-import { dedupePluginsByCanonicalName } from "../registry/merge"
+import { dedupeTuiEntries } from "../registry/merge"
+import { ValidationError } from "../utils/errors"
 import { resolveTargetPath } from "../utils/paths"
 
 // =============================================================================
@@ -88,14 +89,35 @@ function tuiIsFlattened(installRoot: string): boolean {
  * - npm name / already-absolute path → returned unchanged.
  * - `./relative` path → resolved to the absolute install path of the shipped file,
  *   using the same target resolution ocx uses to place the file on disk.
+ *
+ * `../` parent-traversal entries are rejected — ocx can never ship a matching
+ * traversal file target, and (in flattened installs) such a path would otherwise
+ * escape the install root. Embedded `..` that escapes the root is rejected too.
  */
 function resolveTuiPluginEntry(entry: string, installRoot: string): string {
-	if (!entry.startsWith("./") && !entry.startsWith("../")) {
+	if (entry.startsWith("../")) {
+		throw new ValidationError(
+			`Invalid tui plugin entry "${entry}": parent traversal ("../") is not allowed.`,
+		)
+	}
+	// npm name or already-absolute path → use as-is.
+	if (!entry.startsWith("./")) {
 		return entry
 	}
+
 	const root = path.resolve(installRoot)
-	const target = entry.replace(/^\.\//, "")
-	return path.join(root, resolveTargetPath(target, tuiIsFlattened(root), root))
+	const target = entry.slice(2)
+	const resolved = path.join(root, resolveTargetPath(target, tuiIsFlattened(root), root))
+
+	// Defense in depth: reject entries whose resolved path escapes the install root
+	// (e.g. embedded "..") — resolveTargetPath validates this for local installs, but
+	// not for flattened (global/profile) installs.
+	if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+		throw new ValidationError(
+			`Invalid tui plugin entry "${entry}": resolves outside the install root.`,
+		)
+	}
+	return resolved
 }
 
 /**
@@ -173,8 +195,8 @@ export async function applyTuiConfigDelta(
 	const addSet = new Set(addAbsolute)
 	// Keep entries unless this component owned them and no longer declares them.
 	const base = currentPlugins.filter((entry) => !removeSet.has(entry) || addSet.has(entry))
-	// tui entries are plain strings, so the deduped result is string[].
-	const finalPlugins = dedupePluginsByCanonicalName([...base, ...addAbsolute]) as string[]
+	// Dedupe paths by exact string, npm names by canonical name (see dedupeTuiEntries).
+	const finalPlugins = dedupeTuiEntries([...base, ...addAbsolute])
 
 	const originalContent = content
 	const edits = modify(content, ["plugin"], finalPlugins, JSONC_OPTIONS)

--- a/packages/cli/src/updaters/update-tui-config.ts
+++ b/packages/cli/src/updaters/update-tui-config.ts
@@ -1,0 +1,193 @@
+/**
+ * OpenCode TUI Config Updater
+ *
+ * Mirrors the opencode.jsonc updater, but targets opencode's separate TUI config
+ * file (`~/.config/opencode/tui.json`) instead of `opencode.jsonc`.
+ *
+ * Key differences from the opencode.jsonc updater:
+ * - Always the single global file (never a project-local `.opencode/` copy).
+ * - The `plugin[]` array is merged/deduped against existing entries (unrelated
+ *   third-party entries are preserved), not replaced wholesale.
+ * - A reconcile-by-delta primitive (`applyTuiConfigDelta`) serves both install
+ *   (add only) and update (add + drop the entries a component no longer declares).
+ * - Comments are preserved via jsonc-parser's modify/applyEdits.
+ *
+ * Absolute-path note: `tui.json` requires absolute plugin paths. Component `tui`
+ * entries that are `./relative` are resolved to the absolute install path of the
+ * shipped file (npm names and already-absolute paths pass through unchanged).
+ */
+
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { applyEdits, type ModificationOptions, modify, parse as parseJsonc } from "jsonc-parser"
+import { getGlobalOpencodeRoot, resolveOpencodePathScope, TUI_CONFIG_FILE } from "../profile/paths"
+import { dedupePluginsByCanonicalName } from "../registry/merge"
+import { resolveTargetPath } from "../utils/paths"
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/** The structure of the tui.json file. */
+export interface TuiJsonConfig {
+	$schema?: string
+	plugin?: string[]
+	[key: string]: unknown
+}
+
+export interface UpdateTuiConfigResult {
+	/** Path to the tui.json file */
+	path: string
+	/** Whether the file was created (vs updated) */
+	created: boolean
+	/** Whether any changes were made */
+	changed: boolean
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const JSONC_OPTIONS: ModificationOptions = {
+	formattingOptions: {
+		tabSize: 2,
+		insertSpaces: false,
+		eol: "\n",
+	},
+}
+
+// Minimal template for a new tui.json file.
+const TUI_CONFIG_TEMPLATE = `{
+	"$schema": "https://opencode.ai/tui.json"
+}
+`
+
+// =============================================================================
+// PATH RESOLUTION
+// =============================================================================
+
+/**
+ * Absolute path to the global TUI config file (`~/.config/opencode/tui.json`).
+ * Respects XDG_CONFIG_HOME via getGlobalOpencodeRoot.
+ */
+export function getGlobalTuiConfigPath(): string {
+	return path.join(getGlobalOpencodeRoot(), TUI_CONFIG_FILE)
+}
+
+/**
+ * Whether an install root uses opencode's flattened (global/profile) layout.
+ * Matches add.ts's `isFlattened = !!(options.global || options.profile)`, but is
+ * derived from the install root so `add` and `update` reconstruct identical paths.
+ */
+function tuiIsFlattened(installRoot: string): boolean {
+	return resolveOpencodePathScope(path.resolve(installRoot)) !== "local-project"
+}
+
+/**
+ * Resolve a single component `tui.plugin` entry to an absolute path.
+ * - npm name / already-absolute path → returned unchanged.
+ * - `./relative` path → resolved to the absolute install path of the shipped file,
+ *   using the same target resolution ocx uses to place the file on disk.
+ */
+function resolveTuiPluginEntry(entry: string, installRoot: string): string {
+	if (!entry.startsWith("./") && !entry.startsWith("../")) {
+		return entry
+	}
+	const root = path.resolve(installRoot)
+	const target = entry.replace(/^\.\//, "")
+	return path.join(root, resolveTargetPath(target, tuiIsFlattened(root), root))
+}
+
+/**
+ * Resolve a list of component `tui.plugin` entries to absolute paths.
+ */
+export function resolveTuiPluginEntries(entries: string[], installRoot: string): string[] {
+	return entries.map((entry) => resolveTuiPluginEntry(entry, installRoot))
+}
+
+// =============================================================================
+// FILE OPERATIONS
+// =============================================================================
+
+/**
+ * Read the global tui.json (parsed + raw content for comment preservation).
+ * Returns null if it does not exist.
+ */
+export async function readTuiConfig(): Promise<{
+	config: TuiJsonConfig
+	content: string
+	path: string
+} | null> {
+	const configPath = getGlobalTuiConfigPath()
+	const file = Bun.file(configPath)
+	if (!(await file.exists())) {
+		return null
+	}
+	const content = await file.text()
+	return {
+		config: parseJsonc(content, [], { allowTrailingComma: true }) as TuiJsonConfig,
+		content,
+		path: configPath,
+	}
+}
+
+// =============================================================================
+// MAIN UPDATER
+// =============================================================================
+
+/**
+ * Reconcile the global tui.json `plugin[]` array by delta.
+ *
+ * - `removeAbsolute`: absolute entries this component previously contributed and
+ *   no longer declares (dropped, unless also present in `addAbsolute`).
+ * - `addAbsolute`: absolute entries this component now declares (added + deduped).
+ *
+ * Unrelated third-party entries (never in `removeAbsolute`) are preserved. Comments
+ * and other keys survive via jsonc-parser edits. The file is created from a minimal
+ * template when absent.
+ *
+ * Install = call with `removeAbsolute: []`. Update = call with old + new sets.
+ */
+export async function applyTuiConfigDelta(
+	removeAbsolute: string[],
+	addAbsolute: string[],
+): Promise<UpdateTuiConfigResult> {
+	const existing = await readTuiConfig()
+
+	let content: string
+	const configPath = getGlobalTuiConfigPath()
+	const created = !existing
+
+	let currentPlugins: string[] = []
+	if (existing) {
+		content = existing.content
+		currentPlugins = Array.isArray(existing.config.plugin)
+			? existing.config.plugin.filter((p): p is string => typeof p === "string")
+			: []
+	} else {
+		content = TUI_CONFIG_TEMPLATE
+		await mkdir(path.dirname(configPath), { recursive: true })
+	}
+
+	const removeSet = new Set(removeAbsolute)
+	const addSet = new Set(addAbsolute)
+	// Keep entries unless this component owned them and no longer declares them.
+	const base = currentPlugins.filter((entry) => !removeSet.has(entry) || addSet.has(entry))
+	// tui entries are plain strings, so the deduped result is string[].
+	const finalPlugins = dedupePluginsByCanonicalName([...base, ...addAbsolute]) as string[]
+
+	const originalContent = content
+	const edits = modify(content, ["plugin"], finalPlugins, JSONC_OPTIONS)
+	content = applyEdits(content, edits)
+
+	const changed = content !== originalContent
+	if (changed) {
+		await Bun.write(configPath, content)
+	}
+
+	return {
+		path: configPath,
+		created: created && changed,
+		changed,
+	}
+}

--- a/packages/cli/tests/merge.test.ts
+++ b/packages/cli/tests/merge.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from "bun:test"
 import {
 	dedupePluginsByCanonicalName,
+	dedupeTuiEntries,
 	extractCanonicalPluginName,
 	mergeOpencodeConfig,
 } from "../src/registry/merge"
@@ -131,6 +132,49 @@ describe("dedupePluginsByCanonicalName", () => {
 		])
 
 		expect(result).toEqual(["npm:other", ["npm:pkg@2.0.0", { source: "local" }]])
+	})
+})
+
+// =============================================================================
+// dedupeTuiEntries
+// =============================================================================
+
+describe("dedupeTuiEntries", () => {
+	it("keeps distinct absolute paths under a @scope directory (regression: @-truncation)", () => {
+		// extractCanonicalPluginName would truncate both at the first "@", collapsing them.
+		const result = dedupeTuiEntries([
+			"/home/me/.config/opencode/plugins/@acme/a.tui.tsx",
+			"/home/me/.config/opencode/plugins/@acme/b.tui.tsx",
+		])
+		expect(result).toEqual([
+			"/home/me/.config/opencode/plugins/@acme/a.tui.tsx",
+			"/home/me/.config/opencode/plugins/@acme/b.tui.tsx",
+		])
+	})
+
+	it("keeps distinct ./relative paths under a @scope directory", () => {
+		const result = dedupeTuiEntries(["./plugins/@acme/a.tui.tsx", "./plugins/@acme/b.tui.tsx"])
+		expect(result).toEqual(["./plugins/@acme/a.tui.tsx", "./plugins/@acme/b.tui.tsx"])
+	})
+
+	it("dedupes identical filesystem paths by exact string", () => {
+		expect(dedupeTuiEntries(["/abs/a.tui.tsx", "/abs/a.tui.tsx"])).toEqual(["/abs/a.tui.tsx"])
+	})
+
+	it("canonical-dedupes npm specifiers by version-stripped name (last wins)", () => {
+		expect(dedupeTuiEntries(["@vendor/progress@1.0.0", "@vendor/progress@2.0.0"])).toEqual([
+			"@vendor/progress@2.0.0",
+		])
+	})
+
+	it("keeps distinct scoped npm names", () => {
+		expect(dedupeTuiEntries(["@vendor/a", "@vendor/b"])).toEqual(["@vendor/a", "@vendor/b"])
+	})
+
+	it("preserves order and mixes paths with npm names", () => {
+		expect(
+			dedupeTuiEntries(["/abs/a.tui.tsx", "@vendor/x", "/abs/a.tui.tsx", "@vendor/x@2"]),
+		).toEqual(["/abs/a.tui.tsx", "@vendor/x@2"])
 	})
 })
 

--- a/packages/cli/tests/schemas.test.ts
+++ b/packages/cli/tests/schemas.test.ts
@@ -690,6 +690,22 @@ describe("schemas", () => {
 			}
 		})
 
+		it("accepts a top-level tui block with plugin entries", () => {
+			const result = componentManifestSchema.safeParse({
+				name: "my-plugin",
+				type: "plugin",
+				description: "d",
+				files: ["plugins/my-plugin/status.tui.tsx"],
+				dependencies: [],
+				tui: { plugin: ["./plugins/my-plugin/status.tui.tsx"] },
+			})
+
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.data.tui?.plugin).toEqual(["./plugins/my-plugin/status.tui.tsx"])
+			}
+		})
+
 		it("rejects a top-level key that is not in opencode's field set", () => {
 			const result = opencodeConfigSchema.safeParse({ bogus_key: 1 })
 			expect(result.success).toBe(false)

--- a/packages/cli/tests/tui-install.test.ts
+++ b/packages/cli/tests/tui-install.test.ts
@@ -10,13 +10,15 @@ import { cleanupTempDir, createTempDir, parseJsonc as parseJsoncHelper, runCLI }
 const THIRD_PARTY = "@streetturtle/opencode-context-progress"
 
 interface RegistryState {
-	manifest: Record<string, unknown>
-	fileContents: Record<string, string>
+	/** component name -> manifest (mutable, so tests can simulate upstream changes) */
+	components: Record<string, Record<string, unknown>>
+	/** "<component>/<filePath>" -> file content */
+	files: Record<string, string>
 }
 
 /**
- * A tiny mock registry whose served manifest is mutable (unlike the shared
- * startMockRegistry), so we can simulate an upstream `tui` block changing.
+ * A tiny mock registry whose served manifests + files are mutable (unlike the shared
+ * startMockRegistry), so tests can simulate an upstream `tui` block changing.
  */
 function startTuiRegistry(state: RegistryState): { url: string; stop: () => void } {
 	const server = Bun.serve({
@@ -25,30 +27,36 @@ function startTuiRegistry(state: RegistryState): { url: string; stop: () => void
 			const { pathname } = new URL(req.url)
 
 			if (pathname === "/index.json") {
-				const m = state.manifest
 				return Response.json({
 					$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
 					name: "TUI Test Registry",
 					version: "1.0.0",
 					author: "Test",
-					components: [{ name: m.name, type: m.type, description: m.description }],
+					components: Object.values(state.components).map((m) => ({
+						name: m.name,
+						type: m.type,
+						description: m.description,
+					})),
 				})
 			}
 
 			const componentMatch = pathname.match(/^\/components\/(.+)\.json$/)
-			if (componentMatch && componentMatch[1] === state.manifest.name) {
-				return Response.json({
-					name: state.manifest.name,
-					"dist-tags": { latest: "1.0.0" },
-					versions: { "1.0.0": state.manifest },
-				})
+			if (componentMatch) {
+				const manifest = state.components[componentMatch[1] as string]
+				if (manifest) {
+					return Response.json({
+						name: manifest.name,
+						"dist-tags": { latest: "1.0.0" },
+						versions: { "1.0.0": manifest },
+					})
+				}
 			}
 
 			const fileMatch = pathname.match(/^\/components\/(.+?)\/(.+)$/)
 			if (fileMatch) {
 				const [, name, filePath] = fileMatch
-				const content = state.fileContents[filePath]
-				if (name === state.manifest.name && content !== undefined) {
+				const content = state.files[`${name}/${filePath}`]
+				if (content !== undefined) {
 					return new Response(content)
 				}
 			}
@@ -82,17 +90,6 @@ async function readTuiPlugins(): Promise<string[]> {
 	return (parseJsonc(content) as { plugin?: string[] }).plugin ?? []
 }
 
-function baseManifest(): Record<string, unknown> {
-	return {
-		name: "tui-status",
-		type: "plugin",
-		description: "A TUI status plugin",
-		files: [{ path: "status.tui.tsx", target: "plugins/tui-status/status.tui.tsx" }],
-		dependencies: [],
-		tui: { plugin: ["./plugins/tui-status/status.tui.tsx"] },
-	}
-}
-
 describe("ocx add/update — tui.json", () => {
 	let testDir: string
 	let registry: { url: string; stop: () => void }
@@ -100,7 +97,7 @@ describe("ocx add/update — tui.json", () => {
 
 	beforeEach(async () => {
 		await rm(getGlobalTuiConfigPath(), { force: true })
-		state = { manifest: baseManifest(), fileContents: { "status.tui.tsx": "// v1" } }
+		state = { components: {}, files: {} }
 		registry = startTuiRegistry(state)
 	})
 
@@ -111,6 +108,16 @@ describe("ocx add/update — tui.json", () => {
 	})
 
 	it("installs the file and adds its absolute path to tui.json, preserving third-party entries", async () => {
+		state.components["tui-status"] = {
+			name: "tui-status",
+			type: "plugin",
+			description: "A TUI status plugin",
+			files: [{ path: "status.tui.tsx", target: "plugins/tui-status/status.tui.tsx" }],
+			dependencies: [],
+			tui: { plugin: ["./plugins/tui-status/status.tui.tsx"] },
+		}
+		state.files["tui-status/status.tui.tsx"] = "// v1"
+
 		await seedTuiJson([THIRD_PARTY])
 		testDir = await setupProject("tui-add", registry.url)
 
@@ -127,20 +134,28 @@ describe("ocx add/update — tui.json", () => {
 	})
 
 	it("reflects an upstream tui removal on update, leaving third-party entries intact", async () => {
+		state.components["tui-status"] = {
+			name: "tui-status",
+			type: "plugin",
+			description: "A TUI status plugin",
+			files: [{ path: "status.tui.tsx", target: "plugins/tui-status/status.tui.tsx" }],
+			dependencies: [],
+			tui: { plugin: ["./plugins/tui-status/status.tui.tsx"] },
+		}
+		state.files["tui-status/status.tui.tsx"] = "// v1"
+
 		await seedTuiJson([THIRD_PARTY])
 		testDir = await setupProject("tui-update-remove", registry.url)
 
-		const add = await runCLI(["add", "kdco/tui-status"], testDir)
-		expect(add.exitCode).toBe(0)
-
+		expect((await runCLI(["add", "kdco/tui-status"], testDir)).exitCode).toBe(0)
 		const installedFile = join(testDir, ".opencode", "plugins", "tui-status", "status.tui.tsx")
 		expect(await readTuiPlugins()).toContain(installedFile)
 
 		// Upstream drops the tui block and changes the file (so the update is detected).
-		const nextManifest = baseManifest()
-		delete nextManifest.tui
-		state.manifest = nextManifest
-		state.fileContents["status.tui.tsx"] = "// v2"
+		const next = { ...state.components["tui-status"] }
+		delete (next as { tui?: unknown }).tui
+		state.components["tui-status"] = next
+		state.files["tui-status/status.tui.tsx"] = "// v2"
 
 		const upd = await runCLI(["update", "kdco/tui-status"], testDir)
 		if (upd.exitCode !== 0) console.log(upd.output)
@@ -149,5 +164,75 @@ describe("ocx add/update — tui.json", () => {
 		const plugins = await readTuiPlugins()
 		expect(plugins).not.toContain(installedFile)
 		expect(plugins).toContain(THIRD_PARTY)
+	})
+
+	it("detects a tui-only manifest change (identical files) on update", async () => {
+		// Ships two files but registers only one; later registers the second with NO
+		// file-content change — the bundle hash is identical, so only tui-change
+		// detection can surface this update.
+		state.components.p = {
+			name: "p",
+			type: "plugin",
+			description: "plugin with two tui files",
+			files: [
+				{ path: "a.tui.tsx", target: "plugins/p/a.tui.tsx" },
+				{ path: "b.tui.tsx", target: "plugins/p/b.tui.tsx" },
+			],
+			dependencies: [],
+			tui: { plugin: ["./plugins/p/a.tui.tsx"] },
+		}
+		state.files["p/a.tui.tsx"] = "// a"
+		state.files["p/b.tui.tsx"] = "// b"
+
+		testDir = await setupProject("tui-only-change", registry.url)
+		expect((await runCLI(["add", "kdco/p"], testDir)).exitCode).toBe(0)
+
+		const absA = join(testDir, ".opencode", "plugins", "p", "a.tui.tsx")
+		const absB = join(testDir, ".opencode", "plugins", "p", "b.tui.tsx")
+		expect(await readTuiPlugins()).toEqual([absA])
+
+		// Register b too — WITHOUT changing any file content.
+		;(state.components.p as { tui: { plugin: string[] } }).tui.plugin = [
+			"./plugins/p/a.tui.tsx",
+			"./plugins/p/b.tui.tsx",
+		]
+
+		const upd = await runCLI(["update", "kdco/p"], testDir)
+		if (upd.exitCode !== 0) console.log(upd.output)
+		expect(upd.exitCode).toBe(0)
+
+		const plugins = await readTuiPlugins()
+		expect(plugins).toContain(absA)
+		expect(plugins).toContain(absB)
+	})
+
+	it("does not unregister a shared entry still declared by another component", async () => {
+		const shared = "shared-tui-plugin"
+		for (const name of ["comp-a", "comp-b"]) {
+			state.components[name] = {
+				name,
+				type: "plugin",
+				description: `component ${name}`,
+				files: [{ path: "marker.ts", target: `plugins/${name}/marker.ts` }],
+				dependencies: [],
+				tui: { plugin: [shared] },
+			}
+			state.files[`${name}/marker.ts`] = "// v1"
+		}
+
+		testDir = await setupProject("tui-shared-entry", registry.url)
+		expect((await runCLI(["add", "kdco/comp-a", "kdco/comp-b"], testDir)).exitCode).toBe(0)
+		expect(await readTuiPlugins()).toEqual([shared])
+
+		// comp-a drops the shared entry (and changes its file so the update is detected).
+		;(state.components["comp-a"] as { tui: { plugin: string[] } }).tui.plugin = []
+		state.files["comp-a/marker.ts"] = "// v2"
+
+		const upd = await runCLI(["update", "kdco/comp-a"], testDir)
+		if (upd.exitCode !== 0) console.log(upd.output)
+		expect(upd.exitCode).toBe(0)
+
+		// comp-b still declares it, so it must remain registered.
+		expect(await readTuiPlugins()).toContain(shared)
 	})
 })

--- a/packages/cli/tests/tui-install.test.ts
+++ b/packages/cli/tests/tui-install.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { parse as parseJsonc } from "jsonc-parser"
+import { getGlobalOpencodeRoot } from "../src/profile/paths"
+import { getGlobalTuiConfigPath } from "../src/updaters/update-tui-config"
+import { cleanupTempDir, createTempDir, parseJsonc as parseJsoncHelper, runCLI } from "./helpers"
+
+const THIRD_PARTY = "@streetturtle/opencode-context-progress"
+
+interface RegistryState {
+	manifest: Record<string, unknown>
+	fileContents: Record<string, string>
+}
+
+/**
+ * A tiny mock registry whose served manifest is mutable (unlike the shared
+ * startMockRegistry), so we can simulate an upstream `tui` block changing.
+ */
+function startTuiRegistry(state: RegistryState): { url: string; stop: () => void } {
+	const server = Bun.serve({
+		port: 0,
+		fetch(req) {
+			const { pathname } = new URL(req.url)
+
+			if (pathname === "/index.json") {
+				const m = state.manifest
+				return Response.json({
+					$schema: "https://ocx.kdco.dev/schemas/v2/registry.json",
+					name: "TUI Test Registry",
+					version: "1.0.0",
+					author: "Test",
+					components: [{ name: m.name, type: m.type, description: m.description }],
+				})
+			}
+
+			const componentMatch = pathname.match(/^\/components\/(.+)\.json$/)
+			if (componentMatch && componentMatch[1] === state.manifest.name) {
+				return Response.json({
+					name: state.manifest.name,
+					"dist-tags": { latest: "1.0.0" },
+					versions: { "1.0.0": state.manifest },
+				})
+			}
+
+			const fileMatch = pathname.match(/^\/components\/(.+?)\/(.+)$/)
+			if (fileMatch) {
+				const [, name, filePath] = fileMatch
+				const content = state.fileContents[filePath]
+				if (name === state.manifest.name && content !== undefined) {
+					return new Response(content)
+				}
+			}
+
+			return new Response("Not Found", { status: 404 })
+		},
+	})
+	return { url: `http://localhost:${server.port}`, stop: () => server.stop() }
+}
+
+async function setupProject(name: string, registryUrl: string): Promise<string> {
+	const dir = await createTempDir(name)
+	await runCLI(["init"], dir)
+	const configPath = join(dir, ".opencode", "ocx.jsonc")
+	const config = parseJsoncHelper(await readFile(configPath, "utf-8")) as Record<string, unknown>
+	config.registries = { kdco: { url: registryUrl } }
+	await writeFile(configPath, JSON.stringify(config, null, 2))
+	return dir
+}
+
+async function seedTuiJson(entries: string[]): Promise<void> {
+	await mkdir(getGlobalOpencodeRoot(), { recursive: true })
+	await writeFile(
+		getGlobalTuiConfigPath(),
+		JSON.stringify({ $schema: "https://opencode.ai/tui.json", plugin: entries }, null, "\t"),
+	)
+}
+
+async function readTuiPlugins(): Promise<string[]> {
+	const content = await readFile(getGlobalTuiConfigPath(), "utf-8")
+	return (parseJsonc(content) as { plugin?: string[] }).plugin ?? []
+}
+
+function baseManifest(): Record<string, unknown> {
+	return {
+		name: "tui-status",
+		type: "plugin",
+		description: "A TUI status plugin",
+		files: [{ path: "status.tui.tsx", target: "plugins/tui-status/status.tui.tsx" }],
+		dependencies: [],
+		tui: { plugin: ["./plugins/tui-status/status.tui.tsx"] },
+	}
+}
+
+describe("ocx add/update — tui.json", () => {
+	let testDir: string
+	let registry: { url: string; stop: () => void }
+	let state: RegistryState
+
+	beforeEach(async () => {
+		await rm(getGlobalTuiConfigPath(), { force: true })
+		state = { manifest: baseManifest(), fileContents: { "status.tui.tsx": "// v1" } }
+		registry = startTuiRegistry(state)
+	})
+
+	afterEach(async () => {
+		registry?.stop()
+		await rm(getGlobalTuiConfigPath(), { force: true })
+		if (testDir) await cleanupTempDir(testDir)
+	})
+
+	it("installs the file and adds its absolute path to tui.json, preserving third-party entries", async () => {
+		await seedTuiJson([THIRD_PARTY])
+		testDir = await setupProject("tui-add", registry.url)
+
+		const { exitCode, output } = await runCLI(["add", "kdco/tui-status"], testDir)
+		if (exitCode !== 0) console.log(output)
+		expect(exitCode).toBe(0)
+
+		const installedFile = join(testDir, ".opencode", "plugins", "tui-status", "status.tui.tsx")
+		expect(existsSync(installedFile)).toBe(true)
+
+		const plugins = await readTuiPlugins()
+		expect(plugins).toContain(installedFile)
+		expect(plugins).toContain(THIRD_PARTY)
+	})
+
+	it("reflects an upstream tui removal on update, leaving third-party entries intact", async () => {
+		await seedTuiJson([THIRD_PARTY])
+		testDir = await setupProject("tui-update-remove", registry.url)
+
+		const add = await runCLI(["add", "kdco/tui-status"], testDir)
+		expect(add.exitCode).toBe(0)
+
+		const installedFile = join(testDir, ".opencode", "plugins", "tui-status", "status.tui.tsx")
+		expect(await readTuiPlugins()).toContain(installedFile)
+
+		// Upstream drops the tui block and changes the file (so the update is detected).
+		const nextManifest = baseManifest()
+		delete nextManifest.tui
+		state.manifest = nextManifest
+		state.fileContents["status.tui.tsx"] = "// v2"
+
+		const upd = await runCLI(["update", "kdco/tui-status"], testDir)
+		if (upd.exitCode !== 0) console.log(upd.output)
+		expect(upd.exitCode).toBe(0)
+
+		const plugins = await readTuiPlugins()
+		expect(plugins).not.toContain(installedFile)
+		expect(plugins).toContain(THIRD_PARTY)
+	})
+})

--- a/packages/cli/tests/tui-updater.test.ts
+++ b/packages/cli/tests/tui-updater.test.ts
@@ -118,6 +118,17 @@ describe("update-tui-config", () => {
 
 			expect(await readTuiPlugins()).toEqual(["/abs/plugins/mine/status.tui.tsx"])
 		})
+
+		it("keeps distinct absolute paths under a @scope directory (regression: @-truncation)", async () => {
+			await applyTuiConfigDelta(
+				[],
+				["/abs/plugins/@acme/a.tui.tsx", "/abs/plugins/@acme/b.tui.tsx"],
+			)
+			const plugins = await readTuiPlugins()
+			expect(plugins).toContain("/abs/plugins/@acme/a.tui.tsx")
+			expect(plugins).toContain("/abs/plugins/@acme/b.tui.tsx")
+			expect(plugins).toHaveLength(2)
+		})
 	})
 
 	describe("resolveTuiPluginEntries", () => {
@@ -149,6 +160,20 @@ describe("update-tui-config", () => {
 				installRoot,
 			)
 			expect(resolved).toBe(join(installRoot, "plugins", "my-plugin", "status.tui.tsx"))
+		})
+
+		it("rejects ../ parent-traversal entries", () => {
+			expect(() =>
+				resolveTuiPluginEntries(["../evil/plugin.tui.tsx"], getGlobalOpencodeRoot()),
+			).toThrow(/parent traversal/i)
+		})
+
+		it("rejects ./ entries whose embedded .. escapes the install root (flattened)", () => {
+			// Flattened installs skip resolveTargetPath's local containment check, so the
+			// updater's own guard must catch this.
+			expect(() =>
+				resolveTuiPluginEntries(["./plugins/../../etc/passwd"], getGlobalOpencodeRoot()),
+			).toThrow(/install root/i)
 		})
 	})
 

--- a/packages/cli/tests/tui-updater.test.ts
+++ b/packages/cli/tests/tui-updater.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { parse as parseJsonc } from "jsonc-parser"
+import { getGlobalOpencodeRoot } from "../src/profile/paths"
+import {
+	applyTuiConfigDelta,
+	getGlobalTuiConfigPath,
+	readTuiConfig,
+	resolveTuiPluginEntries,
+} from "../src/updaters/update-tui-config"
+
+const THIRD_PARTY = "@streetturtle/opencode-context-progress"
+
+async function readTuiPlugins(): Promise<string[]> {
+	const content = await readFile(getGlobalTuiConfigPath(), "utf-8")
+	const parsed = parseJsonc(content) as { plugin?: string[] }
+	return parsed.plugin ?? []
+}
+
+describe("update-tui-config", () => {
+	// preload.ts points XDG_CONFIG_HOME at an isolated per-process temp dir, so the
+	// global tui.json lives under it. Reset it before/after each test.
+	beforeEach(async () => {
+		await rm(getGlobalTuiConfigPath(), { force: true })
+	})
+
+	afterEach(async () => {
+		await rm(getGlobalTuiConfigPath(), { force: true })
+	})
+
+	describe("applyTuiConfigDelta", () => {
+		it("creates tui.json with a seed $schema and the added plugin when absent", async () => {
+			const result = await applyTuiConfigDelta([], ["/abs/plugins/my-plugin/status.tui.tsx"])
+
+			expect(result.created).toBe(true)
+			expect(result.changed).toBe(true)
+			expect(result.path).toBe(getGlobalTuiConfigPath())
+
+			const content = await readFile(getGlobalTuiConfigPath(), "utf-8")
+			const config = parseJsonc(content) as { $schema?: string; plugin?: string[] }
+			expect(config.$schema).toBe("https://opencode.ai/tui.json")
+			expect(config.plugin).toEqual(["/abs/plugins/my-plugin/status.tui.tsx"])
+		})
+
+		it("preserves an unrelated pre-existing entry while adding the new one", async () => {
+			await mkdir(getGlobalOpencodeRoot(), { recursive: true })
+			await writeFile(
+				getGlobalTuiConfigPath(),
+				JSON.stringify(
+					{ $schema: "https://opencode.ai/tui.json", plugin: [THIRD_PARTY] },
+					null,
+					"\t",
+				),
+			)
+
+			await applyTuiConfigDelta([], ["/abs/plugins/mine/status.tui.tsx"])
+
+			const plugins = await readTuiPlugins()
+			expect(plugins).toContain(THIRD_PARTY)
+			expect(plugins).toContain("/abs/plugins/mine/status.tui.tsx")
+			expect(plugins).toHaveLength(2)
+		})
+
+		it("dedupes on re-apply (idempotent)", async () => {
+			await applyTuiConfigDelta([], ["/abs/plugins/mine/status.tui.tsx"])
+			const result = await applyTuiConfigDelta([], ["/abs/plugins/mine/status.tui.tsx"])
+
+			expect(result.changed).toBe(false)
+			expect(await readTuiPlugins()).toEqual(["/abs/plugins/mine/status.tui.tsx"])
+		})
+
+		it("preserves JSONC comments and other keys", async () => {
+			await mkdir(getGlobalOpencodeRoot(), { recursive: true })
+			await writeFile(
+				getGlobalTuiConfigPath(),
+				`{
+	// keep this comment
+	"$schema": "https://opencode.ai/tui.json",
+	"plugin": ["${THIRD_PARTY}"]
+}
+`,
+			)
+
+			await applyTuiConfigDelta([], ["/abs/plugins/mine/status.tui.tsx"])
+
+			const content = await readFile(getGlobalTuiConfigPath(), "utf-8")
+			expect(content).toContain("// keep this comment")
+			expect(content).toContain(THIRD_PARTY)
+		})
+
+		it("reconciles by delta: drops old, adds new, keeps third-party", async () => {
+			await mkdir(getGlobalOpencodeRoot(), { recursive: true })
+			await writeFile(
+				getGlobalTuiConfigPath(),
+				JSON.stringify(
+					{ $schema: "https://opencode.ai/tui.json", plugin: [THIRD_PARTY, "/abs/old.tui.tsx"] },
+					null,
+					"\t",
+				),
+			)
+
+			await applyTuiConfigDelta(["/abs/old.tui.tsx"], ["/abs/new.tui.tsx"])
+
+			const plugins = await readTuiPlugins()
+			expect(plugins).toContain(THIRD_PARTY)
+			expect(plugins).toContain("/abs/new.tui.tsx")
+			expect(plugins).not.toContain("/abs/old.tui.tsx")
+		})
+
+		it("keeps an entry present in both the remove and add sets (unchanged component)", async () => {
+			await applyTuiConfigDelta([], ["/abs/plugins/mine/status.tui.tsx"])
+			// Same entry declared old and new -> stays.
+			await applyTuiConfigDelta(
+				["/abs/plugins/mine/status.tui.tsx"],
+				["/abs/plugins/mine/status.tui.tsx"],
+			)
+
+			expect(await readTuiPlugins()).toEqual(["/abs/plugins/mine/status.tui.tsx"])
+		})
+	})
+
+	describe("resolveTuiPluginEntries", () => {
+		it("passes npm names and absolute paths through unchanged", () => {
+			const resolved = resolveTuiPluginEntries(
+				[THIRD_PARTY, "/already/absolute/status.tui.tsx"],
+				"/tmp/some-project",
+			)
+			expect(resolved).toEqual([THIRD_PARTY, "/already/absolute/status.tui.tsx"])
+		})
+
+		it("resolves ./relative entries to the local .opencode/ install path", () => {
+			// A project dir outside the global opencode root => local (non-flattened) scope.
+			const installRoot = join(import.meta.dir, "fixtures", "tui-local-project")
+			const [resolved] = resolveTuiPluginEntries(
+				["./plugins/my-plugin/status.tui.tsx"],
+				installRoot,
+			)
+			expect(resolved).toBe(
+				join(installRoot, ".opencode", "plugins", "my-plugin", "status.tui.tsx"),
+			)
+		})
+
+		it("resolves ./relative entries to the flattened path for global installs", () => {
+			// The global opencode root => flattened scope (no .opencode/ prefix).
+			const installRoot = getGlobalOpencodeRoot()
+			const [resolved] = resolveTuiPluginEntries(
+				["./plugins/my-plugin/status.tui.tsx"],
+				installRoot,
+			)
+			expect(resolved).toBe(join(installRoot, "plugins", "my-plugin", "status.tui.tsx"))
+		})
+	})
+
+	describe("readTuiConfig", () => {
+		it("returns null when tui.json does not exist", async () => {
+			expect(await readTuiConfig()).toBeNull()
+		})
+	})
+})

--- a/workers/ocx-kit/AGENTS.md
+++ b/workers/ocx-kit/AGENTS.md
@@ -424,6 +424,31 @@ config: {
 
 ---
 
+## TUI Plugins
+
+OpenCode TUI plugins (`*.tui.tsx`) are **not** part of `opencode.jsonc`. They live in a separate file,
+`~/.config/opencode/tui.json`, whose `plugin` array holds absolute paths or npm names. Declare a
+top-level `tui` block (a sibling of `opencode`, **not** a component `type`) and OCX merges it there:
+
+```json
+{
+  "name": "my-plugin",
+  "type": "plugin",
+  "files": ["plugins/my-plugin/status.tui.tsx"],
+  "tui": {
+    "plugin": ["./plugins/my-plugin/status.tui.tsx"]
+  }
+}
+```
+
+- `./…` entries resolve to the **absolute install path** of the shipped file; npm names and absolute
+  paths pass through unchanged.
+- `ocx add` adds + dedupes into `tui.json`, preserving unrelated third-party entries.
+- `ocx update` reconciles against the component's new `tui` block (adds new, drops removed).
+- `ocx remove` leaves `tui.json` untouched.
+
+---
+
 ## File Patterns
 
 Components can specify files in two formats:


### PR DESCRIPTION
This is a slightly bigger change, but is relatively straightforward. It adds support for opencode TUI plugins while making sure they work with the various quirks in the Opencode codebase (requiring absolute paths is one). 

While I developed this change with Claude, I manually reviewed every single changed file.

Fixes #247 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class TUI plugin support via a new `tui` manifest block and a global `~/.config/opencode/tui.json`. Updates now detect and reconcile `tui` changes even when files are unchanged. Fixes #247.

- **New Features**
  - Top-level `tui.plugin[]` in manifests; validated in schema and documented.
  - Global `~/.config/opencode/tui.json` created/updated; unrelated entries preserved.
  - `ocx add` resolves `./…` to absolute install paths and appends (deduped).
  - `ocx update` reconciles by delta, detects `tui`-only manifest changes, and never removes entries still declared by other components.
  - Improved deduping: filesystem paths dedupe by exact string; npm specifiers dedupe by canonical name. Fixes `@scope` path truncation issues.
  - New utilities: `dedupeTuiEntries`, `resolveTuiPluginEntries`, `applyTuiConfigDelta`, `getGlobalTuiConfigPath`; guards against `../` traversal and root-escape. Tests cover install/update behavior.

- **Migration**
  - No action required for users.
  - Registry authors: add a top-level `tui` block with `plugin` entries (absolute paths, npm names, or `./relative` paths that ocx resolves to absolute). TUI plugins are not auto-removed on `ocx remove`.

<sup>Written for commit e9bd947c5c87b6cb906094fd94408fcddf277487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

