### PR TITLE
fix: Avoid blocking on macOS notifications

### DIFF
--- a/workers/kdco-registry/files/plugins/notify/backend.ts
+++ b/workers/kdco-registry/files/plugins/notify/backend.ts
@@ -64,14 +64,24 @@ export async function sendMacOSAlerterNotification(
 		}
 
 		const alerterArguments = buildAlerterArguments(options)
-		const spawnProcess = runtime.spawnProcess ?? ((argv: string[]) => Bun.spawn(argv, { stdout: "ignore", stderr: "pipe" }))
+		const spawnProcess = runtime.spawnProcess ?? ((argv: string[]) => Bun.spawn(argv, { stdout: "ignore", stderr: "ignore" }))
 		const process = spawnProcess([alerterPath, ...alerterArguments.slice(1)])
-		const exitCode = await process.exited
 
-		if (exitCode === 0) return true
+		// Alerter exits only after the user interacts with or dismisses the notification.
+		// Observe failures without blocking the OpenCode hook that triggered it.
+		void process.exited.then(
+			(exitCode) => {
+				if (exitCode !== 0) {
+					warn(`notify: macOS desktop notification exited with code ${exitCode}.`)
+				}
+			},
+			(error: unknown) => {
+				const message = error instanceof Error ? error.message : String(error)
+				warn(`notify: macOS desktop notification process failed (${message}).`)
+			},
+		)
 
-		warn(`notify: macOS desktop notification skipped; alerter exited with code ${exitCode}.`)
-		return false
+		return true
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		warn(`notify: macOS desktop notification skipped; alerter failed (${message}).`)

--- a/workers/kdco-registry/tests/notify-backend.test.ts
+++ b/workers/kdco-registry/tests/notify-backend.test.ts
@@ -232,6 +232,31 @@ describe("macOS alerter desktop notifications", () => {
 		expect(warn).not.toHaveBeenCalled()
 	})
 
+	it("does not wait for alerter interaction before reporting a successful launch", async () => {
+		let resolveExit: ((exitCode: number) => void) | undefined
+		const exited = new Promise<number>((resolve) => {
+			resolveExit = resolve
+		})
+
+		const result = await Promise.race([
+			sendMacOSAlerterNotification(
+				{
+					title: "Question for you",
+					message: "Please answer",
+				},
+				{
+					which: async () => "/usr/local/bin/alerter",
+					spawnProcess: () => ({ exited }),
+				},
+			),
+			new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 50)),
+		])
+
+		expect(result).toBe(true)
+		resolveExit?.(0)
+		await Promise.resolve()
+	})
+
 	it("warns and reports false when alerter is missing", async () => {
 		const spawnProcess = mock((_argv: string[]) => ({
 			exited: Promise.resolve(0),
@@ -255,7 +280,7 @@ describe("macOS alerter desktop notifications", () => {
 		expect(warn).toHaveBeenCalledWith(expect.stringContaining("alerter not found on PATH"))
 	})
 
-	it("warns and reports false when alerter exits non-zero", async () => {
+	it("reports a successful launch and warns asynchronously when alerter exits non-zero", async () => {
 		const warn = mock(() => {})
 
 		const sent = await sendMacOSAlerterNotification(
@@ -270,9 +295,30 @@ describe("macOS alerter desktop notifications", () => {
 			},
 		)
 
-		expect(sent).toBe(false)
+		expect(sent).toBe(true)
+		await Promise.resolve()
+		expect(warn).toHaveBeenCalledWith("notify: macOS desktop notification exited with code 2.")
+	})
+
+	it("warns asynchronously when monitoring the alerter process fails", async () => {
+		const warn = mock(() => {})
+
+		const sent = await sendMacOSAlerterNotification(
+			{
+				title: "Ready",
+				message: "Task complete",
+			},
+			{
+				which: async () => "/usr/local/bin/alerter",
+				spawnProcess: () => ({ exited: Promise.reject(new Error("wait failed")) }),
+				warn,
+			},
+		)
+
+		expect(sent).toBe(true)
+		await Promise.resolve()
 		expect(warn).toHaveBeenCalledWith(
-			"notify: macOS desktop notification skipped; alerter exited with code 2.",
+			"notify: macOS desktop notification process failed (wait failed).",
 		)
 	})
 


### PR DESCRIPTION
Thanks for the notify plugin!

I ran into an issue where `alerter` remains running until the notification is clicked or dismissed on MacOS (with Ghostty); when OpenCode asked a question, the hook remained blocked and the question did not appear in the terminal until the notification was clicked.

The fix: treat a successful `alerter` spawn as successful notification delivery. Observe the process exit in the background so failures are still reported without blocking OpenCode.

I've tested locally and the issue is gone :)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop blocking on macOS notifications by treating a successful `alerter` spawn as delivery and monitoring the process in the background. Previously we awaited `alerter` exit, which blocked the OpenCode hook until the notification was clicked or dismissed; now we return immediately and warn asynchronously on non‑zero exits or monitor failures.

- Spawn `alerter` with stdout/stderr ignored, return `true` immediately, and warn later if `process.exited` resolves non‑zero or rejects.
- Tests: add a non‑blocking launch test; update the non‑zero exit test to expect immediate success and an async warning; add a monitor‑failure warning test.
- Migration: if any caller inferred delivery failure from the return value, update it—`sendMacOSAlerterNotification` now returns `true` on launch; rely on warnings for failures.

<sup>Written for commit 0868d6eca8d56be1d05c5a13d6e88eb6cbad429e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

