### PR TITLE
feat: allow authentication for all registry operations

### DIFF
--- a/docs/cli/registry.mdx
+++ b/docs/cli/registry.mdx
@@ -13,6 +13,8 @@ ocx registry <subcommand> [options]
 
 Manage configured component registries. Registries are sources for components that OCX can install. By default, registry commands operate on local project configuration; use `--global` for global scope.
 
+For private registries, authenticate per registry with a Bearer token or Basic credentials. `ocx registry add` can persist them for you (`--token`/`--token-env`/`--token-file`, or `--username` + `--password`/`--password-env`/`--password-file`), or you can supply an `OCX_REGISTRY_<ALIAS>_TOKEN` environment variable. See [Registry Authentication](/registries/authentication).
+
 ## Subcommands
 
 - [`ocx registry add`](#registry-add) — Add a registry

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,7 +52,7 @@
 					},
 					{
 						"group": "Registries",
-						"pages": ["registries/create", "registries/protocol"]
+						"pages": ["registries/create", "registries/protocol", "registries/authentication"]
 					},
 					{
 						"group": "Reference",

--- a/docs/registries/authentication.mdx
+++ b/docs/registries/authentication.mdx
@@ -1,0 +1,221 @@
+---
+title: "Registry Authentication"
+description: "Authenticate OCX to private registries with per-registry Bearer or Basic credentials"
+---
+
+## Overview
+
+OCX authenticates to a registry **per registry**. Because a single command (e.g. `ocx add`) can
+pull from several registries at once — and dependencies can cross registries — credentials are
+attached to each registry entry rather than passed globally.
+
+There are three ways to supply credentials, in precedence order (highest first):
+
+1. **CLI flags** — only for a one-off `--from <url>` registry.
+2. **Per-registry environment variables** — `OCX_REGISTRY_<ALIAS>_TOKEN` and friends.
+3. **The registry's `auth` block** in `ocx.jsonc`.
+
+Both **Bearer tokens** and **HTTP Basic** are supported, with the secret provided as a literal, an
+environment variable, or a file.
+
+## Security model
+
+Where a credential *reference* is allowed depends on **which config file** it lives in — the same
+model pnpm uses to stop a checked-out repository from stealing your secrets:
+
+| Config scope | File | Literal creds | `${ENV}` / file references | `insecure` |
+| --- | --- | --- | --- | --- |
+| **local** | `./.opencode/ocx.jsonc` (committed) | ✅ allowed | ❌ **rejected** | ❌ rejected |
+| **global** | `~/.config/opencode/ocx.jsonc` | ✅ allowed | ✅ allowed | ✅ allowed |
+| **profile** | `~/.config/opencode/profiles/<name>/ocx.jsonc` | ✅ allowed | ✅ allowed | ✅ allowed |
+
+<Warning>
+Environment/file references are **not** resolved in a committed local `ocx.jsonc`. If a repository
+you clone paired a registry URL with `${CI_TOKEN}`, resolving it would leak your token to that
+repo's registry. A local config that uses `tokenEnv`, `tokenFile`, `passwordEnv`, `passwordFile`,
+`${…}` in `headers`, `insecure`, or an alias that matches a set `OCX_REGISTRY_<ALIAS>_*` override
+fails fast with an error — move it to your **global** or **profile** config, or use a literal value.
+</Warning>
+
+## The `auth` block
+
+Add an `auth` object to any registry in `ocx.jsonc`.
+
+### Bearer token
+
+```jsonc
+{
+  "registries": {
+    "acme": {
+      "url": "https://reg.acme.com/r",
+      "auth": { "type": "bearer", "tokenEnv": "ACME_TOKEN" }
+    }
+  }
+}
+```
+
+Provide the token with exactly one of:
+
+- `token` — a literal token (allowed in any scope)
+- `tokenEnv` — the name of an environment variable (global/profile only)
+- `tokenFile` — a path to a file containing the token, `~` is expanded (global/profile only)
+
+Produces `Authorization: Bearer <token>`.
+
+### Basic auth
+
+```jsonc
+{
+  "registries": {
+    "acme": {
+      "url": "https://reg.acme.com/r",
+      "auth": { "type": "basic", "username": "ci", "passwordEnv": "ACME_PASS" }
+    }
+  }
+}
+```
+
+Requires `username` plus exactly one of `password`, `passwordEnv`, or `passwordFile`. Produces
+`Authorization: Basic base64(username:password)`.
+
+Committing literal Basic credentials to a local `ocx.jsonc` is allowed if that suits your workflow:
+
+```jsonc
+{
+  "registries": {
+    "acme": {
+      "url": "https://reg.acme.com/r",
+      "auth": { "type": "basic", "username": "ci", "password": "s3cret" }
+    }
+  }
+}
+```
+
+### Raw headers
+
+For anything the structured block doesn't cover, set `headers` directly. `${ENV_VAR}` is expanded
+in global/profile config only:
+
+```jsonc
+{
+  "registries": {
+    "acme": {
+      "url": "https://reg.acme.com/r",
+      "headers": { "X-Api-Key": "${ACME_KEY}" }
+    }
+  }
+}
+```
+
+## Environment variable overrides
+
+Set credentials without editing config — ideal for CI. Variables are keyed by the registry
+**alias**, uppercased with non-alphanumeric characters replaced by `_` (so alias `my-reg` →
+`MY_REG`):
+
+| Variable | Effect |
+| --- | --- |
+| `OCX_REGISTRY_<ALIAS>_TOKEN` | Bearer token |
+| `OCX_REGISTRY_<ALIAS>_TOKEN_FILE` | Path to a file containing a Bearer token |
+| `OCX_REGISTRY_<ALIAS>_BASIC` | `username:password` for Basic auth |
+
+```bash
+OCX_REGISTRY_ACME_TOKEN=$CI_ACME_TOKEN ocx add acme/deploy-bot
+```
+
+An env override takes precedence over the registry's `auth` block, so CI can inject a token even
+when the config ships a different default.
+
+<Warning>
+Env overrides are honored only for registries defined in **global** or **profile** config. Because
+a committed local `ocx.jsonc` controls both the alias and the URL, a local-scope registry whose
+alias matches a set `OCX_REGISTRY_<ALIAS>_*` variable is **rejected** — otherwise a cloned repo
+could name a registry to grab your token and point it at its own URL. Put registries that rely on
+env-var auth in your global or profile config.
+</Warning>
+
+## One-off registries (`--from`)
+
+When installing from an unconfigured registry via `--from <url>`, pass credentials with flags. These
+flags are **only** valid together with `--from`.
+
+| Flag | Meaning |
+| --- | --- |
+| `--token <token>` | Bearer token (literal — avoid in CI; visible in your shell history) |
+| `--token-env <NAME>` | Bearer token from an environment variable |
+| `--token-file <path>` | Bearer token from a file |
+| `--username <user>` | HTTP Basic username (combine with a `--password*` flag) |
+| `--password <pass>` | HTTP Basic password (literal) |
+| `--password-env <NAME>` | HTTP Basic password from an environment variable |
+| `--password-file <path>` | HTTP Basic password from a file |
+| `--auth-header <Name: Value>` | Extra header (repeatable) |
+| `--insecure-skip-tls-verify` | Skip TLS certificate verification |
+
+```bash
+ocx add acme/deploy-bot --from https://reg.acme.com/r --token-env ACME_TOKEN
+```
+
+## TLS
+
+HTTPS certificates are verified by default. To talk to a registry with a self-signed or otherwise
+untrusted certificate, use `--insecure-skip-tls-verify`. It's available on every command that
+fetches from a registry — `add`, `update`, `search`, `profile add`, and `registry add` — and skips
+verification for that invocation's registry requests:
+
+```bash
+ocx add acme/deploy-bot --insecure-skip-tls-verify
+```
+
+For a persistent setting, pass it to `registry add` and it's stored as `"insecure": true` on the
+registry, so later commands skip verification automatically:
+
+```bash
+ocx registry add https://reg.internal --name acme --insecure-skip-tls-verify --global
+```
+
+Unlike env/file credential references, `"insecure": true` is allowed in **any** scope — including a
+committed local `ocx.jsonc`. It is not a secret, and the config author already controls the registry
+URL, so committing it (e.g. for a team's internal self-signed registry) adds no exfiltration risk.
+
+## `ocx registry add`
+
+`ocx registry add` can persist credentials for you — no hand-editing JSON. Pass the credential as a
+flag and it's written into the registry's `auth` block in the right form:
+
+Bearer and Basic use the same flags whether persisted here or passed to `add --from`:
+
+| Flag | Written as |
+| --- | --- |
+| `--token <token>` | `{ "type": "bearer", "token": … }` |
+| `--token-env <NAME>` | `{ "type": "bearer", "tokenEnv": … }` |
+| `--token-file <path>` | `{ "type": "bearer", "tokenFile": … }` |
+| `--username <u> --password <p>` | `{ "type": "basic", "username": …, "password": … }` |
+| `--username <u> --password-env <NAME>` | `{ …, "passwordEnv": … }` |
+| `--username <u> --password-file <path>` | `{ …, "passwordFile": … }` |
+
+The `--password` secret has the same three forms as `--token` (literal, env, file); `--username` is
+the non-secret prefix. The same credential is also used to authenticate the validation request, so
+adding a private registry works in one step:
+
+```bash
+# Basic, persisted literally (fine in any scope)
+ocx registry add https://reg.acme.com/r --name acme --username ci --password s3cret --global
+
+# Bearer, persisted as an env reference (global/profile only)
+ocx registry add https://reg.acme.com/r --name acme --token-env ACME_TOKEN --global
+```
+
+<Warning>
+Scope rules are enforced at write time. Targeting a **committed local** config (`--cwd`, the default)
+with an env/file reference (`--token-env`, `--token-file`, `--password-env`, `--password-file`) is
+**refused** — those are only honored in `--global`/`--profile` config. Literal values (`--token`,
+`--username`/`--password`) are allowed in any scope. Re-running `registry add` with new credentials
+for an existing registry updates its stored `auth`.
+</Warning>
+
+Prefer not to persist anything? Omit the flags and authenticate the validation request with the
+`OCX_REGISTRY_<NAME>_*` env override instead:
+
+```bash
+OCX_REGISTRY_ACME_TOKEN=$TOKEN ocx registry add https://reg.acme.com/r --name acme --global
+```

--- a/docs/registries/protocol.mdx
+++ b/docs/registries/protocol.mdx
@@ -11,6 +11,12 @@ This document specifies the HTTP API that OCX-compatible registries must impleme
 **V2 Changes:** Registry targets are now root-relative (no `.opencode/` prefix required). The OCX CLI handles path resolution based on component type.
 </Note>
 
+<Note>
+**Private registries:** A registry may require authentication. When credentials are configured for a
+registry, OCX attaches them (e.g. an `Authorization` header) to every request below — index,
+component, and file endpoints alike. See [Registry Authentication](/registries/authentication).
+</Note>
+
 ## Discovery (Optional)
 
 ```

--- a/docs/schemas/local.schema.json
+++ b/docs/schemas/local.schema.json
@@ -35,7 +35,26 @@
 					"headers": {
 						"type": "object",
 						"additionalProperties": { "type": "string" },
-						"description": "Custom headers for registry requests"
+						"description": "Custom headers for registry requests. ${ENV_VAR} expansion is NOT applied in a committed local ocx.jsonc (use global/profile config for env references)."
+					},
+					"auth": {
+						"type": "object",
+						"description": "Per-registry authentication. In a committed local ocx.jsonc only LITERAL credentials are allowed; env/file references (tokenEnv/tokenFile/passwordEnv/passwordFile) and insecure must live in global or profile config.",
+						"properties": {
+							"type": { "type": "string", "enum": ["bearer", "basic"] },
+							"token": { "type": "string", "description": "Bearer: literal token" },
+							"tokenEnv": { "type": "string", "description": "Bearer: env var name (global/profile only)" },
+							"tokenFile": { "type": "string", "description": "Bearer: token file path (global/profile only)" },
+							"username": { "type": "string", "description": "Basic: username" },
+							"password": { "type": "string", "description": "Basic: literal password" },
+							"passwordEnv": { "type": "string", "description": "Basic: env var name (global/profile only)" },
+							"passwordFile": { "type": "string", "description": "Basic: password file path (global/profile only)" }
+						},
+						"required": ["type"]
+					},
+					"insecure": {
+						"type": "boolean",
+						"description": "Skip TLS certificate verification for this registry"
 					}
 				}
 			}

--- a/docs/schemas/ocx.schema.json
+++ b/docs/schemas/ocx.schema.json
@@ -24,10 +24,55 @@
 					},
 					"headers": {
 						"type": "object",
-						"description": "Optional HTTP headers for authentication",
+						"description": "Optional raw HTTP headers. Supports ${ENV_VAR} expansion in global/profile config only (never in a committed local ocx.jsonc).",
 						"additionalProperties": {
 							"type": "string"
 						}
+					},
+					"auth": {
+						"type": "object",
+						"description": "Per-registry authentication. Literal credentials are allowed in any scope; env/file references are honored only in global/profile config, never in a committed local ocx.jsonc.",
+						"additionalProperties": false,
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": ["bearer", "basic"],
+								"description": "Authentication scheme"
+							},
+							"token": {
+								"type": "string",
+								"description": "Bearer: literal token (allowed in any scope)"
+							},
+							"tokenEnv": {
+								"type": "string",
+								"description": "Bearer: name of an env var holding the token (global/profile only)"
+							},
+							"tokenFile": {
+								"type": "string",
+								"description": "Bearer: path to a file containing the token (global/profile only)"
+							},
+							"username": {
+								"type": "string",
+								"description": "Basic: username"
+							},
+							"password": {
+								"type": "string",
+								"description": "Basic: literal password (allowed in any scope)"
+							},
+							"passwordEnv": {
+								"type": "string",
+								"description": "Basic: name of an env var holding the password (global/profile only)"
+							},
+							"passwordFile": {
+								"type": "string",
+								"description": "Basic: path to a file containing the password (global/profile only)"
+							}
+						},
+						"required": ["type"]
+					},
+					"insecure": {
+						"type": "boolean",
+						"description": "Skip TLS certificate verification for this registry"
 					}
 				},
 				"required": ["url"]

--- a/docs/schemas/profile.schema.json
+++ b/docs/schemas/profile.schema.json
@@ -35,7 +35,26 @@
 					"headers": {
 						"type": "object",
 						"additionalProperties": { "type": "string" },
-						"description": "Custom headers for registry requests"
+						"description": "Custom headers for registry requests. ${ENV_VAR} expansion is honored in profile config."
+					},
+					"auth": {
+						"type": "object",
+						"description": "Per-registry authentication. Profile config is user-owned, so literal credentials and env/file references (tokenEnv/tokenFile/passwordEnv/passwordFile) are all honored.",
+						"properties": {
+							"type": { "type": "string", "enum": ["bearer", "basic"] },
+							"token": { "type": "string", "description": "Bearer: literal token" },
+							"tokenEnv": { "type": "string", "description": "Bearer: env var name" },
+							"tokenFile": { "type": "string", "description": "Bearer: token file path" },
+							"username": { "type": "string", "description": "Basic: username" },
+							"password": { "type": "string", "description": "Basic: literal password" },
+							"passwordEnv": { "type": "string", "description": "Basic: env var name" },
+							"passwordFile": { "type": "string", "description": "Basic: password file path" }
+						},
+						"required": ["type"]
+					},
+					"insecure": {
+						"type": "boolean",
+						"description": "Skip TLS certificate verification for this registry"
 					}
 				}
 			}

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,7 +14,8 @@ import { GlobalConfigProvider, LocalConfigProvider } from "../config/provider"
 import { ConfigResolver } from "../config/resolver"
 import { CLI_VERSION, GITHUB_REPO } from "../constants"
 import { getProfileDir } from "../profile/paths"
-import { fetchFileContent, fetchRegistryIndex } from "../registry/fetcher"
+import { createAuthResolver } from "../registry/auth"
+import { fetchFileContent, fetchRegistryIndex, setInsecureTls } from "../registry/fetcher"
 import { getPluginSpecifier } from "../registry/merge"
 import type { ResolvedComponent } from "../registry/resolver"
 import { resolveDependencies } from "../registry/resolver"
@@ -57,7 +58,15 @@ import { PathValidationError, validatePath } from "../utils/path-security"
 import { resolveTargetPath } from "../utils/paths"
 import { registerPlannedWriteOrThrow } from "../utils/planned-writes"
 import { hashBundle, hashContent } from "../utils/receipt"
-import { addCommonOptions, addGlobalOption, addVerboseOption } from "../utils/shared-options"
+import {
+	addAuthOptions,
+	addCommonOptions,
+	addGlobalOption,
+	addInsecureTlsOption,
+	addVerboseOption,
+	type CliAuthOptions,
+	resolveCliAuth,
+} from "../utils/shared-options"
 import { createSpinner } from "../utils/spinner"
 import { normalizeRegistryUrl } from "../utils/url"
 import { collectCompatIssues, warnCompatIssues } from "../utils/version-compat"
@@ -150,7 +159,8 @@ export function parseAddInput(input: string): AddInput {
 	return { type: "registry", namespace: "", component: trimmed }
 }
 
-export interface AddOptions {
+// Extends CliAuthOptions for the `--from` credential flags + `--insecure-skip-tls-verify` + `from`.
+export interface AddOptions extends CliAuthOptions {
 	dryRun?: boolean
 	cwd?: string
 	quiet?: boolean
@@ -160,7 +170,6 @@ export interface AddOptions {
 	trust?: boolean
 	global?: boolean
 	profile?: string
-	from?: string
 }
 
 interface NpmAddResult {
@@ -218,9 +227,12 @@ export function registerAddCommand(program: Command): void {
 	addCommonOptions(cmd)
 	addVerboseOption(cmd)
 	addGlobalOption(cmd)
+	addAuthOptions(cmd)
+	addInsecureTlsOption(cmd)
 
 	cmd.action(async (components: string[], options: AddOptions) => {
 		try {
+			setInsecureTls(Boolean(options.insecureSkipTlsVerify))
 			const runtimeOptions = options.json ? { ...options, quiet: true, verbose: false } : options
 
 			// Create appropriate provider based on flags
@@ -237,6 +249,7 @@ export function registerAddCommand(program: Command): void {
 					cwd: profileDir,
 					getRegistries: () => resolver.getRegistries(),
 					getComponentPath: () => resolver.getComponentPath(),
+					getScope: () => "profile",
 				}
 			} else if (runtimeOptions.global) {
 				provider = await GlobalConfigProvider.requireInitialized()
@@ -477,8 +490,12 @@ async function runRegistryAddCore(
 	const isFlattened = !!(options.global || options.profile)
 	const registries = provider.getRegistries()
 
+	// Resolve CLI auth flags (only valid alongside --from; throws otherwise)
+	const cliAuth = resolveCliAuth(options)
+
 	// V2: Handle --from flag for ephemeral registry
 	let effectiveRegistries = registries
+	let ephemeralName: string | undefined
 	if (options.from) {
 		// Validate --from URL
 		const fromUrl = options.from.trim()
@@ -510,13 +527,10 @@ async function runRegistryAddCore(
 		}
 
 		// Use the single prefix as the ephemeral registry name
-		const ephemeralName = Array.from(requestedPrefixes)[0]
+		ephemeralName = Array.from(requestedPrefixes)[0]
 		if (!ephemeralName) {
 			throw new ValidationError("No valid component references provided")
 		}
-
-		// Fetch registry index to validate the URL serves a valid registry (alias-first: ignore its namespace)
-		await fetchRegistryIndex(fromUrl)
 
 		// Create ephemeral registry config (does not persist)
 		effectiveRegistries = {
@@ -524,6 +538,19 @@ async function runRegistryAddCore(
 			[ephemeralName]: {
 				url: fromUrl,
 			},
+		}
+	}
+
+	// Per-registry auth resolver: config `auth`/env for configured registries, CLI flags for --from.
+	const resolveAuth = createAuthResolver(effectiveRegistries, provider.getScope(), {
+		ephemeral: ephemeralName ? { alias: ephemeralName, cliAuth } : undefined,
+	})
+
+	// Validate the --from registry serves a valid index (authenticated; alias-first)
+	if (ephemeralName) {
+		const ephemeralConfig = effectiveRegistries[ephemeralName]
+		if (ephemeralConfig) {
+			await fetchRegistryIndex(ephemeralConfig.url, resolveAuth(ephemeralName))
 		}
 	}
 
@@ -552,12 +579,12 @@ async function runRegistryAddCore(
 		for (const registryAlias of requestedRegistries) {
 			const registryConfig = effectiveRegistries[registryAlias]
 			if (registryConfig) {
-				await fetchRegistryIndex(registryConfig.url)
+				await fetchRegistryIndex(registryConfig.url, resolveAuth(registryAlias))
 			}
 		}
 
 		// Resolve all dependencies across all configured registries
-		const resolved = await resolveDependencies(effectiveRegistries, componentNames)
+		const resolved = await resolveDependencies(effectiveRegistries, componentNames, resolveAuth)
 
 		if (options.verbose) {
 			logger.info("Install order:")
@@ -577,7 +604,7 @@ async function runRegistryAddCore(
 		}
 
 		for (const [namespace, baseUrl] of uniqueBaseUrls) {
-			const index = await fetchRegistryIndex(baseUrl)
+			const index = await fetchRegistryIndex(baseUrl, resolveAuth(namespace))
 			registryIndexes.set(namespace, index)
 		}
 
@@ -653,9 +680,10 @@ async function runRegistryAddCore(
 
 		for (const component of resolved.components) {
 			// Fetch component files and compute bundle hash
+			const auth = resolveAuth(component.registryName)
 			const files: { path: string; content: Buffer }[] = []
 			for (const file of component.files) {
-				const content = await fetchFileContent(component.baseUrl, component.name, file.path)
+				const content = await fetchFileContent(component.baseUrl, component.name, file.path, auth)
 				files.push({ path: file.path, content: Buffer.from(content) })
 			}
 

--- a/packages/cli/src/commands/migrate/transform.ts
+++ b/packages/cli/src/commands/migrate/transform.ts
@@ -203,7 +203,7 @@ const DEPRECATED_REGISTRY_FIELDS = ["version"] as const
  * Detect deprecated `version` fields in registry config entries.
  *
  * Legacy v1.4.6 allowed `registries.<alias>.version` for pinning.
- * Current schema only allows `url` and `headers`. This function
+ * Current schema allows `url`, `headers`, `auth`, and `insecure`. This function
  * inspects raw config data (pre-Zod-parse) to find deprecated keys.
  *
  * Pure function: returns planned actions, never mutates.

--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -20,6 +20,9 @@ import {
 	RequiredGlobalConfigReadError,
 	readRequiredGlobalOcxConfig,
 } from "../../profile/paths"
+import { type RegistryScope, resolveRegistryAuth } from "../../registry/auth"
+import { setInsecureTls } from "../../registry/fetcher"
+import type { RegistryConfig } from "../../schemas/config"
 import type { ProfileOcxConfig } from "../../schemas/ocx"
 import { profileOcxConfigSchema } from "../../schemas/ocx"
 import {
@@ -87,6 +90,7 @@ interface ProfileAddOptions {
 	from?: string
 	global?: boolean
 	json?: boolean
+	insecureSkipTlsVerify?: boolean
 }
 
 interface ProfileAddResult {
@@ -146,7 +150,7 @@ async function readGlobalOcxConfig() {
  */
 async function requireGlobalRegistry(
 	namespace: string,
-): Promise<{ config: ProfileOcxConfig; registryUrl: string }> {
+): Promise<{ config: ProfileOcxConfig; registryUrl: string; registry: RegistryConfig }> {
 	let globalConfig: ProfileOcxConfig
 	try {
 		globalConfig = await readGlobalOcxConfig()
@@ -172,7 +176,7 @@ async function requireGlobalRegistry(
 		)
 	}
 
-	return { config: globalConfig, registryUrl: registry.url }
+	return { config: globalConfig, registryUrl: registry.url, registry }
 }
 
 // =============================================================================
@@ -189,6 +193,7 @@ export function registerProfileAddCommand(parent: Command): void {
 		.option("--source <namespace/component>", "Install from registry (requires --global)")
 		.option("--from <url>", "Ephemeral registry URL for --source (does not persist)")
 		.option("-g, --global", "Create global profile (required — local profiles are unsupported)")
+		.option("--insecure-skip-tls-verify", "Skip TLS certificate verification for registry requests")
 		.option("--json", "Output as JSON")
 		.addHelpText(
 			"after",
@@ -365,30 +370,35 @@ async function runProfileAdd(name: string, options: ProfileAddOptions): Promise<
 	// Route: --source (registry installation)
 	if (options.source) {
 		const { namespace, component } = parseSourceOption(options.source)
-		let registryUrl: string
+		// Run-level TLS-skip applies to the source fetch and its dependency installs.
+		setInsecureTls(Boolean(options.insecureSkipTlsVerify))
 
+		// Resolve the source registry: an ephemeral --from URL, or a configured global registry.
+		let registryUrl: string
+		let sourceConfig: RegistryConfig
+		let sourceScope: RegistryScope
 		if (options.from) {
-			// Ephemeral registry URL
+			// Ephemeral registry URL — source auth via OCX_REGISTRY_<NS>_* env override.
 			registryUrl = normalizeRegistryUrl(options.from.trim())
-			await installProfileFromRegistry({
-				namespace,
-				component,
-				profileName: name,
-				registryUrl,
-				quiet,
-			})
+			sourceConfig = { url: registryUrl }
+			sourceScope = "ephemeral"
 		} else {
-			// Configured registry
+			// Configured registry (global scope: config `auth` block + env override honored).
 			const globalRegistry = await requireGlobalRegistry(namespace)
 			registryUrl = globalRegistry.registryUrl
-			await installProfileFromRegistry({
-				namespace,
-				component,
-				profileName: name,
-				registryUrl,
-				quiet,
-			})
+			sourceConfig = globalRegistry.registry
+			sourceScope = "global"
 		}
+
+		const sourceAuth = resolveRegistryAuth(namespace, sourceConfig, sourceScope)
+		await installProfileFromRegistry({
+			namespace,
+			component,
+			profileName: name,
+			registryUrl,
+			sourceAuth,
+			quiet,
+		})
 
 		return {
 			name,

--- a/packages/cli/src/commands/profile/install-from-registry.ts
+++ b/packages/cli/src/commands/profile/install-from-registry.ts
@@ -14,6 +14,7 @@ import { parse } from "jsonc-parser"
 import type { ConfigProvider } from "../../config/provider"
 import { getProfileDir, getProfilesDir } from "../../profile/paths"
 import { profileNameSchema } from "../../profile/schema"
+import type { RequestAuth } from "../../registry/auth"
 import { fetchComponent, fetchFileContent } from "../../registry/fetcher"
 import type { RegistryConfig } from "../../schemas/config"
 import { writeReceipt } from "../../schemas/config"
@@ -48,6 +49,8 @@ export interface InstallProfileOptions {
 	profileName: string
 	/** Resolved registry URL */
 	registryUrl: string
+	/** Resolved auth for the source registry (config `auth` block / env override). */
+	sourceAuth?: RequestAuth
 	/** Suppress output */
 	quiet?: boolean
 }
@@ -302,7 +305,14 @@ export function resolveEmbeddedProfileTarget(rawTarget: string, stagingDir: stri
  * @throws ConflictError if profile exists and force is not set
  */
 export async function installProfileFromRegistry(options: InstallProfileOptions): Promise<void> {
-	const { namespace: providedNamespace, component, profileName, registryUrl, quiet } = options
+	const {
+		namespace: providedNamespace,
+		component,
+		profileName,
+		registryUrl,
+		sourceAuth,
+		quiet,
+	} = options
 
 	// ==========================================================================
 	// Guard: Validate profile name at boundary (Law 2: Parse Don't Validate)
@@ -355,7 +365,7 @@ export async function installProfileFromRegistry(options: InstallProfileOptions)
 
 	let manifest: Awaited<ReturnType<typeof fetchComponent>>
 	try {
-		manifest = await fetchComponent(registryUrl, component)
+		manifest = await fetchComponent(registryUrl, component, sourceAuth)
 	} catch (error) {
 		fetchSpin?.fail(`Failed to fetch ${qualifiedName}`)
 		if (error instanceof NetworkError) {
@@ -401,7 +411,7 @@ export async function installProfileFromRegistry(options: InstallProfileOptions)
 	const embeddedFiles: { path: string; target: string; content: Buffer }[] = []
 
 	for (const file of normalized.files) {
-		const content = await fetchFileContent(registryUrl, component, file.path)
+		const content = await fetchFileContent(registryUrl, component, file.path, sourceAuth)
 		const fileEntry = {
 			path: file.path,
 			target: file.target,
@@ -560,6 +570,7 @@ export async function installProfileFromRegistry(options: InstallProfileOptions)
 					cwd: profileDir,
 					getRegistries: () => dependencyRegistries,
 					getComponentPath: () => "", // Flat install - no .opencode/ prefix
+					getScope: () => "profile",
 				}
 
 				await runAddCore(depRefs, { profile: profileName, quiet }, provider)

--- a/packages/cli/src/commands/registry.ts
+++ b/packages/cli/src/commands/registry.ts
@@ -10,8 +10,10 @@ import type { Command } from "commander"
 import kleur from "kleur"
 import { ProfileManager } from "../profile/manager"
 import { getProfileOcxConfig } from "../profile/paths"
-import type { RegistryConfig } from "../schemas/config"
-import { findOcxConfig, readOcxConfig, writeOcxConfig } from "../schemas/config"
+import { buildRegistryAuthConfig, type RegistryScope, resolveRegistryAuth } from "../registry/auth"
+import { fetchRegistryIndex, setInsecureTls } from "../registry/fetcher"
+import type { RegistryAuthConfig, RegistryConfig } from "../schemas/config"
+import { AUTH_REF_FIELDS, findOcxConfig, readOcxConfig, writeOcxConfig } from "../schemas/config"
 import { type DryRunResult, outputDryRun } from "../utils/dry-run"
 import {
 	ConfigError,
@@ -26,7 +28,9 @@ import { getGlobalConfigPath } from "../utils/paths"
 import {
 	addCommonOptions,
 	addGlobalOption,
+	addInsecureTlsOption,
 	addProfileOption,
+	addRegistryAuthOptions,
 	validateProfileName,
 } from "../utils/shared-options"
 import { normalizeRegistryUrl } from "../utils/url"
@@ -42,6 +46,33 @@ export interface RegistryOptions {
 export interface RegistryAddOptions extends RegistryOptions {
 	name: string // Always present — enforced by Commander .requiredOption()
 	dryRun?: boolean
+	// Persisted credential flags (parsed by buildRegistryAuthConfig in registry/auth.ts)
+	token?: string
+	tokenEnv?: string
+	tokenFile?: string
+	username?: string
+	password?: string
+	passwordEnv?: string
+	passwordFile?: string
+	insecureSkipTlsVerify?: boolean
+}
+
+type WriteScope = Exclude<RegistryScope, "ephemeral">
+
+/**
+ * A committed local config must not carry env/file credential references. Refuse to write them there
+ * (the runtime resolver would reject the config on read anyway — fail fast at write time instead).
+ */
+export function assertAuthPersistableInScope(auth: RegistryAuthConfig, scope: WriteScope): void {
+	if (scope !== "local") return
+	const refFields = AUTH_REF_FIELDS.filter((f) => auth[f] !== undefined)
+	if (refFields.length > 0) {
+		throw new ValidationError(
+			`Refusing to write ${refFields.join(", ")} to a committed local config (.opencode/ocx.jsonc). ` +
+				`Environment/file credential references are only honored in global or profile config. ` +
+				`Re-run with --global or --profile, or use a literal value (e.g. --token, or --username/--password).`,
+		)
+	}
 }
 
 // =============================================================================
@@ -92,12 +123,38 @@ export async function runRegistryAddCore(
 	const registries = callbacks.getRegistries()
 	const existingByName = registries[name]
 
+	// Build the credential block to persist (if any) and refuse env/file refs for local configs.
+	const authConfig = buildRegistryAuthConfig(options)
+	const writeScope: WriteScope = options.profile ? "profile" : options.global ? "global" : "local"
+	if (authConfig) assertAuthPersistableInScope(authConfig, writeScope)
+
+	// `--insecure-skip-tls-verify` is persisted as `insecure: true`. Unlike env/file credential
+	// refs, TLS-skip is not a secret and is allowed in any scope (including committed local config).
+	// It also applies to this command's own validation fetch below via the run-level toggle.
+	const insecure = options.insecureSkipTlsVerify === true
+	setInsecureTls(insecure)
+
+	// Anything to persist beyond the URL?
+	const hasCredentialChange = authConfig !== undefined || insecure
+
 	// URL uniqueness check: find any existing registry with the same normalized URL
 	const existingByUrl = findRegistryByUrl(registries, normalizedUrl)
 
-	// Fetch registry index to validate the URL serves a valid registry
-	const { fetchRegistryIndex } = await import("../registry/fetcher")
-	await fetchRegistryIndex(normalizedUrl)
+	// The fields to persist beyond the URL (used by both validation and the write rules below).
+	const persistedExtras = {
+		...(authConfig ? { auth: authConfig } : {}),
+		...(insecure ? { insecure: true } : {}),
+	}
+
+	// Fetch registry index to validate the URL serves a valid registry. For a private registry,
+	// auth comes from the credentials just provided (resolved at "ephemeral"/trusted scope), falling
+	// back to the OCX_REGISTRY_<NAME>_* env override — the alias is known here via --name.
+	const validationAuth = resolveRegistryAuth(
+		name,
+		{ url: normalizedUrl, ...persistedExtras },
+		"ephemeral",
+	)
+	await fetchRegistryIndex(normalizedUrl, validationAuth)
 
 	// -------------------------------------------------------------------------
 	// Conflict resolution matrix (alias-first model)
@@ -129,8 +186,15 @@ export async function runRegistryAddCore(
 		}
 
 		const isConflict = (nameExists && !sameUrl) || urlOwnedByDifferentName
-		const isIdempotent = nameExists && sameUrl
+		// Same name + same URL with new credentials/TLS settings updates the entry; otherwise no-op.
+		const isAuthUpdate = nameExists && sameUrl && hasCredentialChange
+		const isIdempotent = nameExists && sameUrl && !isAuthUpdate
 		const targetLabel = callbacks.targetLabel || "config"
+		const details = {
+			url: normalizedUrl,
+			...(authConfig ? { auth: authConfig.type } : {}),
+			...(insecure ? { insecure: true } : {}),
+		}
 
 		const dryRunResult: DryRunResult = {
 			dryRun: true,
@@ -139,11 +203,9 @@ export async function runRegistryAddCore(
 				? []
 				: [
 						{
-							action: "add",
+							action: isAuthUpdate ? "update" : "add",
 							target: `registry:${name}`,
-							details: {
-								url: normalizedUrl,
-							},
+							details,
 						},
 					],
 			validation: {
@@ -154,7 +216,9 @@ export async function runRegistryAddCore(
 				? `Would fail: conflict detected for registry '${name}'`
 				: isIdempotent
 					? `Registry '${name}' already configured with same URL (no-op)`
-					: `Would add registry '${name}' to ${targetLabel}`,
+					: isAuthUpdate
+						? `Would update credentials for registry '${name}' in ${targetLabel}`
+						: `Would add registry '${name}' to ${targetLabel}`,
 		}
 
 		return dryRunResult
@@ -176,15 +240,21 @@ export async function runRegistryAddCore(
 		)
 	}
 
-	// Rule 2: Same name + same URL => idempotent no-op
+	// Rule 2: Same name + same URL. Update stored credentials/TLS if provided; otherwise no-op.
 	if (nameExists && sameUrl) {
+		if (hasCredentialChange) {
+			await callbacks.setRegistry(name, {
+				...existingByName,
+				url: normalizedUrl,
+				...persistedExtras,
+			})
+			return { name, url: normalizedUrl, updated: true, alreadyConfigured: false }
+		}
 		return { name, url: normalizedUrl, updated: false, alreadyConfigured: true }
 	}
 
 	// Rule 1: New name + new URL => add
-	await callbacks.setRegistry(name, {
-		url: normalizedUrl,
-	})
+	await callbacks.setRegistry(name, { url: normalizedUrl, ...persistedExtras })
 
 	return { name, url: normalizedUrl, updated: false, alreadyConfigured: false }
 }
@@ -339,7 +409,12 @@ export function registerRegistryCommand(program: Command): void {
 	// registry add <url> --name <name>
 	const addCmd = registry
 		.command("add")
-		.description("Add a registry")
+		.description(
+			"Add a registry (optionally with credentials).\n\n" +
+				"  Public:  ocx registry add <url> --name <alias>\n" +
+				"  Bearer:  ocx registry add <url> --name <alias> --token-env TOKEN --global\n" +
+				"  Basic:   ocx registry add <url> --name <alias> --username ci --password-env PW --global",
+		)
 		.argument("<url>", "Registry URL")
 		.requiredOption(
 			"--name <name>",
@@ -349,6 +424,8 @@ export function registerRegistryCommand(program: Command): void {
 
 	addGlobalOption(addCmd)
 	addProfileOption(addCmd)
+	addRegistryAuthOptions(addCmd)
+	addInsecureTlsOption(addCmd)
 	addCommonOptions(addCmd)
 
 	addCmd.action(async (url: string, options: RegistryAddOptions, command: Command) => {

--- a/packages/cli/src/commands/search-core.ts
+++ b/packages/cli/src/commands/search-core.ts
@@ -3,7 +3,8 @@ import kleur from "kleur"
 import type { ConfigProvider } from "../config/provider"
 import { LocalConfigProvider } from "../config/provider"
 import { ConfigResolver } from "../config/resolver"
-import { fetchRegistryIndex } from "../registry/fetcher"
+import { createAuthResolver } from "../registry/auth"
+import { fetchRegistryIndex, setInsecureTls } from "../registry/fetcher"
 import { readReceipt } from "../schemas"
 import { outputJson } from "../utils/json-output"
 import { logger } from "../utils/logger"
@@ -14,6 +15,8 @@ export async function runSearchCommandAction(
 	query: string | undefined,
 	options: SearchOptions,
 ): Promise<void> {
+	setInsecureTls(Boolean(options.insecureSkipTlsVerify))
+
 	if (options.installed) {
 		const receipt = await readReceipt(options.cwd)
 		if (!receipt || Object.keys(receipt.installed).length === 0) {
@@ -53,6 +56,7 @@ export async function runSearchCommandAction(
 			cwd: resolver.getCwd(),
 			getRegistries: () => resolver.getRegistries(),
 			getComponentPath: () => resolver.getComponentPath(),
+			getScope: () => "profile",
 		}
 	} else {
 		provider = await LocalConfigProvider.requireInitialized(options.cwd)
@@ -67,6 +71,7 @@ export async function runSearchCore(
 	provider: ConfigProvider,
 ): Promise<void> {
 	const registries = provider.getRegistries()
+	const resolveAuth = createAuthResolver(registries, provider.getScope())
 
 	if (options.verbose) {
 		logger.info(`Searching in ${Object.keys(registries).length} registries...`)
@@ -93,7 +98,7 @@ export async function runSearchCore(
 			if (options.verbose) {
 				logger.info(`Fetching index from ${registryName} (${registryConfig.url})...`)
 			}
-			const index = await fetchRegistryIndex(registryConfig.url)
+			const index = await fetchRegistryIndex(registryConfig.url, resolveAuth(registryName))
 			if (options.verbose) {
 				logger.info(`Found ${index.components.length} components in ${registryName}`)
 			}

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander"
 import { InvalidArgumentError, Option } from "commander"
 import type { ConfigProvider } from "../config/provider"
 import { handleError } from "../utils/handle-error"
-import { addCommonOptions, addVerboseOption } from "../utils/shared-options"
+import { addCommonOptions, addInsecureTlsOption, addVerboseOption } from "../utils/shared-options"
 
 export interface SearchOptions {
 	cwd: string
@@ -12,6 +12,7 @@ export interface SearchOptions {
 	installed: boolean
 	limit: number
 	profile?: string
+	insecureSkipTlsVerify?: boolean
 }
 
 function parsePositiveInt(value: string): number {
@@ -35,6 +36,7 @@ export function registerSearchCommand(program: Command): void {
 
 	addCommonOptions(cmd)
 	addVerboseOption(cmd)
+	addInsecureTlsOption(cmd)
 
 	cmd.action(async (query: string | undefined, options: SearchOptions) => {
 		try {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -10,7 +10,8 @@ import { dirname, join } from "node:path"
 
 import type { Command } from "commander"
 import { type ConfigProvider, GlobalConfigProvider, LocalConfigProvider } from "../config/provider"
-import { fetchComponentVersion, fetchFileContent } from "../registry/fetcher"
+import { createAuthResolver } from "../registry/auth"
+import { fetchComponentVersion, fetchFileContent, setInsecureTls } from "../registry/fetcher"
 import { parseCanonicalId, type Receipt, readReceipt, writeReceipt } from "../schemas/config"
 import {
 	type ComponentFileObject,
@@ -24,7 +25,12 @@ import { logger } from "../utils/logger"
 import { resolveTargetPath } from "../utils/paths"
 import { registerPlannedWriteOrThrow } from "../utils/planned-writes"
 import { checkFileIntegrity, hashBundle, hashContent } from "../utils/receipt"
-import { addCommonOptions, addGlobalOption, addVerboseOption } from "../utils/shared-options"
+import {
+	addCommonOptions,
+	addGlobalOption,
+	addInsecureTlsOption,
+	addVerboseOption,
+} from "../utils/shared-options"
 import { createSpinner } from "../utils/spinner"
 
 // =============================================================================
@@ -40,6 +46,7 @@ export interface UpdateOptions {
 	quiet?: boolean
 	verbose?: boolean
 	json?: boolean
+	insecureSkipTlsVerify?: boolean
 }
 
 interface ComponentSpec {
@@ -109,6 +116,7 @@ export function registerUpdateCommand(program: Command): void {
 	addCommonOptions(cmd)
 	addVerboseOption(cmd)
 	addGlobalOption(cmd)
+	addInsecureTlsOption(cmd)
 
 	cmd
 		.option("--all", "Update all installed components")
@@ -116,6 +124,7 @@ export function registerUpdateCommand(program: Command): void {
 		.option("--dry-run", "Preview changes without applying")
 		.action(async (components: string[], options: UpdateOptions) => {
 			try {
+				setInsecureTls(Boolean(options.insecureSkipTlsVerify))
 				await runUpdate(components, options)
 			} catch (error) {
 				handleError(error, { json: options.json })
@@ -148,6 +157,9 @@ export async function runUpdateCore(
 	const registries = provider.getRegistries()
 	const componentPath = provider.getComponentPath()
 	const isFlattened = componentPath === "" || componentPath === "."
+
+	// Per-registry auth resolver (config `auth` block / OCX_REGISTRY_<ALIAS>_* env), scope-gated.
+	const resolveAuth = createAuthResolver(registries, provider.getScope())
 
 	// -------------------------------------------------------------------------
 	// Parse component specs (Law 2: Parse at boundary before any logic)
@@ -264,7 +276,8 @@ export async function runUpdateCore(
 			}
 
 			// Fetch component (latest version)
-			const fetchResult = await fetchComponentVersion(regConfig.url, componentName, undefined)
+			const auth = resolveAuth(registryName)
+			const fetchResult = await fetchComponentVersion(regConfig.url, componentName, undefined, auth)
 			const manifest = fetchResult.manifest
 
 			const normalizedManifest = normalizeComponentManifest(manifest)
@@ -272,7 +285,7 @@ export async function runUpdateCore(
 			// Fetch all files and compute hash
 			const files: { path: string; content: Buffer }[] = []
 			for (const file of normalizedManifest.files) {
-				const content = await fetchFileContent(regConfig.url, componentName, file.path)
+				const content = await fetchFileContent(regConfig.url, componentName, file.path, auth)
 				files.push({ path: file.path, content: Buffer.from(content) })
 			}
 

--- a/packages/cli/src/config/provider.ts
+++ b/packages/cli/src/config/provider.ts
@@ -9,6 +9,7 @@
  * Implementations parse config at construction; getters are sync and pure.
  */
 
+import type { RegistryScope } from "../registry/auth"
 import { type OcxConfig, type RegistryConfig, readOcxConfig } from "../schemas/config"
 import { ConfigError } from "../utils/errors"
 import { getGlobalConfigPath, globalDirectoryExists } from "../utils/paths"
@@ -30,6 +31,12 @@ export interface ConfigProvider {
 
 	/** Get component installation path */
 	getComponentPath(): string
+
+	/**
+	 * Config scope, used to gate credential resolution.
+	 * `local` is committed (untrusted); `global`/`profile` are user-owned (trusted).
+	 */
+	getScope(): RegistryScope
 }
 
 // =============================================================================
@@ -77,6 +84,10 @@ export class LocalConfigProvider implements ConfigProvider {
 	getComponentPath(): string {
 		// Default to .opencode directory for local projects
 		return ".opencode"
+	}
+
+	getScope(): RegistryScope {
+		return "local"
 	}
 }
 
@@ -130,5 +141,9 @@ export class GlobalConfigProvider implements ConfigProvider {
 	 */
 	getComponentPath(): string {
 		return ""
+	}
+
+	getScope(): RegistryScope {
+		return "global"
 	}
 }

--- a/packages/cli/src/registry/auth.ts
+++ b/packages/cli/src/registry/auth.ts
@@ -1,0 +1,380 @@
+/**
+ * Per-registry authentication resolution.
+ *
+ * Turns a registry's config (+ optional CLI flags for a `--from` registry) into the specific 
+ * request auth (headers + TLS policy) used by the fetcher. Credential precedence, per registry,
+ * for the `Authorization` header (first wins):
+ *
+ *   1. CLI flags        (only present for a one-off `--from <url>` registry)
+ *   2. Per-registry env  `OCX_REGISTRY_<ALIAS>_TOKEN` | `_BASIC` | `_TOKEN_FILE`
+ *   3. Config `auth`     block (literal always; env/file refs only in trusted scopes)
+ *   4. Config `headers`  raw `Authorization` (with `${ENV}` expansion, trusted scopes only)
+ *
+ * Literal credentials are honored in ANY config scope, but any dynamic
+ * credentials are only available in global configurations, to avoid credential
+ * stealing via untrusted repositories.
+ */
+
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import {
+	AUTH_REF_FIELDS,
+	type RegistryAuthConfig,
+	type RegistryConfig,
+	registryAuthConfigSchema,
+} from "../schemas/config"
+import { ConfigError, ValidationError } from "../utils/errors"
+
+/**
+ * Origin of a registry's configuration. Determines whether env/file references may be resolved.
+ * - `local`     → committed `.opencode/ocx.jsonc` (untrusted; literal-only)
+ * - `global`    → `~/.config/opencode/ocx.jsonc` (user-owned; trusted)
+ * - `profile`   → a global profile's ocx.jsonc (user-owned; trusted)
+ * - `ephemeral` → a `--from <url>` registry (CLI-invoked; trusted, auth comes from CLI flags)
+ */
+export type RegistryScope = "local" | "global" | "profile" | "ephemeral"
+
+/** Concrete auth applied to a single registry request. */
+export interface RequestAuth {
+	/** Headers to attach to the request (may include `Authorization`). */
+	headers?: Record<string, string>
+	/** When `false`, TLS certificate verification is skipped for this request. */
+	rejectUnauthorized?: boolean
+}
+
+/** CLI-provided auth for a single `--from` ephemeral registry (applied at highest precedence). */
+export interface CliAuth {
+	/** Structured credential built from the CLI flags (same shape as a config `auth` block). */
+	auth?: RegistryAuthConfig
+	/** Raw headers (`--auth-header "Name: Value"`, repeatable). */
+	headers?: Record<string, string>
+}
+
+/** The credential flags shared by `registry add` (persisted) and `add --from` (ephemeral). */
+export interface CredentialFlags {
+	token?: string
+	tokenEnv?: string
+	tokenFile?: string
+	username?: string
+	password?: string
+	passwordEnv?: string
+	passwordFile?: string
+}
+
+const ENV_REF = /\$\{([^}]+)\}/g
+
+function isTrustedScope(scope: RegistryScope): boolean {
+	return scope !== "local"
+}
+
+/** True if the string contains a `${VAR}` reference. */
+function hasEnvRef(value: string): boolean {
+	return /\$\{[^}]+\}/.test(value)
+}
+
+/** Replace every `${VAR}` with its env value; fail fast if any referenced var is unset. */
+function expandEnvRefs(value: string): string {
+	return value.replace(ENV_REF, (_match, name: string) => {
+		const resolved = process.env[name]
+		if (resolved === undefined) {
+			throw new ConfigError(
+				`Environment variable "${name}" referenced in registry config is not set.`,
+			)
+		}
+		return resolved
+	})
+}
+
+function requireEnv(name: string): string {
+	const value = process.env[name]
+	if (value === undefined || value === "") {
+		throw new ConfigError(
+			`Environment variable "${name}" (referenced in registry auth) is not set.`,
+		)
+	}
+	return value
+}
+
+function expandTilde(filePath: string): string {
+	if (filePath === "~") return homedir()
+	if (filePath.startsWith("~/")) return join(homedir(), filePath.slice(2))
+	return filePath
+}
+
+/** Read a credential from a file, trimming trailing whitespace/newline. */
+function readSecretFile(filePath: string): string {
+	try {
+		const contents = readFileSync(expandTilde(filePath), "utf8").trim()
+		if (!contents) {
+			throw new ConfigError(`Credential file "${filePath}" is empty.`)
+		}
+		return contents
+	} catch (error) {
+		if (error instanceof ConfigError) throw error
+		const reason = error instanceof Error ? error.message : String(error)
+		throw new ConfigError(`Failed to read credential file "${filePath}": ${reason}`)
+	}
+}
+
+function bearerHeader(token: string): Record<string, string> {
+	return { Authorization: `Bearer ${token}` }
+}
+
+function basicHeader(userpass: string): Record<string, string> {
+	return { Authorization: `Basic ${Buffer.from(userpass).toString("base64")}` }
+}
+
+/**
+ * Normalize a registry alias into the env-var segment used for per-registry overrides.
+ */
+export function normalizeAliasEnv(alias: string): string {
+	return alias.toUpperCase().replace(/[^A-Z0-9]/g, "_")
+}
+
+/**
+ * Guard: a committed local config must not carry env/file credential references,
+ * `${ENV}` expansion, or TLS-skip. Literal credentials are allowed.
+ */
+function assertLocalScopeSafe(alias: string, regConfig: RegistryConfig): void {
+	const problems: string[] = []
+
+	const auth = regConfig.auth
+	if (auth) {
+		for (const field of AUTH_REF_FIELDS) {
+			if (auth[field] !== undefined) problems.push(`auth.${field}`)
+		}
+	}
+
+	if (regConfig.headers) {
+		for (const [name, value] of Object.entries(regConfig.headers)) {
+			if (hasEnvRef(value)) problems.push(`headers.${name} (\${…} reference)`)
+		}
+	}
+
+	// A committed local config controls the alias, which selects OCX_REGISTRY_<ALIAS>_* env vars.
+	// If one is set, refuse rather than silently sending the victim's secret to this registry's URL.
+	const envKey = normalizeAliasEnv(alias)
+	for (const suffix of ["TOKEN", "TOKEN_FILE", "BASIC"] as const) {
+		if (process.env[`OCX_REGISTRY_${envKey}_${suffix}`]) {
+			problems.push(`the OCX_REGISTRY_${envKey}_${suffix} environment override`)
+		}
+	}
+
+	if (problems.length > 0) {
+		throw new ConfigError(
+			`Registry '${alias}' is defined in committed local config (.opencode/ocx.jsonc) but uses ` +
+				`${problems.join(", ")}. For security, environment/file credential references, ` +
+				`\${ENV} expansion are only honored in global or profile config. ` +
+				`Use a literal value here, or move this registry to your global (~/.config/opencode) ` +
+				`or profile config.`,
+		)
+	}
+}
+
+/** Resolve a credential from its three possible sources by precedence */
+function pickSecret(
+	literal: string | undefined,
+	envVar: string | undefined,
+	file: string | undefined,
+	trusted: boolean,
+): string | undefined {
+	if (literal !== undefined) return literal
+	if (trusted && envVar) return requireEnv(envVar)
+	if (trusted && file) return readSecretFile(file)
+	return undefined
+}
+
+/** Build an `Authorization` header from a config `auth` block, or null if no credential resolves. */
+function authFromConfig(auth: RegistryAuthConfig, trusted: boolean): Record<string, string> | null {
+	if (auth.type === "bearer") {
+		const token = pickSecret(auth.token, auth.tokenEnv, auth.tokenFile, trusted)
+		return token === undefined ? null : bearerHeader(token)
+	}
+
+	const password = pickSecret(auth.password, auth.passwordEnv, auth.passwordFile, trusted)
+	return password === undefined ? null : basicHeader(`${auth.username ?? ""}:${password}`)
+}
+
+/** Per-registry env override (`OCX_REGISTRY_<ALIAS>_*`), or null if none set. */
+function authFromEnvOverride(alias: string): Record<string, string> | null {
+	const key = normalizeAliasEnv(alias)
+
+	const token = process.env[`OCX_REGISTRY_${key}_TOKEN`]
+	if (token) return bearerHeader(token)
+
+	const tokenFile = process.env[`OCX_REGISTRY_${key}_TOKEN_FILE`]
+	if (tokenFile) return bearerHeader(readSecretFile(tokenFile))
+
+	const basic = process.env[`OCX_REGISTRY_${key}_BASIC`]
+	if (basic) return basicHeader(basic)
+
+	return null
+}
+
+/** Build headers from CLI flags (a `--from` ephemeral registry). CLI credentials are always trusted. */
+function authFromCli(cli: CliAuth): Record<string, string> {
+	const headers: Record<string, string> = { ...(cli.headers ?? {}) }
+	if (cli.auth) {
+		const authHeader = authFromConfig(cli.auth, true)
+		if (authHeader) Object.assign(headers, authHeader)
+	}
+	return headers
+}
+
+/**
+ * Build a {@link RegistryAuthConfig} from credential flags — shared by `registry add` (persisted)
+ * and the `add --from` CLI path. Enforces one scheme (bearer XOR basic); the schema enforces
+ * "exactly one source" per credential. Returns undefined when no credential flag was given.
+ */
+export function buildRegistryAuthConfig(flags: CredentialFlags): RegistryAuthConfig | undefined {
+	const bearerFlags = [
+		flags.token !== undefined ? "--token" : null,
+		flags.tokenEnv ? "--token-env" : null,
+		flags.tokenFile ? "--token-file" : null,
+	].filter((v): v is string => v !== null)
+
+	const basicFlags = [
+		flags.username ? "--username" : null,
+		flags.password !== undefined ? "--password" : null,
+		flags.passwordEnv ? "--password-env" : null,
+		flags.passwordFile ? "--password-file" : null,
+	].filter((v): v is string => v !== null)
+
+	if (bearerFlags.length === 0 && basicFlags.length === 0) return undefined
+
+	if (bearerFlags.length > 0 && basicFlags.length > 0) {
+		throw new ValidationError(
+			`Cannot combine Bearer (${bearerFlags.join(", ")}) and Basic (${basicFlags.join(", ")}) auth flags.`,
+		)
+	}
+
+	let candidate: Record<string, unknown>
+	if (bearerFlags.length > 0) {
+		candidate = { type: "bearer" }
+		if (flags.token !== undefined) candidate.token = flags.token
+		if (flags.tokenEnv) candidate.tokenEnv = flags.tokenEnv
+		if (flags.tokenFile) candidate.tokenFile = flags.tokenFile
+	} else {
+		candidate = { type: "basic" }
+		if (flags.username) candidate.username = flags.username
+		if (flags.password !== undefined) candidate.password = flags.password
+		if (flags.passwordEnv) candidate.passwordEnv = flags.passwordEnv
+		if (flags.passwordFile) candidate.passwordFile = flags.passwordFile
+	}
+
+	const parsed = registryAuthConfigSchema.safeParse(candidate)
+	if (!parsed.success) {
+		const issue = parsed.error.issues[0]
+		throw new ValidationError(`Invalid auth options: ${issue?.message ?? parsed.error.message}`)
+	}
+	return parsed.data
+}
+
+/**
+ * Resolve the request auth for a single registry.
+ *
+ * @param alias     Configured registry alias (used for env-override lookup).
+ * @param regConfig The registry's config entry.
+ * @param scope     Where the config came from (gates env/file expansion).
+ * @param cliAuth   CLI flags — only for a `--from` ephemeral registry.
+ */
+export function resolveRegistryAuth(
+	alias: string,
+	regConfig: RegistryConfig,
+	scope: RegistryScope,
+	cliAuth?: CliAuth,
+): RequestAuth {
+	const trusted = isTrustedScope(scope)
+
+	if (scope === "local") {
+		assertLocalScopeSafe(alias, regConfig)
+	}
+
+	// Applied lowest-precedence first so higher-precedence sources overwrite `Authorization`.
+	const headers: Record<string, string> = {}
+
+	// (4) Raw headers — `${ENV}` expanded only in trusted scopes (local guard forbids refs there).
+	if (regConfig.headers) {
+		for (const [name, value] of Object.entries(regConfig.headers)) {
+			headers[name] = trusted ? expandEnvRefs(value) : value
+		}
+	}
+
+	// (3) Config `auth` block.
+	if (regConfig.auth) {
+		const configAuth = authFromConfig(regConfig.auth, trusted)
+		if (configAuth) Object.assign(headers, configAuth)
+	}
+
+	// (2) Per-registry env override — trusted scopes only. In an untrusted committed local config
+	// the alias is attacker-controlled, so honoring OCX_REGISTRY_<ALIAS>_* here would let a cloned
+	// repo point a victim's env secret at an attacker URL (assertLocalScopeSafe already rejects this).
+	const envAuth = trusted ? authFromEnvOverride(alias) : null
+	if (envAuth) Object.assign(headers, envAuth)
+
+	// (1) CLI credential flags (ephemeral `--from` registry).
+	if (cliAuth) {
+		Object.assign(headers, authFromCli(cliAuth))
+	}
+
+	// Per-registry TLS-skip from config, honored in any scope (not a secret; the config author
+	// already owns the URL). The run-level `--insecure-skip-tls-verify` flag is applied separately
+	// (see createAuthResolver).
+	let rejectUnauthorized: boolean | undefined
+	if (regConfig.insecure) {
+		rejectUnauthorized = false
+	}
+
+	const result: RequestAuth = {}
+	if (Object.keys(headers).length > 0) result.headers = headers
+	if (rejectUnauthorized !== undefined) result.rejectUnauthorized = rejectUnauthorized
+	return result
+}
+
+/**
+ * Lazily resolves (and memoizes) the auth for a registry alias.
+ * Returns undefined for public registries or unknown aliases.
+ */
+export type AuthResolver = (alias: string) => RequestAuth | undefined
+
+/**
+ * Build a memoized {@link AuthResolver} over a set of registries at a given scope.
+ *
+ * Resolution is lazy: a registry's credentials (and any env/file lookups that can throw) are only
+ * evaluated when that alias is actually fetched — so an unrelated registry with an unset token env
+ * never breaks an unrelated install.
+ *
+ * @param opts.ephemeral When set, this alias is treated as a `--from` registry: resolved with scope
+ *                       `ephemeral` and the provided CLI flags instead of the shared `scope`.
+ *
+ * Note: run-level `--insecure-skip-tls-verify` is NOT handled here — it is a process-global toggle
+ * applied in the fetcher (see `setInsecureTls`). Per-registry `insecure: true` still flows through
+ * `resolveRegistryAuth`.
+ */
+export function createAuthResolver(
+	registries: Record<string, RegistryConfig>,
+	scope: RegistryScope,
+	opts?: { ephemeral?: { alias: string; cliAuth?: CliAuth } },
+): AuthResolver {
+	const memo = new Map<string, RequestAuth | undefined>()
+
+	return (alias: string) => {
+		if (memo.has(alias)) return memo.get(alias)
+
+		const regConfig = registries[alias]
+		let auth: RequestAuth | undefined
+		if (regConfig) {
+			const isEphemeral = opts?.ephemeral?.alias === alias
+			auth = resolveRegistryAuth(
+				alias,
+				regConfig,
+				isEphemeral ? "ephemeral" : scope,
+				isEphemeral ? opts?.ephemeral?.cliAuth : undefined,
+			)
+		}
+
+		memo.set(alias, auth)
+		return auth
+	}
+}

--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -23,9 +23,34 @@ import {
 } from "../utils/errors"
 import { isPlainObject } from "../utils/type-guards"
 import { normalizeRegistryUrl } from "../utils/url"
+import type { RequestAuth } from "./auth"
 
 // In-memory cache for deduplication
 const cache = new Map<string, Promise<unknown>>()
+
+/**
+ * Run-level TLS-skip (`--insecure-skip-tls-verify`). This is a process-global toggle set once by the
+ * active command — unlike per-registry auth, it is not alias-scoped, so it lives here rather than
+ * being threaded through every call. Per-registry `insecure: true` still comes via RequestAuth.
+ */
+let insecureTls = false
+export function setInsecureTls(value: boolean): void {
+	insecureTls = value
+}
+
+/**
+ * Build the Bun fetch init (headers + TLS policy) from resolved registry auth.
+ * Returns undefined when there is nothing to apply (keeps public-registry calls unchanged).
+ */
+function buildRequestInit(auth?: RequestAuth): BunFetchRequestInit | undefined {
+	const skipTls = insecureTls || auth?.rejectUnauthorized === false
+	const headers = auth?.headers
+	if (!headers && !skipTls) return undefined
+	const init: BunFetchRequestInit = {}
+	if (headers) init.headers = headers
+	if (skipTls) init.tls = { rejectUnauthorized: false }
+	return init
+}
 type RegistrySchemaMode = "legacy-v1" | "v2"
 const registrySchemaModeCache = new Map<string, RegistrySchemaMode>()
 
@@ -216,7 +241,10 @@ function hasLegacySignalsInManifest(manifest: unknown): boolean {
 	return false
 }
 
-async function resolveRegistrySchemaMode(baseUrl: string): Promise<RegistrySchemaMode | null> {
+async function resolveRegistrySchemaMode(
+	baseUrl: string,
+	auth?: RequestAuth,
+): Promise<RegistrySchemaMode | null> {
 	const normalizedBaseUrl = normalizeRegistryUrl(baseUrl)
 	const cachedMode = registrySchemaModeCache.get(normalizedBaseUrl)
 	if (cachedMode) {
@@ -224,7 +252,7 @@ async function resolveRegistrySchemaMode(baseUrl: string): Promise<RegistrySchem
 	}
 
 	try {
-		await fetchRegistryIndex(normalizedBaseUrl)
+		await fetchRegistryIndex(normalizedBaseUrl, auth)
 	} catch (error) {
 		if (error instanceof NetworkError || error instanceof NotFoundError) {
 			return null
@@ -421,6 +449,7 @@ async function fetchWithCache<T>(
 	options: {
 		phase?: string
 		requestUrl?: string
+		auth?: RequestAuth
 	} = {},
 ): Promise<T> {
 	const cached = cache.get(cacheKey)
@@ -438,7 +467,7 @@ async function fetchWithCache<T>(
 
 		let response: Response
 		try {
-			response = await fetch(requestUrl)
+			response = await fetch(requestUrl, buildRequestInit(options.auth))
 		} catch (error) {
 			throw new NetworkError(
 				`Network request failed for ${requestUrl}: ${error instanceof Error ? error.message : String(error)}`,
@@ -507,7 +536,10 @@ export function classifyRegistryIndexIssue(data: unknown): {
 /**
  * Fetch registry index
  */
-export async function fetchRegistryIndex(baseUrl: string): Promise<RegistryIndex> {
+export async function fetchRegistryIndex(
+	baseUrl: string,
+	auth?: RequestAuth,
+): Promise<RegistryIndex> {
 	const normalizedBaseUrl = normalizeRegistryUrl(baseUrl)
 	const url = `${normalizedBaseUrl}/index.json`
 
@@ -580,15 +612,19 @@ export async function fetchRegistryIndex(baseUrl: string): Promise<RegistryIndex
 			registrySchemaModeCache.set(normalizedBaseUrl, schemaMode)
 			return result.data
 		},
-		{ phase: "registry-index-fetch" },
+		{ phase: "registry-index-fetch", auth },
 	)
 }
 
 /**
  * Fetch a component from registry and return the latest manifest
  */
-export async function fetchComponent(baseUrl: string, name: string): Promise<ComponentManifest> {
-	const result = await fetchComponentVersion(baseUrl, name)
+export async function fetchComponent(
+	baseUrl: string,
+	name: string,
+	auth?: RequestAuth,
+): Promise<ComponentManifest> {
+	const result = await fetchComponentVersion(baseUrl, name, undefined, auth)
 	return result.manifest
 }
 
@@ -600,6 +636,7 @@ export async function fetchComponentVersion(
 	baseUrl: string,
 	name: string,
 	version?: string,
+	auth?: RequestAuth,
 ): Promise<{ manifest: ComponentManifest; version: string }> {
 	const url = `${normalizeRegistryUrl(baseUrl)}/components/${name}.json`
 
@@ -638,7 +675,7 @@ export async function fetchComponentVersion(
 			let manifestSchema = componentManifestSchema
 
 			if (hasLegacySignalsInManifest(manifest)) {
-				const schemaMode = await resolveRegistrySchemaMode(baseUrl)
+				const schemaMode = await resolveRegistrySchemaMode(baseUrl, auth)
 
 				if (schemaMode !== "v2") {
 					candidateManifest = adaptLegacyComponentManifest(manifest, context)
@@ -671,7 +708,7 @@ export async function fetchComponentVersion(
 
 			return { manifest: manifestResult.data, version: resolvedVersion }
 		},
-		{ phase: "packument-fetch", requestUrl: url },
+		{ phase: "packument-fetch", requestUrl: url, auth },
 	)
 }
 
@@ -682,6 +719,7 @@ export async function fetchFileContent(
 	baseUrl: string,
 	componentName: string,
 	filePath: string,
+	auth?: RequestAuth,
 ): Promise<string> {
 	const url = `${normalizeRegistryUrl(baseUrl)}/components/${componentName}/${filePath}`
 	const networkErrorContext = {
@@ -692,7 +730,7 @@ export async function fetchFileContent(
 
 	let response: Response
 	try {
-		response = await fetch(url)
+		response = await fetch(url, buildRequestInit(auth))
 	} catch (error) {
 		throw new NetworkError(
 			`Network request failed for ${url}: ${error instanceof Error ? error.message : String(error)}`,
@@ -717,8 +755,9 @@ export async function fetchFileContent(
 // Re-export types for convenience
 export type { ComponentManifest, McpServer, RegistryIndex }
 
-/** @internal Clear cache for testing purposes only */
+/** @internal Clear cache (and reset run-level TLS-skip) for testing purposes only */
 export function _clearFetcherCacheForTests(): void {
 	cache.clear()
 	registrySchemaModeCache.clear()
+	insecureTls = false
 }

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -14,6 +14,7 @@ import {
 	parseQualifiedComponent,
 } from "../schemas/registry"
 import { NetworkError, NotFoundError, OCXError, ValidationError } from "../utils/errors"
+import type { AuthResolver } from "./auth"
 import { fetchComponent } from "./fetcher"
 import { mergeOpencodeConfig } from "./merge"
 
@@ -73,6 +74,7 @@ export interface ResolvedDependencies {
 export async function resolveDependencies(
 	registries: Record<string, RegistryConfig>,
 	componentNames: string[],
+	resolveAuth?: AuthResolver,
 ): Promise<ResolvedDependencies> {
 	const resolved = new Map<string, ResolvedComponent>()
 	const visiting = new Set<string>()
@@ -111,7 +113,11 @@ export async function resolveDependencies(
 		// Fetch component from the specific registry
 		let component: ComponentManifest
 		try {
-			component = await fetchComponent(regConfig.url, componentName)
+			component = await fetchComponent(
+				regConfig.url,
+				componentName,
+				resolveAuth?.(componentNamespace),
+			)
 		} catch (err) {
 			// Re-throw network errors as-is (preserves exit code 69)
 			if (err instanceof NetworkError) {

--- a/packages/cli/src/schemas/config.ts
+++ b/packages/cli/src/schemas/config.ts
@@ -19,17 +19,93 @@ import { qualifiedComponentSchema } from "./registry"
 // =============================================================================
 
 /**
+ * Per-registry authentication block in ocx.jsonc.
+ *
+ * Credential precedence and security rules are enforced at resolution time in
+ * `src/registry/auth.ts` (not here). Key rules:
+ * - Literal `token`/`password` are allowed in ANY config scope.
+ * - Env/file references (`tokenEnv`, `tokenFile`, `passwordEnv`, `passwordFile`) are only
+ *   honored in user-owned scopes (global/profile), never in a committed local ocx.jsonc.
+ */
+export const registryAuthConfigSchema = object({
+	/** Auth scheme: "bearer" (Authorization: Bearer) or "basic" (Authorization: Basic) */
+	type: zEnum(["bearer", "basic"]),
+
+	// -- bearer sources (choose exactly one) --
+	/** Literal bearer token (allowed in any scope) */
+	token: string().optional(),
+	/** Name of the env var holding the bearer token (trusted scope only) */
+	tokenEnv: string().optional(),
+	/** Path to a file containing the bearer token (trusted scope only) */
+	tokenFile: string().optional(),
+
+	// -- basic sources --
+	/** Basic-auth username */
+	username: string().optional(),
+	/** Literal basic-auth password (allowed in any scope) */
+	password: string().optional(),
+	/** Name of the env var holding the basic-auth password (trusted scope only) */
+	passwordEnv: string().optional(),
+	/** Path to a file containing the basic-auth password (trusted scope only) */
+	passwordFile: string().optional(),
+}).superRefine((data, ctx) => {
+	if (data.type === "bearer") {
+		const sources = [data.token, data.tokenEnv, data.tokenFile].filter((v) => v !== undefined)
+		if (sources.length !== 1) {
+			ctx.addIssue('Bearer auth requires exactly one of "token", "tokenEnv", or "tokenFile".')
+		}
+		for (const field of ["username", "password", "passwordEnv", "passwordFile"] as const) {
+			if (data[field] !== undefined) {
+				ctx.addIssue(`"${field}" is not valid for bearer auth.`)
+			}
+		}
+		return
+	}
+
+	// basic
+	if (!data.username) {
+		ctx.addIssue('Basic auth requires "username".')
+	}
+	const passwordSources = [data.password, data.passwordEnv, data.passwordFile].filter(
+		(v) => v !== undefined,
+	)
+	if (passwordSources.length !== 1) {
+		ctx.addIssue('Basic auth requires exactly one of "password", "passwordEnv", or "passwordFile".')
+	}
+	for (const field of ["token", "tokenEnv", "tokenFile"] as const) {
+		if (data[field] !== undefined) {
+			ctx.addIssue(`"${field}" is not valid for basic auth.`)
+		}
+	}
+})
+
+export type RegistryAuthConfig = ZodInfer<typeof registryAuthConfigSchema>
+
+/**
  * Registry configuration in ocx.jsonc
  */
 export const registryConfigSchema = object({
 	/** Registry URL */
 	url: string().url("Registry URL must be a valid URL"),
 
-	/** Optional auth headers (supports ${ENV_VAR} expansion) */
+	/** Optional raw auth headers (supports ${ENV_VAR} expansion in trusted scopes) */
 	headers: record(string(), string()).optional(),
+
+	/** Structured per-registry authentication */
+	auth: registryAuthConfigSchema.optional(),
+
+	/** Skip TLS certificate verification for this registry (trusted scope only) */
+	insecure: boolean().optional(),
 })
 
 export type RegistryConfig = ZodInfer<typeof registryConfigSchema>
+
+/**
+ * Auth fields that reference a secret indirectly (an env-var name or a file path) rather than
+ * holding a literal. These are only honored in user-owned (global/profile) config — the local-scope
+ * read guard and the `registry add` write guard both key off this list.
+ */
+export const AUTH_REF_FIELDS = ["tokenEnv", "tokenFile", "passwordEnv", "passwordFile"] as const
 
 /**
  * Main OCX config schema (ocx.jsonc)

--- a/packages/cli/src/utils/shared-options.ts
+++ b/packages/cli/src/utils/shared-options.ts
@@ -7,7 +7,9 @@
  */
 
 import { Option } from "commander"
-import { InvalidProfileNameError } from "./errors"
+import { buildRegistryAuthConfig, type CliAuth } from "../registry/auth"
+import { InvalidProfileNameError, ValidationError } from "./errors"
+import { logger } from "./logger"
 
 // =============================================================================
 // OPTION FACTORIES
@@ -85,6 +87,131 @@ export function addGlobalOption<T extends { addOption: (opt: Option) => T }>(cmd
  */
 export function addProfileOption<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
 	return cmd.addOption(sharedOptions.profile())
+}
+
+// =============================================================================
+// REGISTRY CREDENTIAL OPTIONS (shared by `registry add` and `add --from`)
+// =============================================================================
+
+/**
+ * Credential flags for authenticating to a registry — the same vocabulary whether the credential is
+ * persisted (`registry add`) or applied to a one-off ephemeral registry (`add --from`). Bearer and
+ * Basic each expose the secret as a literal, an env var, or a file; env/file references are only
+ * honored in trusted scopes (enforced at resolution time, see registry/auth.ts).
+ */
+const credentialOptions = {
+	token: () => new Option("--token <token>", "Bearer token (literal)"),
+	tokenEnv: () => new Option("--token-env <name>", "Bearer token from an env var"),
+	tokenFile: () => new Option("--token-file <path>", "Bearer token from a file"),
+	username: () => new Option("--username <user>", "HTTP Basic username"),
+	password: () => new Option("--password <pass>", "HTTP Basic password (literal)"),
+	passwordEnv: () => new Option("--password-env <name>", "HTTP Basic password from an env var"),
+	passwordFile: () => new Option("--password-file <path>", "HTTP Basic password from a file"),
+}
+
+function addCredentialOptions<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
+	return cmd
+		.addOption(credentialOptions.token())
+		.addOption(credentialOptions.tokenEnv())
+		.addOption(credentialOptions.tokenFile())
+		.addOption(credentialOptions.username())
+		.addOption(credentialOptions.password())
+		.addOption(credentialOptions.passwordEnv())
+		.addOption(credentialOptions.passwordFile())
+}
+
+/** Add the persisted-credential options to `registry add`. */
+export function addRegistryAuthOptions<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
+	return addCredentialOptions(cmd)
+}
+
+/** Add the credential options (plus a raw `--auth-header` escape hatch) for a `--from` registry. */
+export function addAuthOptions<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
+	return addCredentialOptions(cmd).addOption(
+		new Option("--auth-header <header>", 'Extra "Name: Value" header for the --from registry')
+			.argParser((value: string, previous: string[] = []) => [...previous, value])
+			.default([] as string[]),
+	)
+}
+
+/**
+ * Run-level `--insecure-skip-tls-verify` for any command that fetches from a registry. When set,
+ * TLS certificate verification is skipped for every registry request that command makes.
+ */
+export function addInsecureTlsOption<T extends { addOption: (opt: Option) => T }>(cmd: T): T {
+	return cmd.addOption(
+		new Option(
+			"--insecure-skip-tls-verify",
+			"Skip TLS certificate verification for registry requests",
+		),
+	)
+}
+
+/** Parsed shape of the auth options (as Commander camelCases them). */
+export interface CliAuthOptions {
+	token?: string
+	tokenEnv?: string
+	tokenFile?: string
+	username?: string
+	password?: string
+	passwordEnv?: string
+	passwordFile?: string
+	authHeader?: string[]
+	insecureSkipTlsVerify?: boolean
+	/** The `--from` URL, if any — auth flags require it. */
+	from?: string
+}
+
+function parseAuthHeaders(raw?: string[]): Record<string, string> | undefined {
+	if (!raw || raw.length === 0) return undefined
+	const headers: Record<string, string> = {}
+	for (const entry of raw) {
+		const idx = entry.indexOf(":")
+		if (idx === -1) {
+			throw new ValidationError(`Invalid --auth-header "${entry}". Expected "Name: Value".`)
+		}
+		const name = entry.slice(0, idx).trim()
+		const value = entry.slice(idx + 1).trim()
+		if (!name) {
+			throw new ValidationError(`Invalid --auth-header "${entry}": header name is empty.`)
+		}
+		headers[name] = value
+	}
+	return headers
+}
+
+/**
+ * Convert parsed CLI auth options into a {@link CliAuth}, or undefined when no auth flag was given.
+ * Reuses the shared credential parser; enforces that auth flags require `--from`; warns on a literal
+ * `--token`/`--password` (argv/history exposure).
+ */
+export function resolveCliAuth(options: CliAuthOptions): CliAuth | undefined {
+	const auth = buildRegistryAuthConfig(options)
+	const headers = parseAuthHeaders(options.authHeader)
+
+	if (auth === undefined && headers === undefined) {
+		return undefined
+	}
+
+	if (!options.from) {
+		throw new ValidationError(
+			"Authentication flags (--token(-env|-file), --username, --password(-env|-file), " +
+				"--auth-header) require --from <url>. For configured registries, use the registry's " +
+				"`auth` block in ocx.jsonc or OCX_REGISTRY_<ALIAS>_TOKEN.",
+		)
+	}
+
+	if (options.token !== undefined || options.password !== undefined) {
+		logger.warn(
+			"Passing a literal --token/--password exposes it in your shell history and process list. " +
+				"Prefer the --*-env or --*-file variants.",
+		)
+	}
+
+	const cli: CliAuth = {}
+	if (auth) cli.auth = auth
+	if (headers) cli.headers = headers
+	return cli
 }
 
 // =============================================================================

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -860,6 +860,7 @@ describe("ocx add --json mixed-input contract", () => {
 			cwd: testDir,
 			getRegistries: () => ({ kdco: { url: registry.url } }),
 			getComponentPath: () => ".opencode/components",
+			getScope: () => "local" as const,
 		}
 
 		await runAddCore(
@@ -922,6 +923,7 @@ describe("ocx add --json mixed-input contract", () => {
 			cwd: testDir,
 			getRegistries: () => ({}),
 			getComponentPath: () => ".opencode/components",
+			getScope: () => "local" as const,
 		}
 
 		await runAddCore(["npm:new-plugin"], { quiet: true, trust: true }, provider)
@@ -972,6 +974,7 @@ describe("ocx add --json mixed-input contract", () => {
 			cwd: testDir,
 			getRegistries: () => ({ kdco: { url: registry.url } }),
 			getComponentPath: () => ".opencode/components",
+			getScope: () => "local" as const,
 		}
 
 		let thrownError: unknown

--- a/packages/cli/tests/registry-add-auth.test.ts
+++ b/packages/cli/tests/registry-add-auth.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for `registry add` credential persistence:
+ * building the auth block from flags, and refusing env/file refs in local scope.
+ */
+
+import { describe, expect, it } from "bun:test"
+import { assertAuthPersistableInScope } from "../src/commands/registry"
+import { buildRegistryAuthConfig } from "../src/registry/auth"
+import type { RegistryAuthConfig } from "../src/schemas/config"
+
+describe("buildRegistryAuthConfig", () => {
+	it("returns undefined when no credential flags are given", () => {
+		expect(buildRegistryAuthConfig({})).toBeUndefined()
+	})
+
+	it("builds a literal bearer block", () => {
+		expect(buildRegistryAuthConfig({ token: "abc" })).toEqual({ type: "bearer", token: "abc" })
+	})
+
+	it("builds bearer env and file blocks", () => {
+		expect(buildRegistryAuthConfig({ tokenEnv: "T" })).toEqual({ type: "bearer", tokenEnv: "T" })
+		expect(buildRegistryAuthConfig({ tokenFile: "/p" })).toEqual({
+			type: "bearer",
+			tokenFile: "/p",
+		})
+	})
+
+	it("builds a literal basic block from --username + --password", () => {
+		expect(buildRegistryAuthConfig({ username: "admin", password: "secret" })).toEqual({
+			type: "basic",
+			username: "admin",
+			password: "secret",
+		})
+	})
+
+	it("builds basic from --username + --password-env / --password-file", () => {
+		expect(buildRegistryAuthConfig({ username: "ci", passwordEnv: "PW" })).toEqual({
+			type: "basic",
+			username: "ci",
+			passwordEnv: "PW",
+		})
+		expect(buildRegistryAuthConfig({ username: "ci", passwordFile: "/run/secrets/pw" })).toEqual({
+			type: "basic",
+			username: "ci",
+			passwordFile: "/run/secrets/pw",
+		})
+	})
+
+	it("rejects mixing bearer and basic flags", () => {
+		expect(() => buildRegistryAuthConfig({ token: "a", username: "u" })).toThrow(/Cannot combine/)
+	})
+
+	it("rejects two bearer sources (schema: exactly one)", () => {
+		expect(() => buildRegistryAuthConfig({ token: "a", tokenEnv: "B" })).toThrow(/exactly one/)
+	})
+
+	it("rejects two password sources (schema: exactly one)", () => {
+		expect(() =>
+			buildRegistryAuthConfig({ username: "u", password: "p", passwordEnv: "PW" }),
+		).toThrow(/exactly one/)
+	})
+
+	it("rejects basic without a username", () => {
+		expect(() => buildRegistryAuthConfig({ passwordEnv: "PW" })).toThrow()
+	})
+})
+
+describe("assertAuthPersistableInScope", () => {
+	const bearerEnv: RegistryAuthConfig = { type: "bearer", tokenEnv: "T" }
+	const bearerLiteral: RegistryAuthConfig = { type: "bearer", token: "t" }
+	const basicFile: RegistryAuthConfig = { type: "basic", username: "u", passwordFile: "/p" }
+	const basicLiteral: RegistryAuthConfig = { type: "basic", username: "u", password: "p" }
+
+	it("refuses env/file references in local scope", () => {
+		expect(() => assertAuthPersistableInScope(bearerEnv, "local")).toThrow(/committed local config/)
+		expect(() => assertAuthPersistableInScope(basicFile, "local")).toThrow(/committed local config/)
+	})
+
+	it("allows literal credentials in local scope", () => {
+		expect(() => assertAuthPersistableInScope(bearerLiteral, "local")).not.toThrow()
+		expect(() => assertAuthPersistableInScope(basicLiteral, "local")).not.toThrow()
+	})
+
+	it("allows env/file references in global and profile scope", () => {
+		expect(() => assertAuthPersistableInScope(bearerEnv, "global")).not.toThrow()
+		expect(() => assertAuthPersistableInScope(basicFile, "profile")).not.toThrow()
+	})
+})

--- a/packages/cli/tests/registry-auth.test.ts
+++ b/packages/cli/tests/registry-auth.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for per-registry authentication resolution and fetcher threading.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+	type CliAuth,
+	createAuthResolver,
+	normalizeAliasEnv,
+	resolveRegistryAuth,
+} from "../src/registry/auth"
+import {
+	_clearFetcherCacheForTests,
+	fetchRegistryIndex,
+	setInsecureTls,
+} from "../src/registry/fetcher"
+import type { RegistryConfig } from "../src/schemas/config"
+
+const b64 = (value: string) => Buffer.from(value).toString("base64")
+
+// Snapshot/restore only the env keys a test touches.
+function withEnv(vars: Record<string, string | undefined>, fn: () => void): void {
+	const previous: Record<string, string | undefined> = {}
+	for (const key of Object.keys(vars)) previous[key] = process.env[key]
+	try {
+		for (const [key, value] of Object.entries(vars)) {
+			if (value === undefined) delete process.env[key]
+			else process.env[key] = value
+		}
+		fn()
+	} finally {
+		for (const [key, value] of Object.entries(previous)) {
+			if (value === undefined) delete process.env[key]
+			else process.env[key] = value
+		}
+	}
+}
+
+describe("resolveRegistryAuth — bearer", () => {
+	it("uses a literal token in any scope", () => {
+		const cfg: RegistryConfig = { url: "https://r", auth: { type: "bearer", token: "abc" } }
+		expect(resolveRegistryAuth("r", cfg, "local").headers).toEqual({ Authorization: "Bearer abc" })
+		expect(resolveRegistryAuth("r", cfg, "global").headers).toEqual({ Authorization: "Bearer abc" })
+	})
+
+	it("resolves tokenEnv in a trusted scope", () => {
+		const cfg: RegistryConfig = { url: "https://r", auth: { type: "bearer", tokenEnv: "MY_TOK" } }
+		withEnv({ MY_TOK: "secret" }, () => {
+			expect(resolveRegistryAuth("r", cfg, "global").headers).toEqual({
+				Authorization: "Bearer secret",
+			})
+		})
+	})
+
+	it("throws when tokenEnv is unset", () => {
+		const cfg: RegistryConfig = {
+			url: "https://r",
+			auth: { type: "bearer", tokenEnv: "MISSING_TOK" },
+		}
+		withEnv({ MISSING_TOK: undefined }, () => {
+			expect(() => resolveRegistryAuth("r", cfg, "global")).toThrow(/MISSING_TOK/)
+		})
+	})
+
+	it("reads tokenFile and trims trailing newline", () => {
+		const dir = mkdtempSync(join(tmpdir(), "ocx-auth-"))
+		try {
+			const file = join(dir, "token")
+			writeFileSync(file, "file-token\n")
+			const cfg: RegistryConfig = { url: "https://r", auth: { type: "bearer", tokenFile: file } }
+			expect(resolveRegistryAuth("r", cfg, "profile").headers).toEqual({
+				Authorization: "Bearer file-token",
+			})
+		} finally {
+			rmSync(dir, { recursive: true, force: true })
+		}
+	})
+})
+
+describe("resolveRegistryAuth — basic", () => {
+	it("encodes literal user:pass as base64", () => {
+		const cfg: RegistryConfig = {
+			url: "https://r",
+			auth: { type: "basic", username: "ci", password: "pw" },
+		}
+		expect(resolveRegistryAuth("r", cfg, "local").headers).toEqual({
+			Authorization: `Basic ${b64("ci:pw")}`,
+		})
+	})
+
+	it("resolves passwordEnv in a trusted scope", () => {
+		const cfg: RegistryConfig = {
+			url: "https://r",
+			auth: { type: "basic", username: "ci", passwordEnv: "MY_PW" },
+		}
+		withEnv({ MY_PW: "s3cret" }, () => {
+			expect(resolveRegistryAuth("r", cfg, "global").headers).toEqual({
+				Authorization: `Basic ${b64("ci:s3cret")}`,
+			})
+		})
+	})
+})
+
+describe("resolveRegistryAuth — local-scope security guard", () => {
+	it("rejects env/file references in committed local config", () => {
+		const cfg: RegistryConfig = { url: "https://r", auth: { type: "bearer", tokenEnv: "X" } }
+		expect(() => resolveRegistryAuth("r", cfg, "local")).toThrow(/committed local config/)
+	})
+
+	it("rejects env-var expansion in local headers", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: intentionally a literal ${ENV} reference
+		const cfg: RegistryConfig = { url: "https://r", headers: { Authorization: "Bearer ${X}" } }
+		expect(() => resolveRegistryAuth("r", cfg, "local")).toThrow(/committed local config/)
+	})
+
+	it("rejects an OCX_REGISTRY_<ALIAS>_* env override for a local-config alias (exfil guard)", () => {
+		// A cloned/malicious repo controls the alias + URL; it must not be able to send the
+		// victim's env-var secret to its own registry URL.
+		const cfg: RegistryConfig = { url: "https://attacker.example" }
+		withEnv({ OCX_REGISTRY_R_TOKEN: "victim-secret" }, () => {
+			expect(() => resolveRegistryAuth("r", cfg, "local")).toThrow(/OCX_REGISTRY_R_TOKEN/)
+		})
+	})
+
+	it("does not attach an env override in local scope (no leak) when it does not error", () => {
+		// Sanity: with no env override set, a bare local registry resolves to no auth at all.
+		const cfg: RegistryConfig = { url: "https://attacker.example" }
+		withEnv({ OCX_REGISTRY_R_TOKEN: undefined }, () => {
+			expect(resolveRegistryAuth("r", cfg, "local").headers).toBeUndefined()
+		})
+	})
+
+	it("allows literal credentials and literal headers in local config", () => {
+		const cfg: RegistryConfig = {
+			url: "https://r",
+			auth: { type: "bearer", token: "abc" },
+			headers: { "X-Extra": "value" },
+		}
+		const auth = resolveRegistryAuth("r", cfg, "local")
+		expect(auth.headers).toEqual({ "X-Extra": "value", Authorization: "Bearer abc" })
+	})
+})
+
+describe("resolveRegistryAuth — headers & env expansion", () => {
+	it("expands env references in headers in trusted scopes", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: intentionally a literal ${ENV} reference
+		const cfg: RegistryConfig = { url: "https://r", headers: { "X-Api-Key": "${API_KEY}" } }
+		withEnv({ API_KEY: "k123" }, () => {
+			expect(resolveRegistryAuth("r", cfg, "global").headers).toEqual({ "X-Api-Key": "k123" })
+		})
+	})
+
+	it("auth block overrides raw headers Authorization", () => {
+		const cfg: RegistryConfig = {
+			url: "https://r",
+			headers: { Authorization: "Bearer raw" },
+			auth: { type: "bearer", token: "block" },
+		}
+		expect(resolveRegistryAuth("r", cfg, "global").headers?.Authorization).toBe("Bearer block")
+	})
+})
+
+describe("resolveRegistryAuth — precedence", () => {
+	it("env override beats the config auth block", () => {
+		const cfg: RegistryConfig = { url: "https://r", auth: { type: "bearer", token: "fromConfig" } }
+		withEnv({ OCX_REGISTRY_R_TOKEN: "fromEnv" }, () => {
+			expect(resolveRegistryAuth("r", cfg, "global").headers?.Authorization).toBe("Bearer fromEnv")
+		})
+	})
+
+	it("CLI flags beat the env override for a --from registry", () => {
+		const cfg: RegistryConfig = { url: "https://r" }
+		const cli: CliAuth = { auth: { type: "bearer", token: "fromCli" } }
+		withEnv({ OCX_REGISTRY_R_TOKEN: "fromEnv" }, () => {
+			expect(resolveRegistryAuth("r", cfg, "ephemeral", cli).headers?.Authorization).toBe(
+				"Bearer fromCli",
+			)
+		})
+	})
+
+	it("env override supports OCX_REGISTRY_<ALIAS>_BASIC", () => {
+		const cfg: RegistryConfig = { url: "https://r" }
+		withEnv({ OCX_REGISTRY_R_BASIC: "u:p" }, () => {
+			expect(resolveRegistryAuth("r", cfg, "global").headers?.Authorization).toBe(
+				`Basic ${b64("u:p")}`,
+			)
+		})
+	})
+})
+
+describe("resolveRegistryAuth — TLS", () => {
+	it("honors config insecure in a trusted scope", () => {
+		const cfg: RegistryConfig = { url: "https://r", insecure: true }
+		expect(resolveRegistryAuth("r", cfg, "global").rejectUnauthorized).toBe(false)
+	})
+
+	it("honors config insecure in local scope (not a secret; author owns the URL)", () => {
+		const cfg: RegistryConfig = { url: "https://r", insecure: true }
+		expect(resolveRegistryAuth("r", cfg, "local").rejectUnauthorized).toBe(false)
+	})
+})
+
+describe("resolveRegistryAuth — public registry", () => {
+	it("returns no headers when nothing is configured", () => {
+		const auth = resolveRegistryAuth("r", { url: "https://r" }, "local")
+		expect(auth.headers).toBeUndefined()
+		expect(auth.rejectUnauthorized).toBeUndefined()
+	})
+})
+
+describe("createAuthResolver", () => {
+	it("is lazy — an unrelated registry with a bad env ref does not break others", () => {
+		const registries: Record<string, RegistryConfig> = {
+			good: { url: "https://good", auth: { type: "bearer", token: "ok" } },
+			bad: { url: "https://bad", auth: { type: "bearer", tokenEnv: "UNSET_XYZ" } },
+		}
+		withEnv({ UNSET_XYZ: undefined }, () => {
+			const resolve = createAuthResolver(registries, "global")
+			expect(resolve("good")?.headers?.Authorization).toBe("Bearer ok")
+			expect(() => resolve("bad")).toThrow(/UNSET_XYZ/)
+		})
+	})
+
+	it("applies CLI auth only to the ephemeral alias", () => {
+		const registries: Record<string, RegistryConfig> = {
+			cfg: { url: "https://cfg", auth: { type: "bearer", token: "cfgTok" } },
+			eph: { url: "https://eph" },
+		}
+		const resolve = createAuthResolver(registries, "local", {
+			ephemeral: { alias: "eph", cliAuth: { auth: { type: "bearer", token: "cliTok" } } },
+		})
+		expect(resolve("cfg")?.headers?.Authorization).toBe("Bearer cfgTok")
+		expect(resolve("eph")?.headers?.Authorization).toBe("Bearer cliTok")
+	})
+
+	it("returns undefined for unknown aliases", () => {
+		const resolve = createAuthResolver({}, "global")
+		expect(resolve("nope")).toBeUndefined()
+	})
+})
+
+describe("normalizeAliasEnv", () => {
+	it("uppercases and replaces non-alphanumerics with underscore", () => {
+		expect(normalizeAliasEnv("my-reg")).toBe("MY_REG")
+		expect(normalizeAliasEnv("my.reg")).toBe("MY_REG")
+		expect(normalizeAliasEnv("acme")).toBe("ACME")
+	})
+})
+
+describe("fetcher threading", () => {
+	beforeEach(() => _clearFetcherCacheForTests())
+	afterEach(() => _clearFetcherCacheForTests())
+
+	const okIndex = () =>
+		new Response(JSON.stringify({ author: "test", components: [] }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		})
+
+	it("passes the Authorization header to fetch", async () => {
+		const fetchSpy = spyOn(global, "fetch").mockResolvedValue(okIndex())
+		try {
+			await fetchRegistryIndex("https://reg.example.com", {
+				headers: { Authorization: "Bearer T" },
+			})
+			const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+			expect((init?.headers as Record<string, string>)?.Authorization).toBe("Bearer T")
+		} finally {
+			fetchSpy.mockRestore()
+		}
+	})
+
+	it("passes tls.rejectUnauthorized:false to fetch when insecure", async () => {
+		const fetchSpy = spyOn(global, "fetch").mockResolvedValue(okIndex())
+		try {
+			await fetchRegistryIndex("https://reg.example.com", { rejectUnauthorized: false })
+			const init = fetchSpy.mock.calls[0]?.[1] as
+				| { tls?: { rejectUnauthorized?: boolean } }
+				| undefined
+			expect(init?.tls?.rejectUnauthorized).toBe(false)
+		} finally {
+			fetchSpy.mockRestore()
+		}
+	})
+
+	it("run-level setInsecureTls forces tls.rejectUnauthorized:false even without per-registry auth", async () => {
+		const fetchSpy = spyOn(global, "fetch").mockResolvedValue(okIndex())
+		try {
+			setInsecureTls(true)
+			await fetchRegistryIndex("https://reg.example.com")
+			const init = fetchSpy.mock.calls[0]?.[1] as
+				| { tls?: { rejectUnauthorized?: boolean } }
+				| undefined
+			expect(init?.tls?.rejectUnauthorized).toBe(false)
+		} finally {
+			setInsecureTls(false)
+			fetchSpy.mockRestore()
+		}
+	})
+
+	it("sends no init for a public (no-auth) request", async () => {
+		const fetchSpy = spyOn(global, "fetch").mockResolvedValue(okIndex())
+		try {
+			await fetchRegistryIndex("https://reg.example.com")
+			expect(fetchSpy.mock.calls[0]?.[1]).toBeUndefined()
+		} finally {
+			fetchSpy.mockRestore()
+		}
+	})
+
+	it("does not cache a 401 as success", async () => {
+		const fetchSpy = spyOn(global, "fetch").mockResolvedValue(
+			new Response("nope", { status: 401, statusText: "Unauthorized" }),
+		)
+		try {
+			await expect(fetchRegistryIndex("https://reg.example.com")).rejects.toThrow()
+			await expect(fetchRegistryIndex("https://reg.example.com")).rejects.toThrow()
+			// A cached failure would have short-circuited the second call.
+			expect(fetchSpy.mock.calls.length).toBe(2)
+		} finally {
+			fetchSpy.mockRestore()
+		}
+	})
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds per-registry authentication (Bearer and Basic) across all registry operations with a secure config model and TLS controls. Credentials can be set via config `auth`, per-registry env overrides, or CLI flags for one-off `--from` installs; docs and schemas updated.

- **New Features**
  - Auth precedence per registry: CLI `--from` flags > `OCX_REGISTRY_<ALIAS>_{TOKEN|TOKEN_FILE|BASIC}` > config `auth` > raw `headers`. Applied to all requests (index, component, files) in `add`, `update`, `search`, and `profile add`.
  - `registry add` can persist credentials (`--token*`, `--username` + `--password*`) and validates private registries with those creds; `--insecure-skip-tls-verify` supported and persisted as `insecure: true`.
  - `add --from` supports `--token*`, `--username`/`--password*`, and `--auth-header`; all fetch commands also accept `--insecure-skip-tls-verify`.
  - Security model: local `ocx.jsonc` only allows literal creds; env/file refs and env overrides are honored only in global/profile to prevent token exfiltration by untrusted repos.
  - Docs: new “Registry Authentication” guide; protocol and CLI docs updated; schemas extended with `auth`, `headers` notes, and `insecure`.

<sup>Written for commit 461775f914d250666d47c7a34839bd07416bb63a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

