### PR TITLE
feat: Add notify timeout

### DIFF
--- a/facades/opencode-notify/README.md
+++ b/facades/opencode-notify/README.md
@@ -85,6 +85,7 @@ Works out of the box. To customize, create `~/.config/opencode/kdco-notify.json`
 ```json
 {
   "notifyChildSessions": false,
+  "timeout": 0,
   "terminal": "ghostty",
   "sounds": {
     "idle": "Glass",
@@ -103,6 +104,7 @@ Works out of the box. To customize, create `~/.config/opencode/kdco-notify.json`
 Configuration keys:
 
 - `notifyChildSessions` (default `false`): when `true`, include child/sub-session `session.idle` and `session.error` notifications (question and permission notifications are unaffected).
+- `timeout` (default `0`): seconds before a desktop notification disappears automatically. Set to `0` for no timeout. Supported on macOS and Linux outside of cmux.
 - `terminal` (optional): override terminal auto-detection.
 - `sounds`: per-event sounds (`idle`, `error`, `permission`, optional `question`).
 - `quietHours`: scheduled suppression window.

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -117,7 +117,15 @@ async function loadConfig(): Promise<NotifyConfig> {
 	try {
 		const content = await fs.readFile(configPath, "utf8")
 		const userConfig = JSON.parse(content) as Partial<NotifyConfig>
-		const timeout = userConfig.timeout ?? DEFAULT_CONFIG.timeout
+		const configuredTimeout = userConfig.timeout
+		let timeout = DEFAULT_CONFIG.timeout
+		if (
+			typeof configuredTimeout === "number" &&
+			Number.isFinite(configuredTimeout) &&
+			configuredTimeout >= 0
+		) {
+			timeout = configuredTimeout
+		}
 
 		// Merge with defaults
 		return {

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -117,17 +117,13 @@ async function loadConfig(): Promise<NotifyConfig> {
 	try {
 		const content = await fs.readFile(configPath, "utf8")
 		const userConfig = JSON.parse(content) as Partial<NotifyConfig>
+		const timeout = userConfig.timeout ?? DEFAULT_CONFIG.timeout
 
 		// Merge with defaults
 		return {
 			...DEFAULT_CONFIG,
 			...userConfig,
-			timeout:
-				typeof userConfig.timeout === "number" &&
-				Number.isFinite(userConfig.timeout) &&
-				userConfig.timeout >= 0
-					? userConfig.timeout
-					: DEFAULT_CONFIG.timeout,
+			timeout,
 			sounds: {
 				...DEFAULT_CONFIG.sounds,
 				...userConfig.sounds,

--- a/workers/kdco-registry/files/plugins/notify.ts
+++ b/workers/kdco-registry/files/plugins/notify.ts
@@ -29,7 +29,11 @@ import detectTerminal from "detect-terminal"
 // @ts-expect-error - installed at runtime by OCX
 import notifier from "node-notifier"
 import type { OpencodeClient } from "./kdco-primitives/types"
-import { sendDesktopNotificationByPlatform, sendNotificationWithFallback } from "./notify/backend"
+import {
+	buildNodeNotifierOptions,
+	sendDesktopNotificationByPlatform,
+	sendNotificationWithFallback,
+} from "./notify/backend"
 import {
 	clearCmuxStatus,
 	resolveCmuxNotificationCommand,
@@ -47,6 +51,8 @@ import { parseOscTitleContext, writeOscTitleBestEffort } from "./notify/title"
 interface NotifyConfig {
 	/** Notify for child/sub-session events (default: false) */
 	notifyChildSessions: boolean
+	/** Seconds before a desktop notification disappears (default: 0, no timeout) */
+	timeout: number
 	/** Sound configuration per event type */
 	sounds: {
 		idle: string
@@ -72,6 +78,7 @@ interface TerminalInfo {
 
 const DEFAULT_CONFIG: NotifyConfig = {
 	notifyChildSessions: false,
+	timeout: 0,
 	sounds: {
 		idle: "Glass",
 		error: "Basso",
@@ -115,6 +122,12 @@ async function loadConfig(): Promise<NotifyConfig> {
 		return {
 			...DEFAULT_CONFIG,
 			...userConfig,
+			timeout:
+				typeof userConfig.timeout === "number" &&
+				Number.isFinite(userConfig.timeout) &&
+				userConfig.timeout >= 0
+					? userConfig.timeout
+					: DEFAULT_CONFIG.timeout,
 			sounds: {
 				...DEFAULT_CONFIG.sounds,
 				...userConfig.sounds,
@@ -246,6 +259,7 @@ interface NotificationOptions {
 interface NotificationRuntime {
 	preferCmux: boolean
 	cmuxCommand?: string
+	timeout: number
 }
 
 const QUESTION_DEDUPE_WINDOW_MS = 1500
@@ -382,24 +396,25 @@ function buildPermissionEventDedupeKey(properties: unknown): string | null {
 	return `permission:request:${normalizedRequestID}`
 }
 
-async function sendDesktopNotification(options: NotificationOptions): Promise<void> {
+async function sendDesktopNotification(
+	options: NotificationOptions,
+	timeout: number,
+): Promise<void> {
 	const { title, message, sound, terminalInfo } = options
-
-	// Base notification options
-	const notifyOptions: Record<string, unknown> = {
-		title,
-		message,
-		sound,
-	}
-
-	await sendDesktopNotificationByPlatform({
-		platform: process.platform,
+	const desktopNotificationOptions = {
 		title,
 		message,
 		subtitle: options.subtitle,
 		sound,
 		senderBundleId: terminalInfo.bundleId,
-		sendNodeNotifierNotification: () => notifier.notify(notifyOptions),
+		timeout,
+	}
+
+	await sendDesktopNotificationByPlatform({
+		platform: process.platform,
+		...desktopNotificationOptions,
+		sendNodeNotifierNotification: () =>
+			notifier.notify(buildNodeNotifierOptions(desktopNotificationOptions)),
 	})
 }
 
@@ -418,7 +433,7 @@ async function sendNotification(
 				},
 				{ cmuxCommand: runtime.cmuxCommand },
 			),
-		sendDesktopNotification: () => sendDesktopNotification(options),
+		sendDesktopNotification: () => sendDesktopNotification(options, runtime.timeout),
 	})
 }
 
@@ -564,6 +579,7 @@ const NotifyPlugin: Plugin = async (ctx) => {
 	const notificationRuntime: NotificationRuntime = {
 		preferCmux: Boolean(cmuxCommand),
 		cmuxCommand,
+		timeout: config.timeout,
 	}
 	const oscTitleContext = parseOscTitleContext()
 	const shouldSuppressCmuxSessionStatusWrites = oscTitleContext?.mayWriteOscTitle === true

--- a/workers/kdco-registry/files/plugins/notify/backend.ts
+++ b/workers/kdco-registry/files/plugins/notify/backend.ts
@@ -10,6 +10,7 @@ export interface DesktopNotificationOptions {
 	subtitle?: string
 	sound?: string
 	senderBundleId?: string | null
+	timeout?: number
 }
 
 interface DesktopNotificationRouterOptions extends DesktopNotificationOptions {
@@ -33,6 +34,9 @@ const ALERTER_INSTALL_HINT =
 
 export function buildAlerterArguments(options: DesktopNotificationOptions): string[] {
 	const argv = ["alerter", "--message", options.message, "--title", options.title]
+	if (options.timeout !== undefined) {
+		argv.push("--timeout", String(options.timeout))
+	}
 
 	if (options.subtitle) {
 		argv.push("--subtitle", options.subtitle)
@@ -47,6 +51,17 @@ export function buildAlerterArguments(options: DesktopNotificationOptions): stri
 	}
 
 	return argv
+}
+
+export function buildNodeNotifierOptions(
+	options: DesktopNotificationOptions,
+): Record<string, unknown> {
+	return {
+		title: options.title,
+		message: options.message,
+		sound: options.sound,
+		timeout: options.timeout,
+	}
 }
 
 export async function sendMacOSAlerterNotification(

--- a/workers/kdco-registry/tests/notify-backend.test.ts
+++ b/workers/kdco-registry/tests/notify-backend.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from "bun:test"
 import {
 	buildAlerterArguments,
+	buildNodeNotifierOptions,
 	sendDesktopNotificationByPlatform,
 	sendMacOSAlerterNotification,
 	sendNotificationWithFallback,
@@ -172,6 +173,7 @@ describe("macOS alerter desktop notifications", () => {
 				subtitle: "Session A",
 				sound: "Submarine",
 				senderBundleId: "com.mitchellh.ghostty",
+				timeout: 12,
 			}),
 		).toEqual([
 			"alerter",
@@ -179,6 +181,8 @@ describe("macOS alerter desktop notifications", () => {
 			"Permission needed",
 			"--title",
 			"Waiting for you",
+			"--timeout",
+			"12",
 			"--subtitle",
 			"Session A",
 			"--sound",
@@ -186,6 +190,33 @@ describe("macOS alerter desktop notifications", () => {
 			"--sender",
 			"com.mitchellh.ghostty",
 		])
+	})
+
+	it("maps zero timeout to alerter and node-notifier", () => {
+		const options = {
+			title: "Ready",
+			message: "Task complete",
+			sound: "Glass",
+			timeout: 0,
+		}
+
+		expect(buildAlerterArguments(options)).toEqual([
+			"alerter",
+			"--message",
+			"Task complete",
+			"--title",
+			"Ready",
+			"--timeout",
+			"0",
+			"--sound",
+			"Glass",
+		])
+		expect(buildNodeNotifierOptions(options)).toEqual({
+			title: "Ready",
+			message: "Task complete",
+			sound: "Glass",
+			timeout: 0,
+		})
 	})
 
 	it("omits optional alerter flags when not configured", () => {

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -230,7 +230,7 @@ describe("notify plugin event compatibility and dedupe", () => {
 		})
 
 		expect(notificationPayloads).toHaveLength(1)
-		expect(notificationPayloads[0]?.timeout).toBe("12")
+		expect(String(notificationPayloads[0]?.timeout)).toBe("12")
 	})
 
 	it("defaults the desktop notification timeout to zero", async () => {
@@ -245,7 +245,26 @@ describe("notify plugin event compatibility and dedupe", () => {
 		})
 
 		expect(notificationPayloads).toHaveLength(1)
-		expect(notificationPayloads[0]?.timeout).toBe("0")
+		expect(String(notificationPayloads[0]?.timeout)).toBe("0")
+	})
+
+	it("defaults invalid desktop notification timeouts to zero", async () => {
+		for (const [index, timeout] of [-1, "12"].entries()) {
+			mockedConfig = { timeout }
+			const { hooks } = await createPlugin()
+
+			await emitEvent(hooks, {
+				type: "question.asked",
+				properties: {
+					id: `question-invalid-timeout-${index}`,
+					sessionID: "session-a",
+					questions: [],
+				},
+			})
+		}
+
+		expect(notificationPayloads).toHaveLength(2)
+		expect(notificationPayloads.map((payload) => String(payload.timeout))).toEqual(["0", "0"])
 	})
 
 	it("dedupes permission notification when permission.asked and permission.updated describe same request", async () => {

--- a/workers/kdco-registry/tests/notify-plugin.test.ts
+++ b/workers/kdco-registry/tests/notify-plugin.test.ts
@@ -33,6 +33,7 @@ function pushAlerterNotificationPayload(command: string[]): void {
 		if (flag === "--subtitle") payload.subtitle = value
 		if (flag === "--sound") payload.sound = value
 		if (flag === "--sender") payload.sender = value
+		if (flag === "--timeout") payload.timeout = value
 	}
 
 	notificationPayloads.push(payload)
@@ -213,6 +214,40 @@ function decodeOscTitleWrite(chunk: unknown): string | null {
 }
 
 describe("notify plugin event compatibility and dedupe", () => {
+	it("applies the configured desktop notification timeout", async () => {
+		mockedConfig = {
+			timeout: 12,
+		}
+
+		const { hooks } = await createPlugin()
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-timeout",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(1)
+		expect(notificationPayloads[0]?.timeout).toBe("12")
+	})
+
+	it("defaults the desktop notification timeout to zero", async () => {
+		const { hooks } = await createPlugin()
+		await emitEvent(hooks, {
+			type: "question.asked",
+			properties: {
+				id: "question-default-timeout",
+				sessionID: "session-a",
+				questions: [],
+			},
+		})
+
+		expect(notificationPayloads).toHaveLength(1)
+		expect(notificationPayloads[0]?.timeout).toBe("0")
+	})
+
 	it("dedupes permission notification when permission.asked and permission.updated describe same request", async () => {
 		const { hooks } = await createPlugin()
 


### PR DESCRIPTION
This adds a new `timeout` option, supported out of the box by `alerter` and `node-notify`.

It will allow for self-clearing notifications, should the user prefer it.

I've tested on MacOS with success :)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable desktop notification timeout so notifications can auto-dismiss. Previously notifications persisted until dismissed; default remains 0 (no timeout), and invalid values now fall back to 0.

- Adds a `timeout` field to notify config and validates it as a non‑negative finite number; plumbed through `NotificationRuntime` to backends.
- Maps timeout to `alerter --timeout` and `node-notifier`’s `timeout`; introduces `buildNodeNotifierOptions` and updates `sendDesktopNotification` to pass runtime timeout. Supported on macOS and Linux outside of cmux.
- Updates `facades/opencode-notify/README.md`; adds tests for mapping, default behavior, overrides, and invalid values.

<sup>Written for commit fa43b1ee2176e4c062caeff0a65ab0f375c5c0b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

