### PR TITLE
chore(release): Prepare v2.0.15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "packages/cli": {
       "name": "ocx",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "bin": {
         "ocx": "./dist/index.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ocx",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"description": "OCX CLI - OpenCode extension manager with portable, isolated profiles. Your setup, anywhere.",
 	"author": "kdcokenny",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- bump the publishable ocx package from 2.0.14 to 2.0.15
- keep the workspace lock entry aligned with the package manifest
- prepare the guarded tag workflow for the changes merged in #259 and #260

## Verification

- bun install --frozen-lockfile
- bun run check
- bun run test
- git diff --check

## Release safety

The release tag will only be created after this PR is merged and the version is present on remote main. The repository release:tag helper will revalidate the clean worktree, remote main manifest, npm state, and tag state before pushing v2.0.15.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the `ocx` v2.0.15 release by bumping the package version and aligning `bun.lock`, enabling guarded tagging so the v2.0.15 tag is created only after merge to `main`. This includes all changes since v2.0.14; no runtime behavior changes.

- Updates only `packages/cli/package.json` and `bun.lock` to 2.0.15.
- Tagging is gated: after merge, the release helper validates a clean worktree, remote `main` manifest at 2.0.15, `npm` state, and tag availability before pushing v2.0.15.
- Reviewers: run `bun install --frozen-lockfile && bun run check && bun run test` and confirm manifest and lockfile versions match.

<sup>Written for commit b4573a175a5a4bc48bafd90cbe033012085324c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

