### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/workers/kdco-registry/files/skills/gbr/SKILL.md
+++ b/workers/kdco-registry/files/skills/gbr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: gbr
+description: >
+  Pair a phone running Build Remote Agent to this OpenCode desktop session.
+  Requires gbr-agent run on the host. Attach via Bot API 127.0.0.1:8788 or gbr-mcp.
+  Use when the user wants mobile spectator / inject into this OpenCode CLI session.
+compatibility: Requires gbr-agent ≥ 0.6.0 on the host. Loopback only. No mailbox keys in this file.
+metadata:
+  version: "0.6.1"
+  product: "Build Remote Agent"
+  website: "https://grokbuildremote.com/"
+---
+
+# Build Remote Agent — pairing device
+
+One adapter for OpenCode. Protocol `gbr/1`. No fourth pair protocol.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+Install this skill with OCX (`ocx add kdco/gbr` once published) or copy this file into `.opencode/skills/gbr/SKILL.md`.
+
+## Pair (unchanged)
+
+1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
+2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
+3. Phone scans QR **or** types the 8-char code.
+4. PC: `gbr-agent run` (keep it running).
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Unpair on the phone before a new mailbox. Force-close is not enough.
+
+## Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+
+Phone is spectator + veto, not orchestrator. OpenCode stays in charge of the session.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+curl -sS -X POST http://127.0.0.1:8788/v1/inject \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id":"SESSION","text":"hello","submit":true}'
+```
+
+## MCP (OpenCode `opencode.json`)
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "gbr": {
+      "type": "local",
+      "command": ["node", "GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Never put mailbox keys in OCX profiles or `opencode.json`. Remote bots: phone **Settings → Bot API** copies relay URL + mailbox id + key.
+
+## Loop
+
+diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
+
+Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md

--- a/workers/kdco-registry/registry.jsonc
+++ b/workers/kdco-registry/registry.jsonc
@@ -122,6 +122,13 @@
 			"files": ["skills/plan-review/SKILL.md"],
 			"dependencies": []
 		},
+		{
+			"name": "gbr",
+			"type": "skill",
+			"description": "Pair a phone running Build Remote Agent (gbr/1) as a spectator for this OpenCode session",
+			"files": ["skills/gbr/SKILL.md"],
+			"dependencies": []
+		},
 
 		// ============================================================================
 		// AGENTS


### PR DESCRIPTION
Add **Build Remote Agent** as an optional phone pairing device for a desktop session of this project.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.** Protocol `gbr/1` (existing pair flow only — no new pair protocol).

## Pair

```bash
# macOS / Linux
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version          # need v0.6.0+
gbr-agent pair             # browser QR + printed 8-char code
gbr-agent run              # leave running
```

Phone: open [Build Remote Agent](https://grokbuildremote.com/) → scan QR or type the 8-char code. Unpair in Settings before changing PCs.

## Attach (only these)

- HTTP Bot API: `http://127.0.0.1:8788` after `gbr-agent run`
- MCP stdio: `node …/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js`

```bash
curl -sS http://127.0.0.1:8788/health
curl -sS http://127.0.0.1:8788/v1/sessions
```

Phone is **spectator + veto**, not orchestrator. Never commit mailbox keys.

Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Build Remote Agent (gbr/1) as an optional phone pairing device for OpenCode desktop sessions, letting a phone connect as spectator + veto via local Bot API or MCP. Previously there was no GBR pairing; now a new `gbr` skill documents pairing/attach without changing pair protocols or orchestrator behavior.

- Review
  - Adds `workers/kdco-registry/files/skills/gbr/SKILL.md` and a `gbr` entry in `workers/kdco-registry/registry.jsonc`; no runtime code changes.
  - Uses existing `gbr/1` pair flow; OpenCode remains the orchestrator.
  - Loopback-only networking (`http://127.0.0.1:8788`); no new remote access.

- Rollout
  - Requires `gbr-agent >= 0.6.0` running on the host; attach via `http://127.0.0.1:8788` or `gbr-mcp` (stdio from `GrokBuildRemote-Agents`).
  - Unpair on the phone before switching hosts.
  - Do not store mailbox keys in OCX profiles or `opencode.json`.

<sup>Written for commit 721a6aa8475a6b6cf18889caa9ed2e7114dd12b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kdcokenny/ocx/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

