### PR TITLE
fix(registry): keep kitty launch script alive until the new tab reads it

### DIFF
--- a/workers/kdco-registry/files/plugins/worktree/terminal.ts
+++ b/workers/kdco-registry/files/plugins/worktree/terminal.ts
@@ -617,27 +617,10 @@ export async function openMacOSTerminal(cwd: string, argv?: string[]): Promise<T
 			// DO NOT use withTempScript for these - the finally block would delete
 			// the script before the detached process reads it
 			case "kitty": {
-				// Try kitty @ remote control first (synchronous, can use withTempScript)
-				const remoteResult = await withTempScript(scriptContent, async (scriptPath) => {
-					const result = Bun.spawnSync([
-						"kitty",
-						"@",
-						"launch",
-						"--type",
-						"tab",
-						"--cwd",
-						cwd,
-						"--",
-						"bash",
-						scriptPath,
-					])
-					return result.exitCode === 0
-				})
-				if (remoteResult) {
-					return { success: true }
-				}
-
-				// Fallback: new window (detached) - write script directly
+				// kitty @ launch only blocks until kitty accepts the request, NOT until
+				// the spawned bash reads the script. Write the script directly and rely
+				// on its trap-based self-cleanup - withTempScript would race and delete
+				// the script before bash reads it, silently killing the new tab.
 				detachedScriptPath = path.join(
 					getTempDir(),
 					`worktree-${Date.now()}-${Math.random().toString(36).slice(2)}.sh`,
@@ -645,6 +628,24 @@ export async function openMacOSTerminal(cwd: string, argv?: string[]): Promise<T
 				await Bun.write(detachedScriptPath, scriptContent)
 				await fs.chmod(detachedScriptPath, 0o755)
 
+				const remoteResult = Bun.spawnSync([
+					"kitty",
+					"@",
+					"launch",
+					"--type",
+					"tab",
+					"--cwd",
+					cwd,
+					"--",
+					"bash",
+					detachedScriptPath,
+				])
+				if (remoteResult.exitCode === 0) {
+					detachedScriptPath = null // Clear - script self-cleans via trap
+					return { success: true }
+				}
+
+				// Fallback: new window (detached)
 				const kittyProc = Bun.spawn(
 					["kitty", "--directory", cwd, "-e", "bash", detachedScriptPath],
 					{

--- a/workers/kdco-registry/tests/worktree-terminal.test.ts
+++ b/workers/kdco-registry/tests/worktree-terminal.test.ts
@@ -3,7 +3,7 @@
  * Tests shell escaping functions, temp script cleanup, and security hardening.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -17,6 +17,7 @@ import {
 	detectTerminalType,
 	openCmuxTerminal,
 	openCmuxTerminalWithState,
+	openMacOSTerminal,
 	openTerminal,
 	withTempScript,
 } from "../files/plugins/worktree/terminal"
@@ -698,6 +699,112 @@ setInterval(() => {}, 1000)
 			}
 
 			expect(detectTerminalType()).toBe("tmux")
+		})
+	})
+
+	describe("openMacOSTerminal (kitty)", () => {
+		const originalEnv = { ...process.env }
+		const macTerminalEnvKeys = [
+			"TERM_PROGRAM",
+			"GHOSTTY_RESOURCES_DIR",
+			"ITERM_SESSION_ID",
+			"KITTY_WINDOW_ID",
+			"ALACRITTY_WINDOW_ID",
+			"__CFBundleIdentifier",
+		]
+
+		const spawnSyncSpy = {
+			current: undefined as ReturnType<typeof spyOn<typeof Bun, "spawnSync">> | undefined,
+		}
+		const spawnSpy = {
+			current: undefined as ReturnType<typeof spyOn<typeof Bun, "spawn">> | undefined,
+		}
+		const createdScripts: string[] = []
+
+		beforeEach(() => {
+			for (const key of macTerminalEnvKeys) {
+				delete process.env[key]
+			}
+			process.env.KITTY_WINDOW_ID = "999"
+		})
+
+		afterEach(() => {
+			spawnSyncSpy.current?.mockRestore()
+			spawnSpy.current?.mockRestore()
+			spawnSyncSpy.current = undefined
+			spawnSpy.current = undefined
+			for (const scriptPath of createdScripts) {
+				try {
+					fs.rmSync(scriptPath)
+				} catch {
+					// Best-effort cleanup
+				}
+			}
+			createdScripts.length = 0
+			process.env = { ...originalEnv }
+		})
+
+		it("keeps the launch script alive for the spawned tab", async () => {
+			let launchArgv: readonly string[] = []
+			let scriptExistedAtLaunch = false
+
+			spawnSyncSpy.current = spyOn(Bun, "spawnSync").mockImplementation(
+				((argv: readonly string[]) => {
+					launchArgv = argv
+					const scriptPath = argv[argv.length - 1]
+					scriptExistedAtLaunch = fs.existsSync(scriptPath)
+					createdScripts.push(scriptPath)
+					return { exitCode: 0 }
+				}) as never,
+			)
+
+			const result = await openMacOSTerminal("/tmp/worktree-script-race", [
+				"opencode",
+				"--session",
+				"ses_123",
+			])
+
+			expect(result.success).toBe(true)
+			expect(launchArgv.slice(0, 5)).toEqual(["kitty", "@", "launch", "--type", "tab"])
+			expect(scriptExistedAtLaunch).toBe(true)
+
+			const scriptPath = launchArgv[launchArgv.length - 1]
+			// kitty accepts the launch before the new tab's bash reads the script,
+			// so the plugin must NOT delete it - the script self-cleans via trap.
+			expect(fs.existsSync(scriptPath)).toBe(true)
+			const content = fs.readFileSync(scriptPath, "utf8")
+			expect(content).toContain('trap \'rm -f "$0"\' EXIT INT TERM')
+			expect(content).toContain('cd "/tmp/worktree-script-race"')
+			expect(content).toContain('"opencode" "--session" "ses_123"')
+		})
+
+		it("reuses the live script for the detached fallback window", async () => {
+			let fallbackArgv: readonly string[] = []
+
+			spawnSyncSpy.current = spyOn(Bun, "spawnSync").mockImplementation(
+				((argv: readonly string[]) => {
+					createdScripts.push(argv[argv.length - 1])
+					return { exitCode: 1 }
+				}) as never,
+			)
+			spawnSpy.current = spyOn(Bun, "spawn").mockImplementation(
+				((argv: readonly string[]) => {
+					fallbackArgv = argv
+					return { unref: () => {} }
+				}) as never,
+			)
+
+			const result = await openMacOSTerminal("/tmp/worktree-script-race", ["opencode"])
+
+			expect(result.success).toBe(true)
+			expect(fallbackArgv.slice(0, 3)).toEqual([
+				"kitty",
+				"--directory",
+				"/tmp/worktree-script-race",
+			])
+			const scriptPath = fallbackArgv[fallbackArgv.length - 1]
+			expect(scriptPath).toBe(createdScripts[0])
+			expect(fs.existsSync(scriptPath)).toBe(true)
 		})
 	})
 })


