### PR TITLE
feat: Add support for Yakuake terminal

### DIFF
--- a/workers/kdco-registry/files/plugins/worktree/terminal.ts
+++ b/workers/kdco-registry/files/plugins/worktree/terminal.ts
@@ -229,6 +229,7 @@ type LinuxTerminal =
 	| "foot"
 	| "gnome-terminal"
 	| "konsole"
+	| "yakuake"
 	| "xfce4-terminal"
 	| "xdg-terminal-exec"
 	| "x-terminal-emulator"
@@ -781,20 +782,90 @@ export async function openMacOSTerminal(cwd: string, argv?: string[]): Promise<T
 function detectCurrentLinuxTerminal(): LinuxTerminal | null {
 	const env = linuxTerminalEnvSchema.parse(process.env)
 
+	const termProgram = env.TERM_PROGRAM?.toLowerCase()
+
 	// Check specific env vars first (most reliable)
 	if (env.KITTY_WINDOW_ID) return "kitty"
 	if (env.WEZTERM_PANE) return "wezterm"
 	if (env.ALACRITTY_WINDOW_ID) return "alacritty"
 	if (env.GHOSTTY_RESOURCES_DIR) return "ghostty"
 	if (env.GNOME_TERMINAL_SERVICE) return "gnome-terminal"
+
+	// Yakuake embeds Konsole, so it must be checked first.
+	if (termProgram === "yakuake") return "yakuake"
+
 	if (env.KONSOLE_VERSION) return "konsole"
 
 	// TERM_PROGRAM fallback
-	const termProgram = env.TERM_PROGRAM?.toLowerCase()
 	if (termProgram === "warpterminal") return "warp"
 	if (termProgram === "foot") return "foot"
 
 	return null
+}
+
+type QdbusCommandResult = {
+	exitCode: number
+	stderr: string
+}
+type RunQdbusCommand = (args: string[]) => QdbusCommandResult | Promise<QdbusCommandResult>
+
+/**
+ * Build the ordered qdbus6 command sequence that launches a script in a new
+ * Yakuake session. Order matters: runCommand targets the session created by
+ * addSession, so addSession must complete first.
+ */
+export function buildYakuakeCommandSequence(launchScriptPath: string): string[][] {
+	return [
+		["qdbus6", "org.kde.yakuake", "/yakuake/sessions", "addSession"],
+		["qdbus6", "org.kde.yakuake", "/yakuake/sessions", "runCommand", launchScriptPath],
+	]
+}
+
+async function runQdbusCommandWithBun(args: string[]): Promise<QdbusCommandResult> {
+	const result = Bun.spawnSync(args)
+	return {
+		exitCode: result.exitCode,
+		stderr: result.stderr.toString(),
+	}
+}
+
+/**
+ * Launch a script in a new Yakuake session via qdbus6.
+ *
+ * Commands run sequentially via synchronous spawns: each qdbus6 call is
+ * awaited and must exit successfully before the next one is dispatched.
+ * If addSession were fire-and-forget, runCommand could race the session
+ * creation and target the previously active session.
+ */
+export async function openYakuakeTerminal(
+	launchScriptPath: string,
+	options?: {
+		runCommand?: RunQdbusCommand
+	},
+): Promise<TerminalResult> {
+	const runCommand = options?.runCommand ?? runQdbusCommandWithBun
+
+	for (const args of buildYakuakeCommandSequence(launchScriptPath)) {
+		let result: QdbusCommandResult
+		try {
+			result = await runCommand(args)
+		} catch (error) {
+			return {
+				success: false,
+				error: `yakuake ${args[3]} failed: ${error instanceof Error ? error.message : String(error)}`,
+			}
+		}
+
+		if (result.exitCode !== 0) {
+			const stderr = result.stderr.trim() || "unknown qdbus error"
+			return {
+				success: false,
+				error: `yakuake ${args[3]} failed: ${stderr}`,
+			}
+		}
+	}
+
+	return { success: true }
 }
 
 /**
@@ -999,6 +1070,12 @@ export async function openLinuxTerminal(cwd: string, argv?: string[]): Promise<T
 						"bash",
 						launchScriptPath,
 					])
+					break
+				}
+				case "yakuake": {
+					const launchScriptPath = await ensureScriptPath()
+					const yakuakeResult = await openYakuakeTerminal(launchScriptPath)
+					result = { tried: true, success: yakuakeResult.success }
 					break
 				}
 				default:

--- a/workers/kdco-registry/tests/worktree-terminal.test.ts
+++ b/workers/kdco-registry/tests/worktree-terminal.test.ts
@@ -12,12 +12,14 @@ import {
 	buildBashCommandFromArgv,
 	buildBatchCommandFromArgv,
 	buildCmuxCommandSequence,
+	buildYakuakeCommandSequence,
 	canUseCmuxWorkflow,
 	detectCmuxContext,
 	detectTerminalType,
 	openCmuxTerminal,
 	openCmuxTerminalWithState,
 	openTerminal,
+	openYakuakeTerminal,
 	withTempScript,
 } from "../files/plugins/worktree/terminal"
 
@@ -698,6 +700,86 @@ setInterval(() => {}, 1000)
 			}
 
 			expect(detectTerminalType()).toBe("tmux")
+		})
+	})
+
+	describe("yakuake integration", () => {
+		it("builds addSession before runCommand in the qdbus6 sequence", () => {
+			const sequence = buildYakuakeCommandSequence("/tmp/worktree-launch.sh")
+
+			expect(sequence).toEqual([
+				["qdbus6", "org.kde.yakuake", "/yakuake/sessions", "addSession"],
+				["qdbus6", "org.kde.yakuake", "/yakuake/sessions", "runCommand", "/tmp/worktree-launch.sh"],
+			])
+		})
+
+		it("awaits addSession completion before dispatching runCommand", async () => {
+			const events: string[] = []
+
+			const result = await openYakuakeTerminal("/tmp/worktree-launch.sh", {
+				runCommand: async (args) => {
+					const method = args[3] ?? "unknown"
+					events.push(`start:${method}`)
+					await Bun.sleep(20)
+					events.push(`end:${method}`)
+					return { exitCode: 0, stderr: "" }
+				},
+			})
+
+			expect(result).toEqual({ success: true })
+			expect(events).toEqual([
+				"start:addSession",
+				"end:addSession",
+				"start:runCommand",
+				"end:runCommand",
+			])
+		})
+
+		it("skips runCommand when addSession exits non-zero", async () => {
+			const executed: string[][] = []
+
+			const result = await openYakuakeTerminal("/tmp/worktree-launch.sh", {
+				runCommand: (args) => {
+					executed.push(args)
+					return { exitCode: 1, stderr: "org.kde.yakuake is not registered" }
+				},
+			})
+
+			expect(result).toEqual({
+				success: false,
+				error: "yakuake addSession failed: org.kde.yakuake is not registered",
+			})
+			expect(executed).toHaveLength(1)
+			expect(executed[0][3]).toBe("addSession")
+		})
+
+		it("reports stderr when runCommand exits non-zero", async () => {
+			const result = await openYakuakeTerminal("/tmp/worktree-launch.sh", {
+				runCommand: (args) =>
+					args[3] === "runCommand"
+						? { exitCode: 1, stderr: "failed to run command" }
+						: { exitCode: 0, stderr: "" },
+			})
+
+			expect(result).toEqual({
+				success: false,
+				error: "yakuake runCommand failed: failed to run command",
+			})
+		})
+
+		it("returns failure without throwing when qdbus6 cannot be spawned", async () => {
+			const executed: string[][] = []
+
+			const result = await openYakuakeTerminal("/tmp/worktree-launch.sh", {
+				runCommand: (args) => {
+					executed.push(args)
+					throw new Error('Executable not found in $PATH: "qdbus6"')
+				},
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain("yakuake addSession failed")
+			expect(executed).toHaveLength(1)
 		})
 	})
 })


### PR DESCRIPTION
This adds support for [Yakuake](https://apps.kde.org/yakuake/), a popular drop-down terminal emulator for KDE.

Tested on Arch Linux with KDE Plasma 6.7.4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Linux support for Yakuake so sessions launched inside Yakuake no longer open Konsole. We now detect Yakuake first and create a new session via `qdbus6`, awaiting session creation to prevent races.

- Detects `TERM_PROGRAM=yakuake` before `KONSOLE_VERSION`; adds a "yakuake" terminal type and `openLinuxTerminal` branch.
- Runs ordered `qdbus6` calls: `addSession` then `runCommand <launch-script>`, each awaited; surfaces stderr and spawn errors.
- Exposes `buildYakuakeCommandSequence` and `openYakuakeTerminal`; adds tests for call order, sequencing, early exit, stderr propagation, and missing `qdbus6`.
- Requires `qdbus6` in PATH. Tested on KDE Plasma 6.7.4 (Arch).

<sup>Written for commit 3dc92e5ad37dc3b398fa309da4bfe3c334c80db0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

