### PR TITLE
fix(registry): Use native TUI notifications for background agents

### DIFF
--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -1037,7 +1037,7 @@ class DelegationManager {
 		return {
 			title: `Background agent ${status}: ${title}`,
 			message: message.join("\n"),
-			variant: status === "complete" ? "success" : status === "timeout" ? "warning" : "error",
+variant: status === "complete" ? "success" : status === "cancelled" ? "info" : status === "timeout" ? "warning" : "error",
 		}
 	}
 

--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -794,7 +794,7 @@ class DelegationManager {
 		if (!this.areCycleTerminalNotificationsComplete(parentSessionID, cycleToken)) return
 		if (state.allCompleteNotifiedCycleToken === cycleToken) return
 
-		await this.publishTuiToast(this.buildAllCompleteNotificationToast())
+		const tuiToastDelivered = await this.publishTuiToast(this.buildAllCompleteNotificationToast())
 
 		const deliveryStatus = await this.sendParentNotification(
 			parentSessionID,
@@ -802,6 +802,7 @@ class DelegationManager {
 			this.buildAllCompleteNotification(parentSessionID, cycle, cycleToken),
 			false,
 			this.buildAllCompleteNotificationDisplay(parentSessionID, cycle, cycleToken),
+			tuiToastDelivered,
 		)
 
 		if (state.allCompleteCycleToken !== cycleToken) return
@@ -829,6 +830,7 @@ class DelegationManager {
 		notification: string,
 		noReply: boolean,
 		displayText: string = notification,
+		tuiToastDelivered = true,
 	): Promise<"sent" | "queued" | "timed-out"> {
 		const session = this.client.session
 		let timeout: ReturnType<typeof setTimeout> | undefined
@@ -847,9 +849,11 @@ class DelegationManager {
 						body: {
 							noReply,
 							agent: parentAgent,
-							// Keep the machine-readable notification in model context without
-							// exposing Markdown as a literal user message in the TUI.
-							parts: [{ type: "text", text: notification, synthetic: true }],
+							parts: [
+								tuiToastDelivered
+									? { type: "text", text: notification, synthetic: true }
+									: { type: "text", text: displayText },
+							],
 						},
 					})
 					.then(() => "sent" as const),
@@ -1037,7 +1041,14 @@ class DelegationManager {
 		return {
 			title: `Background agent ${status}: ${title}`,
 			message: message.join("\n"),
-variant: status === "complete" ? "success" : status === "cancelled" ? "info" : status === "timeout" ? "warning" : "error",
+			variant:
+				status === "complete"
+					? "success"
+					: status === "cancelled"
+						? "info"
+						: status === "timeout"
+							? "warning"
+							: "error",
 		}
 	}
 
@@ -1083,10 +1094,10 @@ variant: status === "complete" ? "success" : status === "cancelled" ? "info" : s
 		}
 	}
 