### PR DESCRIPTION
## Problem

On macOS + kitty, `worktree_create` reports "A new terminal has been opened with OpenCode." but no terminal (or tab) ever appears.

## Root cause

The macOS kitty branch in `openMacOSTerminal` wraps the launch script with `withTempScript` and runs:

```
kitty @ launch --type tab --cwd <worktree> -- bash <script>
```

`kitty @ launch` blocks only until **kitty accepts the request**, not until the spawned bash has opened the script file. `withTempScript`'s `finally` block deletes the script immediately after `spawnSync` returns. If bash hasn't read the file yet, it exits instantly (non-zero) and kitty closes the tab silently.

Two facts that make this failure invisible:

1. `kitty @ launch` still exits `0` when the script file doesn't exist (verified on kitty 0.43)
2. `addSession` then runs and the tool reports success

So the plugin reports success while the tab dies in under a second. This is the exact race the comment above this case warns about for detached terminals:

> DO NOT use withTempScript for these - the finally block would delete the script before the detached process reads it

The iTerm, Alacritty, Ghostty and Linux-kitty branches already write the script directly with trap-based self-cleanup; only the macOS kitty remote branch was left using `withTempScript`.

## Fix

Write the script directly and let its `trap 'rm -f "$0"' EXIT INT TERM` remove it after execution - the same pattern used by the other branches. The fallback detached `kitty` window reuses the same still-live script.

## Verification

- Added 2 regression tests in `worktree-terminal.test.ts`:
  - remote launch success: script exists at launch time **and** after the call; contains trap + cd + command
  - remote launch failure: detached fallback reuses the same live script
- Both tests fail against the previous implementation and pass with this change
- `bun run check` (biome + tsc) passes; full suite `1409 pass, 0 fail`
- Real-world repro before fix: no tab survives. After fix applied locally: new tab opens and persists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race on macOS with kitty where new tabs closed instantly by keeping the launch script alive until the tab’s shell reads it. The script now self-cleans via a trap, and the fallback detached window reuses the same script.

- **Bug Fixes**
  - macOS kitty: replace `withTempScript` with a written script file used by `kitty @ launch`; let `trap 'rm -f "$0"'` handle cleanup.
  - On successful remote launch, clear the temp path; on failure, reuse the same live script for the detached kitty window.
  - Added regression tests to confirm the script exists at launch and contains the trap, cd, and command; both tests failed before and pass now.

<sup>Written for commit f11b1be91224e01e68d22fba386d9ea4fbcfc113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