-	private async publishTuiToast(toast: TuiToastOptions): Promise<void> {
+	private async publishTuiToast(toast: TuiToastOptions): Promise<boolean> {
 		try {
 			const tui = this.client.tui
-			if (!tui || typeof tui.publish !== "function") return
+			if (!tui || typeof tui.publish !== "function") return false
 
 			await tui.publish({
 				body: {
@@ -1094,10 +1105,12 @@ variant: status === "complete" ? "success" : status === "cancelled" ? "info" : s
 					properties: toast,
 				},
 			})
+			return true
 		} catch (error) {
 			await this.debugLog(
 				`tui toast failed: ${error instanceof Error ? error.message : "Unknown error"}`,
 			)
+			return false
 		}
 	}
 
@@ -1199,7 +1212,9 @@ variant: status === "complete" ? "success" : status === "cancelled" ? "info" : s
 			const remainingCount = this.getPendingCount(delegation.parentSessionID)
 			const terminalNotification = this.buildTerminalNotification(delegation, remainingCount)
 
-			await this.publishTuiToast(this.buildTerminalNotificationToast(delegation, remainingCount))
+			const tuiToastDelivered = await this.publishTuiToast(
+				this.buildTerminalNotificationToast(delegation, remainingCount),
+			)
 
 			const deliveryStatus = await this.sendParentNotification(
 				delegation.parentSessionID,
@@ -1207,6 +1222,7 @@ variant: status === "complete" ? "success" : status === "cancelled" ? "info" : s
 				terminalNotification,
 				true,
 				this.buildTerminalNotificationDisplay(delegation, remainingCount),
+				tuiToastDelivered,
 			)
 
 			this.markNotified(delegation.id)

--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -386,6 +386,18 @@ function normalizeId(value: string): string {
 	return value.trim()
 }
 
+function escapeNotificationText(value: string): string {
+	return value.replace(/\r?\n/g, " ").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+function escapeNotificationCode(value: string): string {
+	return value.replace(/[\\`]/g, "\\$&").replace(/\r?\n/g, " ")
+}
+
+function escapeNotificationMarkdown(value: string): string {
+	return value.replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
 function parsePersistedStatus(raw: string | undefined): DelegationStatus {
 	if (!raw) return "complete"
 	if (raw === "registered") return "registered"
@@ -749,6 +761,7 @@ class DelegationManager {
 			parentAgent,
 			this.buildAllCompleteNotification(parentSessionID, cycle, cycleToken),
 			false,
+			this.buildAllCompleteNotificationDisplay(parentSessionID, cycle, cycleToken),
 		)
 
 		if (state.allCompleteCycleToken !== cycleToken) return
@@ -775,6 +788,7 @@ class DelegationManager {
 		parentAgent: string,
 		notification: string,
 		noReply: boolean,
+		displayText: string = notification,
 	): Promise<"sent" | "queued" | "timed-out"> {
 		const session = this.client.session
 		let timeout: ReturnType<typeof setTimeout> | undefined
@@ -793,7 +807,7 @@ class DelegationManager {
 						body: {
 							noReply,
 							agent: parentAgent,
-							parts: [{ type: "text", text: notification }],
+							parts: [{ type: "text", text: displayText }],
 						},
 					})
 					.then(() => "sent" as const),
@@ -810,7 +824,7 @@ class DelegationManager {
 
 			return result
 		} catch (error) {
-			this.queuePendingNotification(parentSessionID, notification)
+			this.queuePendingNotification(parentSessionID, displayText)
 			await this.debugLog(
 				`parent notification queued for ${parentSessionID}: ${
 					error instanceof Error ? error.message : "Unknown error"
@@ -926,6 +940,36 @@ class DelegationManager {
 		return lines.filter((line) => line.length > 0).join("\n")
 	}
 
+	private buildTerminalNotificationDisplay(
+		delegation: DelegationRecord,
+		remainingCount: number,
+	): string {
+		const title = escapeNotificationText(delegation.title || delegation.id)
+		const lines = [
+			`### Background agent ${escapeNotificationText(delegation.status)}: ${title}`,
+			"",
+			`- **Task ID:** \`${escapeNotificationCode(delegation.id)}\``,
+			`- **Status:** \`${escapeNotificationCode(delegation.status)}\``,
+			`- **Artifact:** \`${escapeNotificationCode(delegation.artifact.filePath)}\``,
+			`- **Retrieve:** \`delegation_read("${escapeNotificationCode(delegation.id)}")\``,
+		]
+
+		if (delegation.description?.trim()) {
+			lines.push(
+				"",
+				"**Description:**",
+				"",
+				escapeNotificationMarkdown(delegation.description.trim()),
+			)
+		}
+		if (delegation.error) {
+			lines.push(`- **Error:** ${escapeNotificationText(delegation.error)}`)
+		}
+		if (remainingCount > 0) lines.push(`- **Remaining:** ${remainingCount}`)
+
+		return lines.join("\n")
+	}
+
 	private buildAllCompleteNotification(
 		parentSessionID: string,
 		cycle: number,
@@ -943,6 +987,20 @@ class DelegationManager {
 			`<cycle>${cycle}</cycle>`,
 			`<cycle-token>${cycleToken}</cycle-token>`,
 			"</task-notification>",
+		].join("\n")
+	}
+
+	private buildAllCompleteNotificationDisplay(
+		parentSessionID: string,
+		cycle: number,
+		cycleToken: string,
+	): string {
+		return [
+			"### All delegations complete",
+			"",
+			`- **Parent session:** \`${escapeNotificationCode(parentSessionID)}\``,
+			`- **Cycle:** ${cycle}`,
+			`- **Cycle token:** \`${escapeNotificationCode(cycleToken)}\``,
 		].join("\n")
 	}
 
@@ -1049,6 +1107,7 @@ class DelegationManager {
 				delegation.parentAgent,
 				terminalNotification,
 				true,
+				this.buildTerminalNotificationDisplay(delegation, remainingCount),
 			)
 
 			this.markNotified(delegation.id)
@@ -1370,7 +1429,7 @@ ${description}
 			return this.buildDeterministicTerminalReadResponse(delegation)
 		}
 
-		return `Delegation "${delegation.id}" is still running. You will receive a <task-notification> when it reaches a terminal state.`
+		return `Delegation "${delegation.id}" is still running. You will receive a rendered background-agent notification when it reaches a terminal state.`
 	}
 
 	/**
@@ -1714,7 +1773,7 @@ Agents route based on their permissions:
 ## Critical Constraints
 
 **NEVER poll \`delegation_list\` to check completion.**
-You WILL be notified via \`<task-notification>\`. Polling wastes tokens.
+You WILL be notified in a rendered background-agent notification. Polling wastes tokens.
 
 **NEVER wait idle.** Always have productive work while delegations run.
 
@@ -1771,7 +1830,7 @@ function formatDelegationContext(
 
 		// Only include reminder when there ARE running delegations
 		sections.push(
-			"> **Note:** You WILL be notified via `<task-notification>` when delegations complete.",
+			"> **Note:** You WILL be notified in a rendered background-agent notification when delegations complete.",
 		)
 		sections.push("> Do NOT poll `delegation_list` - continue productive work.")
 		sections.push("")

--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -13,7 +13,7 @@ import * as fs from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
 import { type Plugin, type ToolContext, tool } from "@opencode-ai/plugin"
-import type { Event, Message, Part, TextPart } from "@opencode-ai/sdk"
+import type { Event, EventTuiToastShow, Message, Part, TextPart } from "@opencode-ai/sdk"
 import { adjectives, animals, colors, uniqueNamesGenerator } from "unique-names-generator"
 import { getProjectId } from "./kdco-primitives/get-project-id"
 import type { OpencodeClient } from "./kdco-primitives/types"
@@ -39,6 +39,8 @@ interface GeneratedMetadata {
 	title: string
 	description: string
 }
+
+type TuiToastOptions = EventTuiToastShow["properties"]
 
 /**
  * Generate title and description from result content using small_model
@@ -401,7 +403,15 @@ function escapeNotificationText(value: string): string {
 		.replace(/&/g, "&amp;")
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;")
-		.replace(/[\\`*_[\]{}()#+\-.!|]/g, "\\$&")
+		.replace(/[\\`*_[\]{}()#+\-.!|~]/g, "\\$&")
+}
+
+function plainNotificationText(value: string): string {
+	return value.replace(/\r?\n/g, " ").trim()
+}
+
+function escapeNotificationXml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
 /**
@@ -784,6 +794,8 @@ class DelegationManager {
 		if (!this.areCycleTerminalNotificationsComplete(parentSessionID, cycleToken)) return
 		if (state.allCompleteNotifiedCycleToken === cycleToken) return
 
+		await this.publishTuiToast(this.buildAllCompleteNotificationToast())
+
 		const deliveryStatus = await this.sendParentNotification(
 			parentSessionID,
 			parentAgent,
@@ -835,7 +847,9 @@ class DelegationManager {
 						body: {
 							noReply,
 							agent: parentAgent,
-							parts: [{ type: "text", text: displayText }],
+							// Keep the machine-readable notification in model context without
+							// exposing Markdown as a literal user message in the TUI.
+							parts: [{ type: "text", text: notification, synthetic: true }],
 						},
 					})
 					.then(() => "sent" as const),
@@ -951,16 +965,22 @@ class DelegationManager {
 	}
 
 	private buildTerminalNotification(delegation: DelegationRecord, remainingCount: number): string {
+		const id = escapeNotificationXml(delegation.id)
+		const status = escapeNotificationXml(delegation.status)
+		const title = escapeNotificationXml(delegation.title || delegation.id)
+		const description = delegation.description ? escapeNotificationXml(delegation.description) : ""
+		const error = delegation.error ? escapeNotificationXml(delegation.error) : ""
+		const artifact = escapeNotificationXml(delegation.artifact.filePath)
 		const lines = [
 			"<task-notification>",
-			`<task-id>${delegation.id}</task-id>`,
-			`<status>${delegation.status}</status>`,
-			`<summary>Background agent ${delegation.status}: ${delegation.title || delegation.id}</summary>`,
-			delegation.title ? `<title>${delegation.title}</title>` : "",
-			delegation.description ? `<description>${delegation.description}</description>` : "",
-			delegation.error ? `<error>${delegation.error}</error>` : "",
-			`<artifact>${delegation.artifact.filePath}</artifact>`,
-			`<retrieval>Use delegation_read("${delegation.id}") for full output.</retrieval>`,
+			`<task-id>${id}</task-id>`,
+			`<status>${status}</status>`,
+			`<summary>Background agent ${status}: ${title}</summary>`,
+			delegation.title ? `<title>${title}</title>` : "",
+			delegation.description ? `<description>${description}</description>` : "",
+			delegation.error ? `<error>${error}</error>` : "",
+			`<artifact>${artifact}</artifact>`,
+			`<retrieval>Use delegation_read("${id}") for full output.</retrieval>`,
 			remainingCount > 0 ? `<remaining>${remainingCount}</remaining>` : "",
 			"</task-notification>",
 		]
@@ -998,6 +1018,29 @@ class DelegationManager {
 		return lines.join("\n")
 	}
 
+	private buildTerminalNotificationToast(
+		delegation: DelegationRecord,
+		remainingCount: number,
+	): TuiToastOptions {
+		const status = plainNotificationText(delegation.status)
+		const title = plainNotificationText(delegation.title || delegation.id)
+		const message = [
+			`Status: ${status}`,
+			`Task ID: ${plainNotificationText(delegation.id)}`,
+			`Artifact: ${plainNotificationText(delegation.artifact.filePath)}`,
+			`Retrieve: delegation_read("${plainNotificationText(delegation.id)}")`,
+		]
+
+		if (delegation.error) message.push(`Error: ${plainNotificationText(delegation.error)}`)
+		if (remainingCount > 0) message.push(`Remaining: ${remainingCount}`)
+
+		return {
+			title: `Background agent ${status}: ${title}`,
+			message: message.join("\n"),
+			variant: status === "complete" ? "success" : status === "timeout" ? "warning" : "error",
+		}
+	}
+
 	private buildAllCompleteNotification(
 		parentSessionID: string,
 		cycle: number,
@@ -1011,9 +1054,9 @@ class DelegationManager {
 			"<type>all-complete</type>",
 			"<status>completed</status>",
 			"<summary>All delegations complete.</summary>",
-			`<parent-session-id>${parentSessionID}</parent-session-id>`,
+			`<parent-session-id>${escapeNotificationXml(parentSessionID)}</parent-session-id>`,
 			`<cycle>${cycle}</cycle>`,
-			`<cycle-token>${cycleToken}</cycle-token>`,
+			`<cycle-token>${escapeNotificationXml(cycleToken)}</cycle-token>`,
 			"</task-notification>",
 		].join("\n")
 	}
@@ -1030,6 +1073,32 @@ class DelegationManager {
 			`- **Cycle:** ${cycle}`,
 			`- **Cycle token:** ${markdownCodeSpan(cycleToken)}`,
 		].join("\n")
+	}
+
+	private buildAllCompleteNotificationToast(): TuiToastOptions {
+		return {
+			title: "Background agents",
+			message: "All delegations complete.",
+			variant: "success",
+		}
+	}
+
+	private async publishTuiToast(toast: TuiToastOptions): Promise<void> {
+		try {
+			const tui = this.client.tui
+			if (!tui || typeof tui.publish !== "function") return
+
+			await tui.publish({
+				body: {
+					type: "tui.toast.show",
+					properties: toast,
+				},
+			})
+		} catch (error) {
+			await this.debugLog(
+				`tui toast failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+			)
+		}
 	}
 
 	private buildDeterministicTerminalReadResponse(delegation: DelegationRecord): string {
@@ -1129,6 +1198,8 @@ class DelegationManager {
 
 			const remainingCount = this.getPendingCount(delegation.parentSessionID)
 			const terminalNotification = this.buildTerminalNotification(delegation, remainingCount)
+
+			await this.publishTuiToast(this.buildTerminalNotificationToast(delegation, remainingCount))
 
 			const deliveryStatus = await this.sendParentNotification(
 				delegation.parentSessionID,
@@ -2065,6 +2136,7 @@ const BackgroundAgentsPluginWithInternals = Object.assign(BackgroundAgentsPlugin
 		DelegationManager,
 		formatDelegationContext,
 		escapeNotificationText,
+		escapeNotificationXml,
 		markdownCodeSpan,
 	},
 } as const)

--- a/workers/kdco-registry/files/plugins/background-agents.ts
+++ b/workers/kdco-registry/files/plugins/background-agents.ts
@@ -386,12 +386,40 @@ function normalizeId(value: string): string {
 	return value.trim()
 }
 
+/**
+ * Escapes a value destined for plain notification text (title, error): HTML
+ * entities so it can sit inside a Markdown document, then Markdown's own
+ * control characters so a generated title or error message displays as
+ * literal text instead of restructuring the notification (a title of
+ * `[x](evil)` becoming a link, `**y**` becoming bold, and so on). The
+ * `description` field is the one intentional Markdown channel and goes
+ * through {@link escapeNotificationMarkdown} instead, never this function.
+ */
 function escapeNotificationText(value: string): string {
-	return value.replace(/\r?\n/g, " ").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+	return value
+		.replace(/\r?\n/g, " ")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/[\\`*_[\]{}()#+\-.!|]/g, "\\$&")
 }
 
-function escapeNotificationCode(value: string): string {
-	return value.replace(/[\\`]/g, "\\$&").replace(/\r?\n/g, " ")
+/**
+ * Wraps a value in a Markdown inline code span, escaped the way code spans
+ * actually work: backslashes are not special inside one, so escaping a
+ * backtick with `\` only doubles literal backslashes (breaking Windows
+ * paths) without stopping the backtick from closing the span early. The
+ * correct escape is a fence longer than the longest run of backticks the
+ * value itself contains, padded with a single space on each side when the
+ * value starts or ends with a backtick, so the fence characters never touch
+ * the content's own backticks.
+ */
+function markdownCodeSpan(value: string): string {
+	const collapsed = value.replace(/\r?\n/g, " ")
+	const longestBacktickRun = Math.max(0, ...(collapsed.match(/`+/g) ?? []).map((run) => run.length))
+	const fence = "`".repeat(longestBacktickRun + 1)
+	const needsPadding = collapsed.startsWith("`") || collapsed.endsWith("`")
+	return needsPadding ? `${fence} ${collapsed} ${fence}` : `${fence}${collapsed}${fence}`
 }
 
 function escapeNotificationMarkdown(value: string): string {
@@ -948,10 +976,10 @@ class DelegationManager {
 		const lines = [
 			`### Background agent ${escapeNotificationText(delegation.status)}: ${title}`,
 			"",
-			`- **Task ID:** \`${escapeNotificationCode(delegation.id)}\``,
-			`- **Status:** \`${escapeNotificationCode(delegation.status)}\``,
-			`- **Artifact:** \`${escapeNotificationCode(delegation.artifact.filePath)}\``,
-			`- **Retrieve:** \`delegation_read("${escapeNotificationCode(delegation.id)}")\``,
+			`- **Task ID:** ${markdownCodeSpan(delegation.id)}`,
+			`- **Status:** ${markdownCodeSpan(delegation.status)}`,
+			`- **Artifact:** ${markdownCodeSpan(delegation.artifact.filePath)}`,
+			`- **Retrieve:** ${markdownCodeSpan(`delegation_read("${delegation.id}")`)}`,
 		]
 
 		if (delegation.description?.trim()) {
@@ -998,9 +1026,9 @@ class DelegationManager {
 		return [
 			"### All delegations complete",
 			"",
-			`- **Parent session:** \`${escapeNotificationCode(parentSessionID)}\``,
+			`- **Parent session:** ${markdownCodeSpan(parentSessionID)}`,
 			`- **Cycle:** ${cycle}`,
-			`- **Cycle token:** \`${escapeNotificationCode(cycleToken)}\``,
+			`- **Cycle token:** ${markdownCodeSpan(cycleToken)}`,
 		].join("\n")
 	}
 
@@ -2036,6 +2064,8 @@ const BackgroundAgentsPluginWithInternals = Object.assign(BackgroundAgentsPlugin
 	testInternals: {
 		DelegationManager,
 		formatDelegationContext,
+		escapeNotificationText,
+		markdownCodeSpan,
 	},
 } as const)
 

--- a/workers/kdco-registry/tests/background-agents.test.ts
+++ b/workers/kdco-registry/tests/background-agents.test.ts
@@ -204,9 +204,9 @@ describe("background-agents lifecycle refactor", () => {
 			rootSessionID,
 			childPromptMode: "pending",
 			onParentPrompt: async (text) => {
-				if (!text.includes("<task-id>stable-lifecycle-id</task-id>")) return
+				if (!text.includes("- **Task ID:** `stable-lifecycle-id`")) return
 
-				const artifactPathMatch = text.match(/<artifact>([^<]+)<\/artifact>/)
+				const artifactPathMatch = text.match(/- \*\*Artifact:\*\* `([^`]+)`/)
 				if (!artifactPathMatch) return
 
 				try {
@@ -255,7 +255,7 @@ describe("background-agents lifecycle refactor", () => {
 		expect(completedList.find((item) => item.id === delegation.id)?.status).toBe("complete")
 
 		const terminalNotifications = state.notificationTexts.filter((text) =>
-			text.includes("<task-id>stable-lifecycle-id</task-id>"),
+			text.includes("- **Task ID:** `stable-lifecycle-id`"),
 		)
 		expect(terminalNotifications).toHaveLength(1)
 	})
@@ -276,7 +276,7 @@ describe("background-agents lifecycle refactor", () => {
 			allCompleteQuietPeriodMs: 5,
 			metadataGenerator: async () => ({
 				title: "Queued Result",
-				description: "Direct delivery failed.",
+				description: "## Details\n\n- Direct delivery failed.\n\n<script>alert(1)</script>",
 			}),
 		})
 
@@ -298,8 +298,13 @@ describe("background-agents lifecycle refactor", () => {
 		const output = { parts: [{ type: "text", text: "continue" }] }
 		manager.injectPendingNotificationsIntoChatMessage(output, rootSessionID)
 
-		expect(output.parts[0]?.text).toContain("<task-id>queued-notification-id</task-id>")
-		expect(output.parts[0]?.text).toContain("<summary>All delegations complete.</summary>")
+		expect(output.parts[0]?.text).toContain("### Background agent complete: Queued Result")
+		expect(output.parts[0]?.text).toContain("- **Task ID:** `queued-notification-id`")
+		expect(output.parts[0]?.text).toContain("## Details")
+		expect(output.parts[0]?.text).toContain("&lt;script&gt;alert(1)&lt;/script&gt;")
+		expect(output.parts[0]?.text).not.toContain("<script>")
+		expect(output.parts[0]?.text).toContain("### All delegations complete")
+		expect(output.parts[0]?.text).not.toContain("<task-notification>")
 		expect(output.parts[0]?.text).toContain("continue")
 
 		const secondOutput = { parts: [{ type: "text", text: "next" }] }
@@ -424,23 +429,23 @@ describe("background-agents lifecycle refactor", () => {
 		await sleep(allCompleteQuietPeriodMs + 30)
 
 		const allCompleteNotifications = state.notificationTexts.filter((text) =>
-			text.includes("<summary>All delegations complete.</summary>"),
+			text.includes("### All delegations complete"),
 		)
 		expect(allCompleteNotifications).toHaveLength(1)
 
 		const terminalNotifications = state.notificationTexts.filter((text) =>
-			text.includes("<task-id>"),
+			text.includes("- **Task ID:** `"),
 		)
 		expect(terminalNotifications).toHaveLength(2)
 
 		const parentPromptCalls = state.promptCalls.filter((call) => call.sessionID === rootSessionID)
 		const terminalPromptCalls = parentPromptCalls.filter((call) =>
-			getPromptText(call).includes("<task-id>"),
+			getPromptText(call).includes("- **Task ID:** `"),
 		)
 		expect(terminalPromptCalls).toHaveLength(2)
 		const terminalPromptIndices = parentPromptCalls
 			.map((call, index) => ({ call, index }))
-			.filter(({ call }) => getPromptText(call).includes("<task-id>"))
+			.filter(({ call }) => getPromptText(call).includes("- **Task ID:** `"))
 			.map(({ index }) => index)
 		expect(terminalPromptIndices).toHaveLength(2)
 		for (const call of terminalPromptCalls) {
@@ -448,12 +453,12 @@ describe("background-agents lifecycle refactor", () => {
 		}
 
 		const allCompletePromptCalls = parentPromptCalls.filter((call) =>
-			getPromptText(call).includes("<summary>All delegations complete.</summary>"),
+			getPromptText(call).includes("### All delegations complete"),
 		)
 		expect(allCompletePromptCalls).toHaveLength(1)
 		expect(allCompletePromptCalls[0]?.body.noReply).toBe(false)
 		const allCompletePromptIndex = parentPromptCalls.findIndex((call) =>
-			getPromptText(call).includes("<summary>All delegations complete.</summary>"),
+			getPromptText(call).includes("### All delegations complete"),
 		)
 		expect(allCompletePromptIndex).toBeGreaterThan(Math.max(...terminalPromptIndices))
 	})
@@ -512,14 +517,14 @@ describe("background-agents lifecycle refactor", () => {
 		expect(completedList.find((item) => item.id === second.id)?.status).toBe("complete")
 
 		const terminalNotifications = state.notificationTexts.filter((text) =>
-			text.includes("<task-id>"),
+			text.includes("- **Task ID:** `"),
 		)
 		expect(terminalNotifications).toHaveLength(2)
 		expect(terminalNotifications.some((text) => text.includes(first.id))).toBe(true)
 		expect(terminalNotifications.some((text) => text.includes(second.id))).toBe(true)
 
 		const allCompleteNotifications = state.notificationTexts.filter((text) =>
-			text.includes("<summary>All delegations complete.</summary>"),
+			text.includes("### All delegations complete"),
 		)
 		expect(allCompleteNotifications).toHaveLength(1)
 	})
@@ -564,7 +569,7 @@ describe("background-agents lifecycle refactor", () => {
 		await manager.handleSessionIdle(batchADelegation.sessionID)
 
 		const allCompleteAfterBatchAFinalize = state.notificationTexts.filter((text) =>
-			text.includes("<summary>All delegations complete.</summary>"),
+			text.includes("### All delegations complete"),
 		)
 		expect(allCompleteAfterBatchAFinalize).toHaveLength(0)
 
@@ -591,7 +596,7 @@ describe("background-agents lifecycle refactor", () => {
 		await sleep(allCompleteQuietPeriodMs + 40)
 
 		const allCompleteBeforeBatchBFinalize = state.notificationTexts.filter((text) =>
-			text.includes("<summary>All delegations complete.</summary>"),
+			text.includes("### All delegations complete"),
 		)
 		expect(allCompleteBeforeBatchBFinalize).toHaveLength(0)
 
@@ -602,22 +607,22 @@ describe("background-agents lifecycle refactor", () => {
 		await sleep(allCompleteQuietPeriodMs + 40)
 
 		const allCompleteNotifications = state.notificationTexts.filter((text) =>
-			text.includes("<summary>All delegations complete.</summary>"),
+			text.includes("### All delegations complete"),
 		)
 		expect(allCompleteNotifications).toHaveLength(1)
-		expect(allCompleteNotifications[0]).toContain("<cycle>2</cycle>")
+		expect(allCompleteNotifications[0]).toContain("- **Cycle:** 2")
 		expect(allCompleteNotifications[0]).toContain(
-			`<cycle-token>${batchBDelegation.notificationCycleToken}</cycle-token>`,
+			`- **Cycle token:** \`${batchBDelegation.notificationCycleToken}\``,
 		)
 		expect(allCompleteNotifications[0]).not.toContain(
-			`<cycle-token>${batchADelegation.notificationCycleToken}</cycle-token>`,
+			`- **Cycle token:** \`${batchADelegation.notificationCycleToken}\``,
 		)
 
 		const notificationsAfterBatchBStart = state.notificationTexts
 			.slice(notificationCountAtBatchBStart)
-			.filter((text) => text.includes("<summary>All delegations complete.</summary>"))
+			.filter((text) => text.includes("### All delegations complete"))
 		expect(notificationsAfterBatchBStart).toHaveLength(1)
-		expect(notificationsAfterBatchBStart[0]).toContain("<cycle>2</cycle>")
+		expect(notificationsAfterBatchBStart[0]).toContain("- **Cycle:** 2")
 	})
 
 	it("preserves unread carry-forward when delegation_read returns terminal fallback first", async () => {

--- a/workers/kdco-registry/tests/background-agents.test.ts
+++ b/workers/kdco-registry/tests/background-agents.test.ts
@@ -11,13 +11,26 @@ type PromptCall = {
 	body: {
 		noReply?: boolean
 		agent?: string
-		parts?: Array<{ type: string; text?: string }>
+		parts?: Array<{ type: string; text?: string; synthetic?: boolean }>
 		tools?: Record<string, boolean>
+	}
+}
+
+type TuiToastCall = {
+	body?: {
+		type?: string
+		properties?: {
+			title?: string
+			message: string
+			variant: string
+			duration?: number
+		}
 	}
 }
 
 type MockClientState = {
 	promptCalls: PromptCall[]
+	tuiToastCalls: TuiToastCall[]
 	notificationTexts: string[]
 	messagesBySession: Map<string, string>
 	createdChildSessions: string[]
@@ -43,6 +56,7 @@ function createMockClient(options: MockClientOptions): {
 
 	const state: MockClientState = {
 		promptCalls: [],
+		tuiToastCalls: [],
 		notificationTexts: [],
 		messagesBySession: new Map(),
 		createdChildSessions: [],
@@ -83,6 +97,14 @@ function createMockClient(options: MockClientOptions): {
 		return { data: { parts: [] } }
 	}
 
+	const tui = {
+		publish(options: TuiToastCall) {
+			if (this !== tui) throw new Error("publish lost its client context")
+			state.tuiToastCalls.push(options)
+			return Promise.resolve({ data: true })
+		},
+	}
+
 	const client = {
 		app: {
 			agents: async () => ({
@@ -120,6 +142,7 @@ function createMockClient(options: MockClientOptions): {
 				},
 			}),
 		},
+		tui,
 		session: {
 			get: async ({ path: { id } }: { path: { id: string } }) => ({
 				data: {
@@ -204,9 +227,9 @@ describe("background-agents lifecycle refactor", () => {
 			rootSessionID,
 			childPromptMode: "pending",
 			onParentPrompt: async (text) => {
-				if (!text.includes("- **Task ID:** `stable-lifecycle-id`")) return
+				if (!text.includes("<task-id>stable-lifecycle-id</task-id>")) return
 
-				const artifactPathMatch = text.match(/- \*\*Artifact:\*\* `([^`]+)`/)
+				const artifactPathMatch = text.match(/<artifact>([^<]+)<\/artifact>/)
 				if (!artifactPathMatch) return
 
 				try {
@@ -255,9 +278,24 @@ describe("background-agents lifecycle refactor", () => {
 		expect(completedList.find((item) => item.id === delegation.id)?.status).toBe("complete")
 
 		const terminalNotifications = state.notificationTexts.filter((text) =>
-			text.includes("- **Task ID:** `stable-lifecycle-id`"),
+			text.includes("<task-id>stable-lifecycle-id</task-id>"),
 		)
 		expect(terminalNotifications).toHaveLength(1)
+		expect(state.promptCalls.some((call) => call.body.parts?.[0]?.synthetic)).toBe(true)
+		expect(state.tuiToastCalls).toHaveLength(1)
+		expect(state.tuiToastCalls[0]?.body).toEqual({
+			type: "tui.toast.show",
+			properties: {
+				title: "Background agent complete: Lifecycle Result",
+				message: [
+					"Status: complete",
+					"Task ID: stable-lifecycle-id",
+					`Artifact: ${delegation.artifact.filePath}`,
+					'Retrieve: delegation_read("stable-lifecycle-id")',
+				].join("\n"),
+				variant: "success",
+			},
+		})
 	})
 
 	it("queues parent notifications when direct delivery fails and injects them into the next chat message", async () => {
@@ -429,38 +467,44 @@ describe("background-agents lifecycle refactor", () => {
 		await sleep(allCompleteQuietPeriodMs + 30)
 
 		const allCompleteNotifications = state.notificationTexts.filter((text) =>
-			text.includes("### All delegations complete"),
+			text.includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompleteNotifications).toHaveLength(1)
 
 		const terminalNotifications = state.notificationTexts.filter((text) =>
-			text.includes("- **Task ID:** `"),
+			text.includes("<task-id>"),
 		)
 		expect(terminalNotifications).toHaveLength(2)
 
 		const parentPromptCalls = state.promptCalls.filter((call) => call.sessionID === rootSessionID)
 		const terminalPromptCalls = parentPromptCalls.filter((call) =>
-			getPromptText(call).includes("- **Task ID:** `"),
+			getPromptText(call).includes("<task-id>"),
 		)
 		expect(terminalPromptCalls).toHaveLength(2)
 		const terminalPromptIndices = parentPromptCalls
 			.map((call, index) => ({ call, index }))
-			.filter(({ call }) => getPromptText(call).includes("- **Task ID:** `"))
+			.filter(({ call }) => getPromptText(call).includes("<task-id>"))
 			.map(({ index }) => index)
 		expect(terminalPromptIndices).toHaveLength(2)
 		for (const call of terminalPromptCalls) {
 			expect(call.body.noReply).toBe(true)
+			expect(call.body.parts?.[0]?.synthetic).toBe(true)
 		}
 
 		const allCompletePromptCalls = parentPromptCalls.filter((call) =>
-			getPromptText(call).includes("### All delegations complete"),
+			getPromptText(call).includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompletePromptCalls).toHaveLength(1)
 		expect(allCompletePromptCalls[0]?.body.noReply).toBe(false)
+		expect(allCompletePromptCalls[0]?.body.parts?.[0]?.synthetic).toBe(true)
 		const allCompletePromptIndex = parentPromptCalls.findIndex((call) =>
-			getPromptText(call).includes("### All delegations complete"),
+			getPromptText(call).includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompletePromptIndex).toBeGreaterThan(Math.max(...terminalPromptIndices))
+		expect(state.tuiToastCalls).toHaveLength(3)
+		expect(
+			state.tuiToastCalls.filter((call) => call.body?.properties?.title === "Background agents"),
+		).toHaveLength(1)
 	})
 
 	it("finalizes completed child prompts even when session.idle is not delivered", async () => {
@@ -517,14 +561,14 @@ describe("background-agents lifecycle refactor", () => {
 		expect(completedList.find((item) => item.id === second.id)?.status).toBe("complete")
 
 		const terminalNotifications = state.notificationTexts.filter((text) =>
-			text.includes("- **Task ID:** `"),
+			text.includes("<task-id>"),
 		)
 		expect(terminalNotifications).toHaveLength(2)
 		expect(terminalNotifications.some((text) => text.includes(first.id))).toBe(true)
 		expect(terminalNotifications.some((text) => text.includes(second.id))).toBe(true)
 
 		const allCompleteNotifications = state.notificationTexts.filter((text) =>
-			text.includes("### All delegations complete"),
+			text.includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompleteNotifications).toHaveLength(1)
 	})
@@ -569,7 +613,7 @@ describe("background-agents lifecycle refactor", () => {
 		await manager.handleSessionIdle(batchADelegation.sessionID)
 
 		const allCompleteAfterBatchAFinalize = state.notificationTexts.filter((text) =>
-			text.includes("### All delegations complete"),
+			text.includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompleteAfterBatchAFinalize).toHaveLength(0)
 
@@ -596,7 +640,7 @@ describe("background-agents lifecycle refactor", () => {
 		await sleep(allCompleteQuietPeriodMs + 40)
 
 		const allCompleteBeforeBatchBFinalize = state.notificationTexts.filter((text) =>
-			text.includes("### All delegations complete"),
+			text.includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompleteBeforeBatchBFinalize).toHaveLength(0)
 
@@ -607,22 +651,22 @@ describe("background-agents lifecycle refactor", () => {
 		await sleep(allCompleteQuietPeriodMs + 40)
 
 		const allCompleteNotifications = state.notificationTexts.filter((text) =>
-			text.includes("### All delegations complete"),
+			text.includes("<summary>All delegations complete.</summary>"),
 		)
 		expect(allCompleteNotifications).toHaveLength(1)
-		expect(allCompleteNotifications[0]).toContain("- **Cycle:** 2")
+		expect(allCompleteNotifications[0]).toContain("<cycle>2</cycle>")
 		expect(allCompleteNotifications[0]).toContain(
-			`- **Cycle token:** \`${batchBDelegation.notificationCycleToken}\``,
+			`<cycle-token>${batchBDelegation.notificationCycleToken}</cycle-token>`,
 		)
 		expect(allCompleteNotifications[0]).not.toContain(
-			`- **Cycle token:** \`${batchADelegation.notificationCycleToken}\``,
+			`<cycle-token>${batchADelegation.notificationCycleToken}</cycle-token>`,
 		)
 
 		const notificationsAfterBatchBStart = state.notificationTexts
 			.slice(notificationCountAtBatchBStart)
-			.filter((text) => text.includes("### All delegations complete"))
+			.filter((text) => text.includes("<summary>All delegations complete.</summary>"))
 		expect(notificationsAfterBatchBStart).toHaveLength(1)
-		expect(notificationsAfterBatchBStart[0]).toContain("- **Cycle:** 2")
+		expect(notificationsAfterBatchBStart[0]).toContain("<cycle>2</cycle>")
 	})
 
 	it("preserves unread carry-forward when delegation_read returns terminal fallback first", async () => {
@@ -774,7 +818,8 @@ describe("background-agents lifecycle refactor", () => {
 })
 
 describe("notification text escaping", () => {
-	const { escapeNotificationText, markdownCodeSpan } = BackgroundAgentsPlugin.testInternals
+	const { escapeNotificationText, escapeNotificationXml, markdownCodeSpan } =
+		BackgroundAgentsPlugin.testInternals
 
 	it("escapes Markdown control characters so a generated title cannot restructure the notification", () => {
 		const escaped = escapeNotificationText("[click me](https://evil.example) and **bold**")
@@ -792,6 +837,16 @@ describe("notification text escaping", () => {
 	it("collapses newlines to spaces", () => {
 		expect(escapeNotificationText("line one\nline two\r\nline three")).toBe(
 			"line one line two line three",
+		)
+	})
+
+	it("escapes Markdown strikethrough markers", () => {
+		expect(escapeNotificationText("~~struck~~")).toBe("\\~\\~struck\\~\\~")
+	})
+
+	it("escapes XML text before sending it to the model", () => {
+		expect(escapeNotificationXml("<title>A & B</title>")).toBe(
+			"&lt;title&gt;A &amp; B&lt;/title&gt;",
 		)
 	})
 

--- a/workers/kdco-registry/tests/background-agents.test.ts
+++ b/workers/kdco-registry/tests/background-agents.test.ts
@@ -42,6 +42,7 @@ type MockClientOptions = {
 	rootSessionID: string
 	childPromptMode?: "pending" | "resolve"
 	parentPromptMode?: "resolve" | "reject"
+	tuiMode?: "available" | "missing" | "reject"
 	agentPermissions?: Record<string, "readonly" | "write">
 	onChildPrompt?: (sessionID: string, prompt: string) => Promise<void> | void
 	onParentPrompt?: (text: string) => Promise<void> | void
@@ -98,9 +99,12 @@ function createMockClient(options: MockClientOptions): {
 	}
 
 	const tui = {
-		publish(options: TuiToastCall) {
+		publish(toastOptions: TuiToastCall) {
 			if (this !== tui) throw new Error("publish lost its client context")
-			state.tuiToastCalls.push(options)
+			if (options.tuiMode === "reject") {
+				return Promise.reject(new Error("TUI publish aborted"))
+			}
+			state.tuiToastCalls.push(toastOptions)
 			return Promise.resolve({ data: true })
 		},
 	}
@@ -142,7 +146,7 @@ function createMockClient(options: MockClientOptions): {
 				},
 			}),
 		},
-		tui,
+		tui: options.tuiMode === "missing" ? undefined : tui,
 		session: {
 			get: async ({ path: { id } }: { path: { id: string } }) => ({
 				data: {
@@ -349,6 +353,65 @@ describe("background-agents lifecycle refactor", () => {
 		manager.injectPendingNotificationsIntoChatMessage(secondOutput, rootSessionID)
 		expect(secondOutput.parts[0]?.text).toBe("next")
 	})
+
+	for (const tuiMode of ["missing", "reject"] as const) {
+		it(`falls back to a visible chat part when the TUI toast is ${tuiMode}`, async () => {
+			const rootSessionID = "root-session"
+			const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "background-agents-tui-fallback-"))
+			testDirs.push(baseDir)
+
+			const { client, state } = createMockClient({
+				rootSessionID,
+				childPromptMode: "pending",
+				tuiMode,
+			})
+
+			const manager = new DelegationManager(client as never, baseDir, createNoopLogger(), {
+				idGenerator: () => `tui-${tuiMode}-id`,
+				allCompleteQuietPeriodMs: 5,
+				metadataGenerator: async () => ({
+					title: "TUI Fallback",
+					description: "The chat remains visible without a native toast.",
+				}),
+			})
+
+			const delegation = await manager.delegate({
+				parentSessionID: rootSessionID,
+				parentMessageID: "msg-1",
+				parentAgent: "plan",
+				prompt: "Finish without a TUI",
+				agent: "researcher",
+			})
+
+			state.messagesBySession.set(delegation.sessionID, "Fallback completion payload")
+			await manager.handleSessionIdle(delegation.sessionID)
+			await sleep(20)
+
+			expect(state.tuiToastCalls).toHaveLength(0)
+
+			const parentPromptCalls = state.promptCalls.filter((call) => call.sessionID === rootSessionID)
+			const terminalCall = parentPromptCalls.find((call) =>
+				getPromptText(call).includes("### Background agent complete: TUI Fallback"),
+			)
+			expect(terminalCall).toBeDefined()
+			expect(terminalCall?.body.parts?.[0]).toEqual({
+				type: "text",
+				text: expect.stringContaining("### Background agent complete: TUI Fallback"),
+			})
+			expect(terminalCall?.body.parts?.[0]?.synthetic).toBeUndefined()
+			expect(terminalCall?.body.parts?.[0]?.text ?? "").not.toContain("<task-notification>")
+
+			const allCompleteCall = parentPromptCalls.find((call) =>
+				getPromptText(call).includes("### All delegations complete"),
+			)
+			expect(allCompleteCall).toBeDefined()
+			expect(allCompleteCall?.body.parts?.[0]).toEqual({
+				type: "text",
+				text: expect.stringContaining("### All delegations complete"),
+			})
+			expect(allCompleteCall?.body.parts?.[0]?.synthetic).toBeUndefined()
+		})
+	}
 
 	it("delegation_read blocks until terminal and resolves deterministic timeout path", async () => {
 		const rootSessionID = "root-session"

--- a/workers/kdco-registry/tests/background-agents.test.ts
+++ b/workers/kdco-registry/tests/background-agents.test.ts
@@ -772,3 +772,60 @@ describe("background-agents lifecycle refactor", () => {
 		).rejects.toThrow("read-only")
 	})
 })
+
+describe("notification text escaping", () => {
+	const { escapeNotificationText, markdownCodeSpan } = BackgroundAgentsPlugin.testInternals
+
+	it("escapes Markdown control characters so a generated title cannot restructure the notification", () => {
+		const escaped = escapeNotificationText("[click me](https://evil.example) and **bold**")
+		expect(escaped).not.toContain("[click me](https://evil.example)")
+		expect(escaped).not.toContain("**bold**")
+		expect(escaped).toBe("\\[click me\\]\\(https://evil\\.example\\) and \\*\\*bold\\*\\*")
+	})
+
+	it("still HTML-escapes angle brackets and ampersands in plain text", () => {
+		const escaped = escapeNotificationText("<script>alert(1)</script> & friends")
+		expect(escaped).not.toContain("<script>")
+		expect(escaped).toBe("&lt;script&gt;alert\\(1\\)&lt;/script&gt; &amp; friends")
+	})
+
+	it("collapses newlines to spaces", () => {
+		expect(escapeNotificationText("line one\nline two\r\nline three")).toBe(
+			"line one line two line three",
+		)
+	})
+
+	it("wraps an ordinary value in single backticks", () => {
+		expect(markdownCodeSpan("stable-lifecycle-id")).toBe("`stable-lifecycle-id`")
+	})
+
+	it("widens the fence instead of backslash-escaping a backtick in the value", () => {
+		const span = markdownCodeSpan("a`b")
+		// A single backslash before the backtick would not be literal inside a code
+		// span at all: it would still close the span early. The fence has to widen
+		// past the internal backtick instead, which a 2-backtick fence already does
+		// unambiguously since the lone internal backtick is a run of length 1, not 2.
+		expect(span).toBe("``a`b``")
+	})
+
+	it("widens the fence past the longest run of backticks the value contains", () => {
+		const span = markdownCodeSpan("has ``double`` backticks")
+		expect(span).toBe("```has ``double`` backticks```")
+	})
+
+	it("pads with a space when the value itself starts or ends with a backtick", () => {
+		// Without the padding space, the fence's own backtick would merge with the
+		// value's leading one into a run one longer than the parser is looking for.
+		expect(markdownCodeSpan("`leading")).toBe("`` `leading ``")
+		expect(markdownCodeSpan("trailing`")).toBe("`` trailing` ``")
+	})
+
+	it("does not double backslashes in a Windows-style path", () => {
+		const span = markdownCodeSpan("C:\\Users\\foo\\artifact.txt")
+		expect(span).toBe("`C:\\Users\\foo\\artifact.txt`")
+	})
+
+	it("collapses newlines inside a code span too", () => {
+		expect(markdownCodeSpan("line one\nline two")).toBe("`line one line two`")
+	})
+})


### PR DESCRIPTION
## Summary

- keep the XML notification as synthetic model context
- publish terminal and all-complete notifications through the native TUI toast event
- keep Markdown formatting for queued notifications injected into assistant output
- escape XML fields and Markdown strikethrough markers

## Root cause

`promptAsync` creates a user message. The OpenCode TUI renders user messages as plain text, so Markdown sent through that path appears literally. `noReply` does not change the renderer.

The notification now keeps its machine-readable XML payload in a synthetic text part. OpenCode keeps that part in model context while hiding it from the TUI and web conversation. The TUI receives a separate plain-text `tui.toast.show` event. Queued notifications still use the Markdown display text when they are injected into assistant output.

## Validation

- `bun run check`
- `bun run build`
- `bun test workers/kdco-registry/tests/background-agents.test.ts` with 19 tests passing
- local SDK request test for `POST /tui/publish`

The full registry test command still reports the existing `detect-terminal` import failure in the unrelated `notify` tests. All background-agent tests pass.